### PR TITLE
Swagger 문서 구조 개선: Controller → Interface 분리

### DIFF
--- a/src/main/java/com/chukchuk/haksa/application/academic/wrapper/PortalLoginApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/application/academic/wrapper/PortalLoginApiResponse.java
@@ -1,6 +1,6 @@
-package com.chukchuk.haksa.application.api.wrapper;
+package com.chukchuk.haksa.application.academic.wrapper;
 
-import com.chukchuk.haksa.application.api.dto.PortalLoginResponse;
+import com.chukchuk.haksa.application.dto.PortalLoginResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/chukchuk/haksa/application/academic/wrapper/ScrapingApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/application/academic/wrapper/ScrapingApiResponse.java
@@ -1,6 +1,6 @@
-package com.chukchuk.haksa.application.api.wrapper;
+package com.chukchuk.haksa.application.academic.wrapper;
 
-import com.chukchuk.haksa.application.api.dto.ScrapingResponse;
+import com.chukchuk.haksa.application.dto.ScrapingResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
+++ b/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
@@ -1,17 +1,15 @@
 package com.chukchuk.haksa.application.api;
 
 import com.chukchuk.haksa.application.academic.dto.SyncAcademicRecordResult;
+import com.chukchuk.haksa.application.api.docs.SuwonScrapeControllerDocs;
 import com.chukchuk.haksa.application.dto.PortalLoginResponse;
 import com.chukchuk.haksa.application.dto.ScrapingResponse;
-import com.chukchuk.haksa.application.academic.wrapper.PortalLoginApiResponse;
-import com.chukchuk.haksa.application.academic.wrapper.ScrapingApiResponse;
 import com.chukchuk.haksa.application.portal.InitializePortalConnectionService;
 import com.chukchuk.haksa.application.portal.RefreshPortalConnectionService;
 import com.chukchuk.haksa.application.portal.SyncAcademicRecordService;
 import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.service.UserService;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.exception.CommonException;
 import com.chukchuk.haksa.global.exception.ErrorCode;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
@@ -21,11 +19,6 @@ import com.chukchuk.haksa.infrastructure.portal.model.PortalData;
 import com.chukchuk.haksa.infrastructure.portal.repository.PortalRepository;
 import com.chukchuk.haksa.infrastructure.redis.RedisCacheStore;
 import com.chukchuk.haksa.infrastructure.redis.RedisPortalCredentialStore;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,7 +37,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Tag(name = "Suwon Scraping", description = "수원대학교 포털 크롤링 관련 API")
 @Slf4j
