### PR TITLE
fix: logstash 포트 연결 안되던 문제 해결

### DIFF
--- a/elk-config/docker-compose.yml
+++ b/elk-config/docker-compose.yml
@@ -41,8 +41,8 @@ services:
         target: /usr/share/logstash/pipeline
         read_only: true
     ports:
-      - "6000:5000/tcp"
-      - "6000:5000/udp"
+      - "5044:5044/tcp"
+      - "5044:5044/udp"
       - "9600:9600"
     environment:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"
@@ -71,6 +71,7 @@ services:
 
 networks:
   elk:
+    name: elk
     driver: bridge
 
 volumes:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
     </appender>
 
     <appender name="stash" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>logstash:6000</destination>
+        <destination>localhost:5044</destination>
 
         <!-- encoder is required -->
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />


### PR DESCRIPTION
- Spring을 local에서 실행하는 동안은 host를 localhost로 해야함
- port 6000 -> 5044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 서비스 통신을 위한 포트 매핑 및 네트워크 구성이 개선되어 연결의 명확성과 안정성이 향상되었습니다.
- **Refactor**
	- 로그 출력 대상을 원격에서 로컬 환경으로 전환하여 로그 관리 효율성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->