### PR TITLE
feat: 로그인 응답 리팩토링

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/dto/AuthDto.java
@@ -1,5 +1,7 @@
 package com.chukchuk.haksa.domain.auth.dto;
 
+import lombok.Builder;
+
 import java.util.Date;
 
 public class AuthDto {
@@ -14,6 +16,15 @@ public class AuthDto {
     }
 
     public record RefreshResponse(String accessToken, String refreshToken) {
+
+    }
+
+    @Builder
+    public record SignInTokenResponse(
+            String accessToken,
+            String refreshToken,
+            boolean isPortalLinked
+    ) {
 
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.chukchuk.haksa.domain.user.controller;
 
+import com.chukchuk.haksa.domain.auth.dto.AuthDto;
 import com.chukchuk.haksa.domain.auth.service.TokenCookieProvider;
 import com.chukchuk.haksa.domain.user.dto.UserDto;
 import com.chukchuk.haksa.domain.user.service.UserService;
@@ -42,6 +43,7 @@ public class UserController {
         return ResponseEntity.ok(com.chukchuk.haksa.global.common.response.ApiResponse.success("회원 탈퇴가 완료되었습니다."));
     }
 
+    /* 회원가입/로그인 */
     @PostMapping("/signin")
     @Operation(
             summary = "회원 가입",
@@ -72,21 +74,20 @@ public class UserController {
     public ResponseEntity<?> signInUser(
             @RequestBody UserDto.SignInRequest signInRequest
             ) {
-        UserDto.SignInResponse signInResponse = userService.signInWithKakao(signInRequest);
+        AuthDto.SignInTokenResponse tokens = userService.signInWithKakao(signInRequest);
 
-        ResponseCookie accessCookie = tokenCookieProvider.createAccessTokenCookie(signInResponse.accessToken());
-        ResponseCookie refreshCookie = tokenCookieProvider.createRefreshTokenCookie(signInResponse.refreshToken());
+        ResponseCookie accessCookie = tokenCookieProvider.createAccessTokenCookie(tokens.accessToken());
+        ResponseCookie refreshCookie = tokenCookieProvider.createRefreshTokenCookie(tokens.refreshToken());
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.SET_COOKIE, accessCookie.toString());
         headers.add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
-        UserDto.SignInResponse body = UserDto.SignInResponse.builder()
-                .status(signInResponse.status())
-                .build();
+        UserDto.PortalLinkStatusResponse body = new UserDto.PortalLinkStatusResponse(tokens.isPortalLinked());
 
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(com.chukchuk.haksa.global.common.response.ApiResponse.success(body));
     }
+
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/dto/UserDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/dto/UserDto.java
@@ -1,8 +1,5 @@
 package com.chukchuk.haksa.domain.user.dto;
 
-import lombok.Builder;
-import org.springframework.http.HttpStatus;
-
 public class UserDto {
     public record SignInRequest(
             String id_token,
@@ -11,12 +8,5 @@ public class UserDto {
 
     }
 
-    @Builder
-    public record SignInResponse(
-            HttpStatus status,
-            String accessToken,
-            String refreshToken
-    ) {
-
-    }
+    public record PortalLinkStatusResponse(boolean isPortalLinked) {}
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import io.jsonwebtoken.Claims;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -41,7 +40,7 @@ public class UserService {
     }
 
     @Transactional
-    public UserDto.SignInResponse signInWithKakao(UserDto.SignInRequest signInRequest) {
+    public AuthDto.SignInTokenResponse signInWithKakao(UserDto.SignInRequest signInRequest) {
         Claims claims = verifyKakaoToken(signInRequest);
         String email = extractEmail(claims);
 
@@ -75,12 +74,12 @@ public class UserService {
                 ));
     }
 
-    private UserDto.SignInResponse generateSignInResponse(User user) {
+    private AuthDto.SignInTokenResponse generateSignInResponse(User user) {
         String userId = user.getId().toString();
         String accessToken = jwtProvider.createAccessToken(userId, user.getEmail(), "USER");
         AuthDto.RefreshTokenWithExpiry refresh = jwtProvider.createRefreshToken(userId);
         refreshTokenService.save(userId, refresh.token(), refresh.expiry());
 
-        return new UserDto.SignInResponse(HttpStatus.OK, accessToken, refresh.token());
+        return new AuthDto.SignInTokenResponse(accessToken, refresh.token(), user.getPortalConnected());
     }
 }


### PR DESCRIPTION
연동 여부 body에 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 카카오 로그인 시 포털 연동 여부(isPortalLinked) 정보를 함께 제공합니다.

- **변경 사항**
    - 로그인 응답 구조가 변경되어, 기존의 access/refresh 토큰과 상태(status) 대신 access/refresh 토큰과 포털 연동 여부만 반환합니다.
    - 로그인 응답에 사용되는 데이터 형식이 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->