-public class SuwonScrapeController {
+public class SuwonScrapeController implements SuwonScrapeControllerDocs {
 
     private final PortalRepository portalRepository;
     private final InitializePortalConnectionService initializePortalConnectionService;
@@ -55,23 +48,10 @@ public class SuwonScrapeController {
     private final UserService userService;
 
     @PostMapping("/login")
-    @Operation(
-            summary = "포털 로그인",
-            description = "수원대학교 포털 로그인 후 Redis에 계정 정보를 저장합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PortalLoginApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 실패 (ErrorCode: P01, 포털 로그인 실패)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR, 서버 오류)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<PortalLoginResponse>> login(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam @Parameter(description = "포털 로그인 ID", required = true) String username,
-            @RequestParam @Parameter(description = "포털 로그인 비밀번호", required = true) String password
+            @RequestParam String username,
+            @RequestParam String password
     ) {
         String userId = userDetails.getUsername();
         redisPortalCredentialStore.save(userId, username, password);
@@ -80,19 +60,6 @@ public class SuwonScrapeController {
     }
 
     @PostMapping("/start")
-    @Operation(
-            summary = "포털 데이터 크롤링 및 동기화",
-            description = "Redis에 저장된 포털 로그인 정보를 사용하여 데이터를 크롤링하고 초기화 및 학업 이력을 동기화합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "동기화 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ScrapingApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 필요 (ErrorCode: C01, 세션 만료)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: C02, 포털 크롤링 실패)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<ScrapingResponse>> startScraping(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
@@ -139,19 +106,6 @@ public class SuwonScrapeController {
     }
 
     @PostMapping("/refresh")
-    @Operation(
-            summary = "포털 정보 재연동 및 학업 이력 동기화",
-            description = "포털 정보를 재연동하고 학업 이력을 다시 동기화합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "202", description = "재연동 및 동기화 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ScrapingApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인 필요 (ErrorCode: C01, 세션 만료)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: C03, 재연동 실패)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<ScrapingResponse>> refreshAndSync(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
+++ b/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
@@ -1,10 +1,10 @@
 package com.chukchuk.haksa.application.api;
 
 import com.chukchuk.haksa.application.academic.dto.SyncAcademicRecordResult;
-import com.chukchuk.haksa.application.api.dto.PortalLoginResponse;
-import com.chukchuk.haksa.application.api.dto.ScrapingResponse;
-import com.chukchuk.haksa.application.api.wrapper.PortalLoginApiResponse;
-import com.chukchuk.haksa.application.api.wrapper.ScrapingApiResponse;
+import com.chukchuk.haksa.application.dto.PortalLoginResponse;
+import com.chukchuk.haksa.application.dto.ScrapingResponse;
+import com.chukchuk.haksa.application.academic.wrapper.PortalLoginApiResponse;
+import com.chukchuk.haksa.application.academic.wrapper.ScrapingApiResponse;
 import com.chukchuk.haksa.application.portal.InitializePortalConnectionService;
 import com.chukchuk.haksa.application.portal.RefreshPortalConnectionService;
 import com.chukchuk.haksa.application.portal.SyncAcademicRecordService;

--- a/src/main/java/com/chukchuk/haksa/application/api/docs/SuwonScrapeControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/application/api/docs/SuwonScrapeControllerDocs.java
@@ -1,0 +1,75 @@
+// SuwonScrapeControllerDocs.java
+package com.chukchuk.haksa.application.api.docs;
+
+import com.chukchuk.haksa.application.academic.wrapper.PortalLoginApiResponse;
+import com.chukchuk.haksa.application.academic.wrapper.ScrapingApiResponse;
+import com.chukchuk.haksa.application.dto.PortalLoginResponse;
+import com.chukchuk.haksa.application.dto.ScrapingResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface SuwonScrapeControllerDocs {
+
+    @Operation(
+            summary = "포털 로그인",
+            description = "수원대학교 포털 로그인 후 Redis에 계정 정보를 저장합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "로그인 성공",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PortalLoginApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "로그인 실패 (ErrorCode: P01, 포털 로그인 실패)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR, 서버 오류)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<PortalLoginResponse>> login(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam @Parameter(description = "포털 로그인 ID", required = true) String username,
+            @RequestParam @Parameter(description = "포털 로그인 비밀번호", required = true) String password
+    );
+
+    @Operation(
+            summary = "포털 데이터 크롤링 및 동기화",
+            description = "Redis에 저장된 포털 로그인 정보를 사용하여 데이터를 크롤링하고 초기화 및 학업 이력을 동기화합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "202", description = "동기화 성공",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ScrapingApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요 (ErrorCode: C01, 세션 만료)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: C02, 포털 크롤링 실패)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<ScrapingResponse>> startScraping(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "포털 정보 재연동 및 학업 이력 동기화",
+            description = "포털 정보를 재연동하고 학업 이력을 다시 동기화합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "202", description = "재연동 및 동기화 성공",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ScrapingApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요 (ErrorCode: C01, 세션 만료)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: C03, 재연동 실패)",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<ScrapingResponse>> refreshAndSync(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/application/dto/PortalLoginResponse.java
+++ b/src/main/java/com/chukchuk/haksa/application/dto/PortalLoginResponse.java
@@ -1,4 +1,4 @@
-package com.chukchuk.haksa.application.api.dto;
+package com.chukchuk.haksa.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/chukchuk/haksa/application/dto/ScrapingResponse.java
+++ b/src/main/java/com/chukchuk/haksa/application/dto/ScrapingResponse.java
@@ -1,4 +1,4 @@
-package com.chukchuk.haksa.application.api.dto;
+package com.chukchuk.haksa.application.dto;
 
 import com.chukchuk.haksa.infrastructure.portal.model.PortalConnectionResult;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/AcademicRecordController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/AcademicRecordController.java
@@ -1,19 +1,11 @@
 package com.chukchuk.haksa.domain.academic.record.controller;
 
+import com.chukchuk.haksa.domain.academic.record.controller.docs.AcademicRecordControllerDocs;
 import com.chukchuk.haksa.domain.academic.record.dto.AcademicRecordResponse;
 import com.chukchuk.haksa.domain.academic.record.service.AcademicRecordService;
 import com.chukchuk.haksa.domain.academic.record.service.StudentAcademicRecordService;
-import com.chukchuk.haksa.domain.academic.record.wrapper.AcademicRecordApiResponse;
-import com.chukchuk.haksa.domain.academic.record.wrapper.AcademicSummaryApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,53 +21,16 @@ import static com.chukchuk.haksa.domain.academic.record.dto.StudentAcademicRecor
 @RestController
 @RequestMapping("/api/academic")
 @RequiredArgsConstructor
-@Tag(name = "Academic Record", description = "학업 성적 관련 API")
-public class AcademicRecordController {
+public class AcademicRecordController implements AcademicRecordControllerDocs {
 
     private final AcademicRecordService academicRecordService;
     private final StudentAcademicRecordService studentAcademicRecordService;
 
-    /* 학기별 성적 및 수강 과목 정보 조회 API */
     @GetMapping("/record")
-    @Operation(
-            summary = "학기별 성적 및 수강 과목 정보 조회",
-            description = "지정한 학기(year, semester)에 해당하는 성적 및 수강 과목 정보를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "지정 학기 성적 및 수강 과목 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = AcademicRecordApiResponse.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "인증 실패",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "해당 학기 성적 데이터 없음 (A01)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 내부 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    )
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<AcademicRecordResponse>> getAcademicRecord(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam @Parameter(description = "연도", example = "2024", required = true) Integer year,
-            @RequestParam @Parameter(description = "학기", example = "10, 15, 20 ...", required = true) Integer semester) {
+            @RequestParam Integer year,
+            @RequestParam Integer semester) {
 
         UUID studentId = userDetails.getStudentId();
         AcademicRecordResponse response = academicRecordService.getAcademicRecord(studentId, year, semester);
@@ -83,42 +38,7 @@ public class AcademicRecordController {
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 
-    /* 사용자 학업 요약 정보 조회 API */
     @GetMapping("/summary")
-    @Operation(
-            summary = "사용자 학업 요약 정보 조회",
-            description = "로그인된 사용자의 학업 요약 정보를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "학업 요약 정보 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = AcademicSummaryApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "인증 실패",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "학업 요약 정보 없음 또는 사용자 정보 없음 (ErrorCode: U02, S01)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 내부 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    )
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<AcademicSummaryResponse>> getAcademicSummary(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
@@ -127,5 +47,4 @@ public class AcademicRecordController {
 
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
-
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/SemesterController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/SemesterController.java
@@ -1,17 +1,10 @@
 package com.chukchuk.haksa.domain.academic.record.controller;
 
+import com.chukchuk.haksa.domain.academic.record.controller.docs.SemesterControllerDocs;
 import com.chukchuk.haksa.domain.academic.record.dto.SemesterAcademicRecordDto.SemesterGradeResponse;
 import com.chukchuk.haksa.domain.academic.record.service.SemesterAcademicRecordService;
-import com.chukchuk.haksa.domain.academic.record.wrapper.SemesterGradesApiResponse;
-import com.chukchuk.haksa.domain.academic.record.wrapper.StudentSemesterListApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,76 +20,23 @@ import static com.chukchuk.haksa.domain.student.dto.StudentSemesterDto.StudentSe
 @RestController
 @RequestMapping("/api/semester")
 @RequiredArgsConstructor
-@Tag(name = "Semester Record", description = "학기 별 성적 및 학기 정보 관련 API")
-public class SemesterController {
+public class SemesterController implements SemesterControllerDocs {
 
     private final SemesterAcademicRecordService semesterAcademicRecordService;
 
     @GetMapping
-    @Operation(
-            summary = "사용자 학기 목록 조회",
-            description = "사용자의 모든 학기 정보를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "사용자의 모든 학기 정보 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = StudentSemesterListApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "학기 데이터 없음 (ErrorCode: A03, FRESHMAN_NO_SEMESTER)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            })
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<List<StudentSemesterInfoResponse>>> getSemesterRecord(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         UUID studentId = userDetails.getStudentId();
-
         List<StudentSemesterInfoResponse> response = semesterAcademicRecordService.getSemestersByStudentId(studentId);
-
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 
     @GetMapping("/grades")
-    @Operation(
-            summary = "사용자 학기 별 성적 조회",
-            description = "사용자의 학기 별 성적 정보를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "사용자의 학기 별 성적 정보 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = SemesterGradesApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "학기 성적 데이터 없음 (ErrorCode: A02, SEMESTER_RECORD_EMPTY)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            })
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<List<SemesterGradeResponse>>> getSemesterGrades(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         UUID studentId = userDetails.getStudentId();
-
         List<SemesterGradeResponse> response = semesterAcademicRecordService.getAllSemesterGrades(studentId);
-
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/AcademicRecordControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/AcademicRecordControllerDocs.java
@@ -1,0 +1,62 @@
+package com.chukchuk.haksa.domain.academic.record.controller.docs;
+
+import com.chukchuk.haksa.domain.academic.record.dto.AcademicRecordResponse;
+import com.chukchuk.haksa.domain.academic.record.wrapper.AcademicRecordApiResponse;
+import com.chukchuk.haksa.domain.academic.record.wrapper.AcademicSummaryApiResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static com.chukchuk.haksa.domain.academic.record.dto.StudentAcademicRecordDto.AcademicSummaryResponse;
+
+public interface AcademicRecordControllerDocs {
+
+    @Operation(
+            summary = "학기별 성적 및 수강 과목 정보 조회",
+            description = "지정한 학기(year, semester)에 해당하는 성적 및 수강 과목 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "지정 학기 성적 및 수강 과목 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AcademicRecordApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 학기 성적 데이터 없음 (A01)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<AcademicRecordResponse>> getAcademicRecord(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam @Parameter(description = "연도", example = "2024", required = true) Integer year,
+            @RequestParam @Parameter(description = "학기", example = "10, 15, 20 ...", required = true) Integer semester
+    );
+
+    @Operation(
+            summary = "사용자 학업 요약 정보 조회",
+            description = "로그인된 사용자의 학업 요약 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "학업 요약 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AcademicSummaryApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "404", description = "학업 요약 정보 없음 또는 사용자 정보 없음 (U02, S01)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<AcademicSummaryResponse>> getAcademicSummary(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/SemesterControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/SemesterControllerDocs.java
@@ -1,0 +1,56 @@
+package com.chukchuk.haksa.domain.academic.record.controller.docs;
+
+import com.chukchuk.haksa.domain.academic.record.dto.SemesterAcademicRecordDto.SemesterGradeResponse;
+import com.chukchuk.haksa.domain.academic.record.wrapper.SemesterGradesApiResponse;
+import com.chukchuk.haksa.domain.academic.record.wrapper.StudentSemesterListApiResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.util.List;
+
+import static com.chukchuk.haksa.domain.student.dto.StudentSemesterDto.StudentSemesterInfoResponse;
+
+public interface SemesterControllerDocs {
+
+    @Operation(
+            summary = "사용자 학기 목록 조회",
+            description = "사용자의 모든 학기 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자의 모든 학기 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = StudentSemesterListApiResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "학기 데이터 없음 (ErrorCode: A03, FRESHMAN_NO_SEMESTER)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<List<StudentSemesterInfoResponse>>> getSemesterRecord(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "사용자 학기 별 성적 조회",
+            description = "사용자의 학기 별 성적 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자의 학기 별 성적 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = SemesterGradesApiResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "학기 성적 데이터 없음 (ErrorCode: A02, SEMESTER_RECORD_EMPTY)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<List<SemesterGradeResponse>>> getSemesterGrades(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/controller/AuthController.java
@@ -1,13 +1,8 @@
 package com.chukchuk.haksa.domain.auth.controller;
 
+import com.chukchuk.haksa.domain.auth.controller.docs.AuthControllerDocs;
 import com.chukchuk.haksa.domain.auth.service.RefreshTokenService;
-import com.chukchuk.haksa.domain.auth.wrapper.RefreshTokenApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,38 +16,13 @@ import static com.chukchuk.haksa.domain.auth.dto.AuthDto.RefreshResponse;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-@Tag(name = "Auth", description = "인증 관련 API")
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
+
     private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/refresh")
-    @Operation(
-            summary = "토큰 재발급",
-            description = "리프레시 토큰을 사용해 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "토큰 재발급 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = RefreshTokenApiResponse.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "인증 실패 (ErrorCode: T04, T10, T12, T11)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "사용자 정보 없음 (ErrorCode: U01)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
     public ResponseEntity<SuccessResponse<RefreshResponse>> refreshResponse(@RequestBody RefreshRequest request) {
         RefreshResponse response = refreshTokenService.reissue(request.refreshToken());
-
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/controller/docs/AuthControllerDocs.java
@@ -1,0 +1,45 @@
+package com.chukchuk.haksa.domain.auth.controller.docs;
+
+import com.chukchuk.haksa.domain.auth.wrapper.RefreshTokenApiResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import static com.chukchuk.haksa.domain.auth.dto.AuthDto.RefreshRequest;
+import static com.chukchuk.haksa.domain.auth.dto.AuthDto.RefreshResponse;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+public interface AuthControllerDocs {
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레시 토큰을 사용해 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "토큰 재발급 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = RefreshTokenApiResponse.class))),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패 (ErrorCode: T04, T10, T12, T11)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자 정보 없음 (ErrorCode: U01)",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<RefreshResponse>> refreshResponse(@RequestBody RefreshRequest request);
+}

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/controller/GraduationController.java
@@ -1,16 +1,10 @@
 package com.chukchuk.haksa.domain.graduation.controller;
 
+import com.chukchuk.haksa.domain.graduation.controller.docs.GraduationControllerDocs;
 import com.chukchuk.haksa.domain.graduation.dto.GraduationProgressResponse;
 import com.chukchuk.haksa.domain.graduation.service.GraduationService;
-import com.chukchuk.haksa.domain.graduation.wrapper.GraduationProgressApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,47 +17,15 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/graduation")
-@Tag(name = "Graduation", description = "졸업 요건 및 진행 현황 관련 API")
-public class GraduationController {
+public class GraduationController implements GraduationControllerDocs {
 
     private final GraduationService graduationService;
 
-    /**
-     * 졸업 요건 진행 상황 조회 API
-     */
     @GetMapping("/progress")
-    @Operation(
-            summary = "졸업 요건 진행 상황 조회",
-            description = "로그인된 사용자의 졸업 요건 충족 여부를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "졸업 요건 충족 여부 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = GraduationProgressApiResponse.class)
-                            )),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "사용자 정보 없음 (ErrorCode: S01, FRESHMAN_NO_SEMESTER)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class)
-                            )),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "졸업 요건 정보 없음 (ErrorCode: G01, GRADUATION_REQUIREMENTS_NOT_FOUND)",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<GraduationProgressResponse>> getGraduationProgress(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         UUID studentId = userDetails.getStudentId();
-
         GraduationProgressResponse response = graduationService.getGraduationProgress(studentId);
         return ResponseEntity.ok(SuccessResponse.of(response));
     }

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/controller/docs/GraduationControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/controller/docs/GraduationControllerDocs.java
@@ -1,0 +1,45 @@
+package com.chukchuk.haksa.domain.graduation.controller.docs;
+
+import com.chukchuk.haksa.domain.graduation.dto.GraduationProgressResponse;
+import com.chukchuk.haksa.domain.graduation.wrapper.GraduationProgressApiResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "Graduation", description = "졸업 요건 및 진행 현황 관련 API")
+public interface GraduationControllerDocs {
+
+    @Operation(
+            summary = "졸업 요건 진행 상황 조회",
+            description = "로그인된 사용자의 졸업 요건 충족 여부를 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "졸업 요건 충족 여부 조회 성공",
+                            content = @Content(schema = @Schema(implementation = GraduationProgressApiResponse.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자 정보 없음 (ErrorCode: S01, FRESHMAN_NO_SEMESTER)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "졸업 요건 정보 없음 (ErrorCode: G01, GRADUATION_REQUIREMENTS_NOT_FOUND)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))
+                    )
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<GraduationProgressResponse>> getGraduationProgress(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/controller/StudentController.java
@@ -1,18 +1,10 @@
 package com.chukchuk.haksa.domain.student.controller;
 
+import com.chukchuk.haksa.domain.student.controller.docs.StudentControllerDocs;
 import com.chukchuk.haksa.domain.student.service.StudentService;
-import com.chukchuk.haksa.domain.student.wrapper.StudentProfileApiResponse;
-import com.chukchuk.haksa.domain.student.wrapper.TargetGpaApiResponse;
 import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,74 +14,29 @@ import java.util.UUID;
 
 import static com.chukchuk.haksa.domain.student.dto.StudentDto.StudentProfileResponse;
 
-
 @RestController
 @RequestMapping("/api/student")
 @RequiredArgsConstructor
-@Tag(name = "Student", description = "학생 설정 관련 API")
-public class StudentController {
+public class StudentController implements StudentControllerDocs {
 
     private final StudentService studentService;
 
     @PostMapping("/target-gpa")
-    @Operation(
-            summary = "목표 GPA 설정",
-            description = "로그인된 사용자의 목표 GPA를 저장합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "목표 GPA 설정 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TargetGpaApiResponse.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 GPA 입력 (ErrorCode: S02, INVALID_TARGET_GPA)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "학생 정보 없음 (ErrorCode: S01, STUDENT_NOT_FOUND)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    )
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setTargetGpa(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false)
-            @Parameter(description = "목표 GPA", example = "3.8") Double targetGpa
+            @RequestParam(required = false) Double targetGpa
     ) {
         UUID studentId = userDetails.getStudentId();
-
         studentService.setStudentTargetGpa(studentId, targetGpa);
         return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("목표 학점 저장 완료")));
     }
 
     @GetMapping("/profile")
-    @Operation(
-            summary = "사용자 프로필 조회",
-            description = "로그인된 사용자의 프로필 정보를 조회합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "사용자 프로필 정보 조회 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = StudentProfileApiResponse.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "학생 정보 없음 (ErrorCode: S01, STUDENT_NOT_FOUND)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    )
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<StudentProfileResponse>> getProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         UUID studentId = userDetails.getStudentId();
-
         StudentProfileResponse response = studentService.getStudentProfile(studentId);
-
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/controller/docs/StudentControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/controller/docs/StudentControllerDocs.java
@@ -1,0 +1,58 @@
+package com.chukchuk.haksa.domain.student.controller.docs;
+
+import com.chukchuk.haksa.domain.student.wrapper.StudentProfileApiResponse;
+import com.chukchuk.haksa.domain.student.wrapper.TargetGpaApiResponse;
+import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static com.chukchuk.haksa.domain.student.dto.StudentDto.StudentProfileResponse;
+
+@Tag(name = "Student", description = "학생 설정 관련 API")
+public interface StudentControllerDocs {
+
+    @Operation(
+            summary = "목표 GPA 설정",
+            description = "로그인된 사용자의 목표 GPA를 저장합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "목표 GPA 설정 성공",
+                            content = @Content(schema = @Schema(implementation = TargetGpaApiResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 GPA 입력 (ErrorCode: S02, INVALID_TARGET_GPA)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "404", description = "학생 정보 없음 (ErrorCode: S01, STUDENT_NOT_FOUND)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setTargetGpa(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false)
+            @Parameter(description = "목표 GPA", example = "3.8") Double targetGpa
+    );
+
+    @Operation(
+            summary = "사용자 프로필 조회",
+            description = "로그인된 사용자의 프로필 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 프로필 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = StudentProfileApiResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "학생 정보 없음 (ErrorCode: S01, STUDENT_NOT_FOUND)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<StudentProfileResponse>> getProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
@@ -1,19 +1,12 @@
 package com.chukchuk.haksa.domain.user.controller;
 
 import com.chukchuk.haksa.domain.auth.dto.AuthDto;
+import com.chukchuk.haksa.domain.user.controller.docs.UserControllerDocs;
 import com.chukchuk.haksa.domain.user.dto.UserDto;
 import com.chukchuk.haksa.domain.user.service.UserService;
-import com.chukchuk.haksa.domain.user.wrapper.DeleteUserApiResponse;
-import com.chukchuk.haksa.domain.user.wrapper.SignInApiResponse;
 import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
-import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,74 +18,26 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@Tag(name = "User", description = "사용자 관련 API")
 @Slf4j
-public class UserController {
+public class UserController implements UserControllerDocs {
 
     private final UserService userService;
 
     @DeleteMapping("/delete")
-    @Operation(
-            summary = "회원 탈퇴",
-            description = "로그인된 사용자의 계정을 삭제합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "회원 탈퇴 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DeleteUserApiResponse.class))
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "사용자 정보 없음 (ErrorCode: U01, USER_NOT_FOUND)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))
-                    )
-            }
-    )
-    @SecurityRequirement(name = "bearerAuth")
     public ResponseEntity<SuccessResponse<MessageOnlyResponse>> deleteUser(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         UUID userId = UUID.fromString(userDetails.getUsername());
         userService.deleteUserById(userId);
-
         return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("회원 탈퇴가 완료되었습니다.")));
     }
 
-    /* 회원가입/로그인 */
     @PostMapping("/signin")
-    @Operation(
-            summary = "회원 가입 및 로그인",
-            description = "사용자가 카카오 소셜 로그인으로 회원가입 및 로그인을 진행합니다.",
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "회원가입/로그인 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = SignInApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "토큰 유효성 오류 (ErrorCode: T10, TOKEN_INVALID)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "만료된 토큰 오류 (ErrorCode: T04, TOKEN_EXPIRED)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseWrapper.class)))
-            }
-    )
     public ResponseEntity<SuccessResponse<UserDto.SignInResponse>> signInUser(
             @RequestBody UserDto.SignInRequest signInRequest
-            ) {
+    ) {
         AuthDto.SignInTokenResponse tokens = userService.signInWithKakao(signInRequest);
-
         UserDto.SignInResponse response = new UserDto.SignInResponse(tokens.accessToken(), tokens.refreshToken(), tokens.isPortalLinked());
-
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/docs/UserControllerDocs.java
@@ -1,0 +1,55 @@
+package com.chukchuk.haksa.domain.user.controller.docs;
+
+import com.chukchuk.haksa.domain.user.dto.UserDto;
+import com.chukchuk.haksa.domain.user.wrapper.DeleteUserApiResponse;
+import com.chukchuk.haksa.domain.user.wrapper.SignInApiResponse;
+import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "User", description = "사용자 관련 API")
+public interface UserControllerDocs {
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "로그인된 사용자의 계정을 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+                            content = @Content(schema = @Schema(implementation = DeleteUserApiResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "사용자 정보 없음 (ErrorCode: U01, USER_NOT_FOUND)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> deleteUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "회원 가입 및 로그인",
+            description = "사용자가 카카오 소셜 로그인으로 회원가입 및 로그인을 진행합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원가입/로그인 성공",
+                            content = @Content(schema = @Schema(implementation = SignInApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "토큰 유효성 오류 (ErrorCode: T10, TOKEN_INVALID)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "401", description = "만료된 토큰 오류 (ErrorCode: T04, TOKEN_EXPIRED)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류 (ErrorCode: INTERNAL_ERROR)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<UserDto.SignInResponse>> signInUser(
+            @RequestBody UserDto.SignInRequest signInRequest
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서화**
    - 모든 컨트롤러의 Swagger/OpenAPI 문서화 어노테이션을 별도의 인터페이스로 분리하여 코드 내 어노테이션을 제거하고, API 문서화 일관성을 개선했습니다.
    - 각 컨트롤러는 대응하는 문서화 인터페이스를 구현하도록 변경되었습니다.
    - 새로운 문서화 인터페이스가 추가되어 각 API 엔드포인트의 설명, 응답, 오류 코드 등이 명확하게 정의되었습니다.

- **리팩터링**
    - 일부 클래스의 패키지 구조가 정리되어 코드 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->