### PR TITLE
feat: 회원 탈퇴 API 구현 #19 

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.chukchuk.haksa.domain.user.controller;
+
+import com.chukchuk.haksa.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @DeleteMapping("/users/delete")
+    public ResponseEntity<?> deleteUser(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        userService.deleteUserByEmail(email);
+        return ResponseEntity.ok(Map.of("success", true));
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.user.service;
 import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.repository.UserRepository;
 import com.chukchuk.haksa.global.exception.DataNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,5 +30,11 @@ public class UserService {
         return userRepository.findByEmail(email)
                 .map(user -> user.getId())
                 .orElseThrow(() -> new DataNotFoundException("User not found"));
+    }
+
+    @Transactional
+    public void deleteUserByEmail(String email){
+        UUID userId = getUserId(email);
+        userRepository.deleteById(userId);
     }
 }


### PR DESCRIPTION
feat:
- 회원 탈퇴 API 구현
- 탈퇴 시 해당 유저의 정보 데이터 하드 삭제
---
향후 작업:
- 자식 엔티티에 대한 연관 관계 추가 및 cascade 설정
  -students, student_courses, student_academic_records, semester_academic_records는 User 삭제와 동시에 같이 사라져야 한다고 생각함
- 이 entity들이 student와 @ManyToOne로 연결된 것을 이용해 Student와 User을 종속관계에 두는 것은 어떤지 고려됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자가 자신의 계정을 삭제할 수 있는 기능이 추가되었습니다. 인증 정보를 활용하여 안전하게 계정 삭제 요청을 처리함으로써, 사용자 편의와 보안이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->