### PR TITLE
feat: Add StudentController (#15) -학생이 수강한 모든 학기 정보를 조회하는 API

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface SemesterAcademicRecordRepository extends JpaRepository<SemesterAcademicRecord, UUID> {
 
     List<SemesterAcademicRecord> findByStudentIdAndYearAndSemester(UUID studentId, Integer year, Integer semester);
+    List<SemesterAcademicRecord> findByStudentId(UUID studentId);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordService.java
@@ -26,7 +26,7 @@ public class AcademicRecordService {
 
         // 학기별 성적 조회
         List<SemesterAcademicRecordDto.SemesterGradeDto> semesterGrades =
-                semesterAcademicRecordService.getSemesterGrades(studentId, year, semester);
+                semesterAcademicRecordService.getSemesterGrades(userEmail, year, semester);
 
         // TODO: 수강 과목 조회, 과목 카테고리 분류를 하나로 병합?
         // 수강 과목 조회

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/service/SemesterAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/service/SemesterAcademicRecordService.java
@@ -2,7 +2,9 @@ package com.chukchuk.haksa.domain.academic.record.service;
 
 import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
 import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
+import com.chukchuk.haksa.domain.user.service.UserService;
 import com.chukchuk.haksa.global.exception.DataNotFoundException;
+import com.chukchuk.haksa.global.exception.FreshmanException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,21 +18,45 @@ import static com.chukchuk.haksa.domain.academic.record.dto.SemesterAcademicReco
 @RequiredArgsConstructor
 public class SemesterAcademicRecordService {
     private final SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+    private final UserService userService;
+
+    public UUID getStudentId(String email) {
+        return userService.getUserId(email);
+    }
 
     public List<SemesterAcademicRecord> getSemesterRecords(UUID studentId, Integer year, Integer semester) {
         return semesterAcademicRecordRepository
                 .findByStudentIdAndYearAndSemester(studentId, year, semester);
     }
 
-    public List<SemesterGradeDto> getSemesterGrades(UUID studentId, Integer year, Integer semester) {
+    public List<SemesterGradeDto> getSemesterGrades(String email, Integer year, Integer semester) {
+        UUID studentId = getStudentId(email);
         List<SemesterAcademicRecord> records = getSemesterRecords(studentId, year, semester);
 
-        if (records.isEmpty()) {
-            throw new DataNotFoundException("학기 성적 데이터를 찾을 수 없습니다.");
+        if (isFreshman(studentId)) {
+            throw new FreshmanException("신입생은 학기 기록이 없습니다.");
         }
+
+        if (records.isEmpty()) {
+            throw new DataNotFoundException("해당 학기에 대한 학기 기록이 존재하지 않습니다.");
+        }
+        validateSemesterRequest(year, semester);
 
         return records.stream()
                 .map(SemesterGradeDto::from)
                 .collect(Collectors.toList());
+    }
+
+    private void validateSemesterRequest(Integer year, Integer semester) {
+        if (year < 2000 || year > 2025) {
+            throw new IllegalArgumentException("유효하지 않은 연도입니다.");
+        }
+        if (semester < 1 || semester > 4) {
+            throw new IllegalArgumentException("유효하지 않은 학기입니다.");
+        }
+    }
+
+    private boolean isFreshman(UUID studentId) {
+        return semesterAcademicRecordRepository.findByStudentId(studentId).isEmpty();
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
@@ -1,11 +1,7 @@
 package com.chukchuk.haksa.domain.student.controller;
 
-import com.chukchuk.haksa.domain.academic.record.dto.AcademicRecordResponse;
 import com.chukchuk.haksa.domain.academic.record.dto.SemesterAcademicRecordDto;
-import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
 import com.chukchuk.haksa.domain.academic.record.service.SemesterAcademicRecordService;
-import com.chukchuk.haksa.domain.user.service.UserService;
-import com.chukchuk.haksa.global.exception.DataNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,30 +12,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/semester")
 @RequiredArgsConstructor
 public class StudentController {
     private final SemesterAcademicRecordService semesterAcademicRecordService;
-    private final UserService userService;
 
     @GetMapping("/get-semesters")
     public ResponseEntity<List<SemesterAcademicRecordDto.SemesterGradeDto>> getSemesterRecord(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam("year") int year,//Param 값 year는 int로 받아도 될 것 같음
-            @RequestParam("semester") String semester) { //Param 값 semester는 String
-        String email = userDetails.getUsername(); //UserDetail에서 email얻고
-        UUID studentId = userService.getUserId(email); //받아온 email로 유저 UUID 구하기
+            @RequestParam("year") int year,
+            @RequestParam("semester") int semester) {
 
-        List<SemesterAcademicRecordDto.SemesterGradeDto> response = semesterAcademicRecordService.getSemesterGrades(studentId, year, Integer.parseInt(semester));
-        //getSemesterRecords보다 getSemesterGrades를 쓰는것이 안전하고 예외처리도 가능 할 것 같아서 사용
-        /*if (response.isEmpty()){
-            throw new DataNotFoundException("신입생은 아직 학사 기록이 존재하지 않습니다.");
-        }*/
-        //이미 SemesterAcademicRecordService getSemesterGrades에서 예외 처리 하는데 따로 여기에서 해야할 필요성을 모르겠음
-        //response.isEmpty() -> 학기 정보가 없는 것을 신입생으로 규정하고 예외처리를 할 것인지 신입생과 오류로인한 Empty를 구별할 것인지
+        String email = userDetails.getUsername();
+        List<SemesterAcademicRecordDto.SemesterGradeDto> response = semesterAcademicRecordService.getSemesterGrades(email, year, semester);
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
@@ -1,0 +1,45 @@
+package com.chukchuk.haksa.domain.student.controller;
+
+import com.chukchuk.haksa.domain.academic.record.dto.AcademicRecordResponse;
+import com.chukchuk.haksa.domain.academic.record.dto.SemesterAcademicRecordDto;
+import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
+import com.chukchuk.haksa.domain.academic.record.service.SemesterAcademicRecordService;
+import com.chukchuk.haksa.domain.user.service.UserService;
+import com.chukchuk.haksa.global.exception.DataNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/semester")
+@RequiredArgsConstructor
+public class StudentController {
+    private final SemesterAcademicRecordService semesterAcademicRecordService;
+    private final UserService userService;
+
+    @GetMapping("/get-semesters")
+    public ResponseEntity<List<SemesterAcademicRecordDto.SemesterGradeDto>> getSemesterRecord(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("year") int year,//Param 값 year는 int로 받아도 될 것 같음
+            @RequestParam("semester") String semester) { //Param 값 semester는 String
+        String email = userDetails.getUsername(); //UserDetail에서 email얻고
+        UUID studentId = userService.getUserId(email); //받아온 email로 유저 UUID 구하기
+
+        List<SemesterAcademicRecordDto.SemesterGradeDto> response = semesterAcademicRecordService.getSemesterGrades(studentId, year, Integer.parseInt(semester));
+        //getSemesterRecords보다 getSemesterGrades를 쓰는것이 안전하고 예외처리도 가능 할 것 같아서 사용
+        /*if (response.isEmpty()){
+            throw new DataNotFoundException("신입생은 아직 학사 기록이 존재하지 않습니다.");
+        }*/
+        //이미 SemesterAcademicRecordService getSemesterGrades에서 예외 처리 하는데 따로 여기에서 해야할 필요성을 모르겠음
+        //response.isEmpty() -> 학기 정보가 없는 것을 신입생으로 규정하고 예외처리를 할 것인지 신입생과 오류로인한 Empty를 구별할 것인지
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/global/exception/FreshmanException.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/FreshmanException.java
@@ -1,0 +1,7 @@
+package com.chukchuk.haksa.global.exception;
+
+public class FreshmanException extends RuntimeException {
+    public FreshmanException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.chukchuk.haksa.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleDataNotFoundException(DataNotFoundException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "Data Not Found");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(FreshmanException.class)
+    public ResponseEntity<Map<String, String>> handleFreshmanException(FreshmanException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "No Semester Record");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "Invalid Request");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneralException(Exception ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "Internal Server Error");
+        errorResponse.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}
+


### PR DESCRIPTION
Base branch: main
Compare branch: feat/semester-controller
Add StudentController

### 변경 내용
- SemesterAcademicRecord를 활용하는 StudentCOntroller 개발

### 테스트 여부
- [x] 테스트

### 기타사항
- Parm year의 경우 int를 사용하는 것이 좋다 판단되어 int로 설정해보았음
- 데이터 베이스에 저장되는 semester값이 "1학기", "2학기", "여름학기", "겨울학기"일 것을 감안하여 String으로 유지 확인 필요
- userDetails.getUsername()로 얻어온 email값으로 유저 UUID 얻어옴
- 요구사항이었던 신입생 예외 처리는 SemesterGradeDto내부의 예외처리로도 충분할 것 같다고 생각됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 사용자가 입력한 연도와 학기 정보에 따라 본인의 학기 성적 데이터를 조회할 수 있는 REST API 엔드포인트가 추가되었습니다. 이 기능은 인증된 사용자 정보를 기반으로 성적 데이터를 안전하게 제공하며, 사용자 경험을 개선합니다.
  - 학기 성적 조회 시 학생의 이메일을 사용하여 성적 정보를 가져오는 방식으로 변경되었습니다.
  - 새로 추가된 예외 처리 기능으로, 신입생에 대한 오류 메시지가 개선되었습니다.

- **버그 수정**
  - 데이터가 없을 경우의 오류 메시지가 보다 명확하게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->