### PR TITLE
133 fix: 포털 크롤링 로직 예외 처리 분기

### DIFF
--- a/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
+++ b/src/main/java/com/chukchuk/haksa/application/api/SuwonScrapeController.java
@@ -8,12 +8,10 @@ import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.service.UserService;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
-import com.chukchuk.haksa.global.exception.type.BaseException;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.logging.annotation.LogTime;
 import com.chukchuk.haksa.global.logging.sanitize.LogSanitizer;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
-import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import com.chukchuk.haksa.infrastructure.portal.model.PortalData;
 import com.chukchuk.haksa.infrastructure.portal.repository.PortalRepository;
 import com.chukchuk.haksa.infrastructure.redis.RedisCacheStore;
@@ -125,7 +123,7 @@ public class SuwonScrapeController implements SuwonScrapeControllerDocs {
     }
 
     private PortalData fetchPortalData(String userId) {
-        String username = redisPortalCredentialStore.getUsername(userId); //학번
+        String username = redisPortalCredentialStore.getUsername(userId);
         String password = redisPortalCredentialStore.getPassword(userId);
 
         if (username == null || password == null) {
@@ -134,19 +132,13 @@ public class SuwonScrapeController implements SuwonScrapeControllerDocs {
 
         long t0 = LogTime.start();
 
-        try {
-            PortalData portalData = portalRepository.fetchPortalData(username, password);
-            long tookMs = LogTime.elapsedMs(t0);
-            if (tookMs >= SLOW_MS) {
-                log.info("[BIZ] portal.fetch.done userId={} took_ms={}", userId, tookMs);
-            }
-            return portalData;
-        } catch (BaseException e) {
-            throw e;
-        } catch (Exception e) {
-            // 정말 예상 못한 케이스만 C02
-            log.error("[BIZ] portal.fetch.error userId={} ex={}", userId, e.getClass().getSimpleName(), e);
-            throw new PortalScrapeException(ErrorCode.SCRAPING_FAILED, e);
+        PortalData portalData = portalRepository.fetchPortalData(username, password);
+        long tookMs = LogTime.elapsedMs(t0);
+
+        if (tookMs >= SLOW_MS) {
+            log.info("[BIZ] portal.fetch.done userId={} took_ms={}", userId, tookMs);
         }
+
+        return portalData;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
@@ -7,7 +7,7 @@ import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -24,38 +24,46 @@ public class PortalClient {
     public RawPortalData scrapeAll(String username, String password) {
         String uri = "/scrape";
         long t0 = LogTime.start();
+
         try {
-            return webClient.post().uri(baseUrl + uri)
+            return webClient.post()
+                    .uri(baseUrl + uri)
                     .header("Content-Type", "application/json")
                     .bodyValue(new LoginRequest(username, password))
-                    .retrieve().bodyToMono(RawPortalData.class).block();
+                    .retrieve()
+                    .bodyToMono(RawPortalData.class)
+                    .block();
+
         } catch (WebClientResponseException e) {
+            logHttpError(uri, t0, e);
+            throw new PortalScrapeException(mapHttpStatus(e.getStatusCode()), e);
+
+        } catch (Exception e) {
             long tookMs = LogTime.elapsedMs(t0);
-            int status = e.getStatusCode().value();
-
-            if (status >= 500)      log.error("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
-            else if (status == 429) log.warn ("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
-            else                    log.warn ("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
-
-            HttpStatus st = HttpStatus.resolve(status);
-
-            ErrorCode code;
-            if (st == null) {
-                // 비표준/미지원 상태코드(예: 499, 520 등)
-                log.warn("[PORTAL] unknown http status={} -> map to PORTAL_SCRAPE_FAILED", status);
-                code = ErrorCode.PORTAL_SCRAPE_FAILED;
-            } else {
-                // 필요 매핑만 명시, 나머지는 기본값
-                switch (st) {
-                    case UNAUTHORIZED -> code = ErrorCode.PORTAL_LOGIN_FAILED;
-                    case LOCKED       -> code = ErrorCode.PORTAL_ACCOUNT_LOCKED;
-                    default           -> code = ErrorCode.PORTAL_SCRAPE_FAILED;
-                }
-            }
-
-            throw new PortalScrapeException(code, e);
+            log.error("[EXT] method=POST uri={} unexpected_error took_ms={}", uri, tookMs, e);
+            throw new PortalScrapeException(ErrorCode.PORTAL_SCRAPE_FAILED, e);
         }
     }
 
     private record LoginRequest(String username, String password) {}
+
+    private void logHttpError(String uri, long t0, WebClientResponseException e) {
+        long tookMs = LogTime.elapsedMs(t0);
+        int status = e.getStatusCode().value();
+
+        if (status >= 500) log.error("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
+        else               log.warn ("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
+    }
+
+    private ErrorCode mapHttpStatus(HttpStatusCode status) {
+        if (status == null) {
+            return ErrorCode.PORTAL_SCRAPE_FAILED;
+        }
+
+        return switch (status.value()) {
+            case 401 -> ErrorCode.PORTAL_LOGIN_FAILED;
+            case 423 -> ErrorCode.PORTAL_ACCOUNT_LOCKED;
+            default  -> ErrorCode.PORTAL_SCRAPE_FAILED;
+        };
+    }
 }


### PR DESCRIPTION
기존에는 비즈니스 로직에서 예외를 던져도 controller 단에서 다시 예외를 감싸서 반환했기 때문에 모든에 같은 예외가 발생함
```java
catch (BaseException e) {
   throw e;
} 
```
를 추가하여, 비즈니스 로직에서 반환된 예외를 그대로 던지도록 수정