### PR TITLE
182 feat: 카카오 OIDC aud 다중 키 허용

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -31,6 +31,7 @@ jobs:
           JWT_ACCESS_EXPIRATION: ${{ secrets.JWT_ACCESS_EXPIRATION }}
           JWT_REFRESH_EXPIRATION: ${{ secrets.JWT_REFRESH_EXPIRATION }}
           APP_KEY: ${{ secrets.APP_KEY }}
+          APP_NATIVE_KEY: ${{ secrets.APP_NATIVE_KEY }}
           CRAWLER_BASE_URL: ${{ secrets.CRAWLER_BASE_URL }}
           REDIS_ENCRYPT_KEY: ${{ secrets.REDIS_ENCRYPT_KEY }}
           LOCAL_DB_URL: ${{ secrets.LOCAL_DB_URL }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,6 +31,7 @@ jobs:
           JWT_ACCESS_EXPIRATION: ${{ secrets.JWT_ACCESS_EXPIRATION }}
           JWT_REFRESH_EXPIRATION: ${{ secrets.JWT_REFRESH_EXPIRATION }}
           APP_KEY: ${{ secrets.APP_KEY }}
+          APP_NATIVE_KEY: ${{ secrets.APP_NATIVE_KEY }}
           CRAWLER_BASE_URL: ${{ secrets.CRAWLER_BASE_URL }}
           REDIS_ENCRYPT_KEY: ${{ secrets.REDIS_ENCRYPT_KEY }}
           LOCAL_DB_URL: ${{ secrets.LOCAL_DB_URL }}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@
 
 ---
 
+## 배포 환경 변수 (OIDC)
+
+- `APP_KEY`: 카카오 OIDC `aud` 검증에 사용하는 기본 키(REST API 키)
+- `APP_NATIVE_KEY`: 안드로이드 OIDC `aud` 검증에 사용하는 네이티브 앱 키 (선택)
+
+> GitHub Actions 배포 시 `dev/prod` 저장소 secrets에 `APP_NATIVE_KEY`를 함께 등록해야 합니다.
+
+---
+
 ## 기술 스택
 
 ### Back-end

--- a/src/main/java/com/chukchuk/haksa/infrastructure/oidc/KakaoOidcService.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/oidc/KakaoOidcService.java
@@ -20,6 +20,9 @@ import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.Date;
 
 @Service
@@ -30,6 +33,9 @@ public class KakaoOidcService implements OidcService {
 
     @Value("${security.appKey}")
     private String appKey;
+
+    @Value("${security.nativeAppKey:}")
+    private String nativeAppKey;
 
     public Claims verifyIdToken(String idToken, String expectedNonce) {
         try {
@@ -93,18 +99,7 @@ public class KakaoOidcService implements OidcService {
             throw new TokenException(ErrorCode.TOKEN_INVALID_ISS);
         }
 
-        Object audClaim = claims.get("aud");
-        if (audClaim instanceof String) {
-            if (!appKey.equals(audClaim)) {
-                throw new TokenException(ErrorCode.TOKEN_INVALID_AUD);
-            }
-        } else if (audClaim instanceof java.util.List) {
-            if (!((java.util.List<?>) audClaim).contains(appKey)) {
-                throw new TokenException(ErrorCode.TOKEN_INVALID_AUD);
-            }
-        } else {
-            throw new TokenException(ErrorCode.TOKEN_INVALID_AUD_FORMAT);
-        }
+        validateAudience(claims.get("aud"));
 
         String hashedNonce = hashSHA256(expectedNonce);
         String nonce = claims.get("nonce", String.class);
@@ -122,6 +117,49 @@ public class KakaoOidcService implements OidcService {
             }
         }
         return null;
+    }
+
+    private void validateAudience(Object audClaim) {
+        Set<String> allowedAudiences = resolveAllowedAudiences();
+
+        if (audClaim instanceof String aud) {
+            if (!allowedAudiences.contains(aud)) {
+                throw new TokenException(ErrorCode.TOKEN_INVALID_AUD);
+            }
+            return;
+        }
+
+        if (audClaim instanceof List<?> audiences) {
+            boolean matched = audiences.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .anyMatch(allowedAudiences::contains);
+
+            if (!matched) {
+                throw new TokenException(ErrorCode.TOKEN_INVALID_AUD);
+            }
+            return;
+        }
+
+        throw new TokenException(ErrorCode.TOKEN_INVALID_AUD_FORMAT);
+    }
+
+    private Set<String> resolveAllowedAudiences() {
+        Set<String> allowedAudiences = new LinkedHashSet<>();
+        addIfPresent(allowedAudiences, appKey);
+        addIfPresent(allowedAudiences, nativeAppKey);
+        return allowedAudiences;
+    }
+
+    private void addIfPresent(Set<String> targets, String value) {
+        if (value == null) {
+            return;
+        }
+
+        String normalized = value.trim();
+        if (!normalized.isEmpty()) {
+            targets.add(normalized);
+        }
     }
 
     private String hashSHA256(String input) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,7 @@ security:
     access-expiration: ${JWT_ACCESS_EXPIRATION}
     refresh-expiration: ${JWT_REFRESH_EXPIRATION}
   appKey: ${APP_KEY}
+  nativeAppKey: ${APP_NATIVE_KEY:}
 
 crawler:
   base-url: ${CRAWLER_BASE_URL}

--- a/src/test/java/com/chukchuk/haksa/infrastructure/oidc/KakaoOidcServiceAudValidationTests.java
+++ b/src/test/java/com/chukchuk/haksa/infrastructure/oidc/KakaoOidcServiceAudValidationTests.java
@@ -1,0 +1,125 @@
+package com.chukchuk.haksa.infrastructure.oidc;
+
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.TokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.impl.DefaultClaims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Date;
+import java.util.HexFormat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KakaoOidcServiceAudValidationTests {
+
+    private static final String APP_KEY = "rest-app-key";
+    private static final String NATIVE_APP_KEY = "native-app-key";
+    private static final String RAW_NONCE = "nonce-raw-value";
+
+    private KakaoOidcService kakaoOidcService;
+    private Method validateClaimsMethod;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        kakaoOidcService = new KakaoOidcService();
+        validateClaimsMethod = KakaoOidcService.class.getDeclaredMethod("validateClaims", String.class, Claims.class);
+        validateClaimsMethod.setAccessible(true);
+
+        setPrivateField("appKey", APP_KEY);
+        setPrivateField("nativeAppKey", NATIVE_APP_KEY);
+    }
+
+    @Test
+    @DisplayName("aud가 APP_KEY와 일치하면 검증에 성공한다")
+    void validateClaimsPassesWhenAudMatchesAppKey() {
+        Claims claims = validClaims(APP_KEY);
+
+        invokeValidateClaims(RAW_NONCE, claims);
+    }
+
+    @Test
+    @DisplayName("aud가 APP_NATIVE_KEY와 일치하면 검증에 성공한다")
+    void validateClaimsPassesWhenAudMatchesNativeAppKey() {
+        Claims claims = validClaims(NATIVE_APP_KEY);
+
+        invokeValidateClaims(RAW_NONCE, claims);
+    }
+
+    @Test
+    @DisplayName("aud가 배열일 때 허용 키 중 하나라도 포함하면 검증에 성공한다")
+    void validateClaimsPassesWhenAudListContainsAllowedAudience() {
+        Claims claims = validClaims(List.of("unknown-aud", NATIVE_APP_KEY));
+
+        invokeValidateClaims(RAW_NONCE, claims);
+    }
+
+    @Test
+    @DisplayName("aud가 허용 키와 모두 불일치하면 T06 예외를 던진다")
+    void validateClaimsThrowsWhenAudienceDoesNotMatch() {
+        Claims claims = validClaims("unknown-aud");
+
+        assertThatThrownBy(() -> invokeValidateClaims(RAW_NONCE, claims))
+                .isInstanceOf(TokenException.class)
+                .extracting(ex -> ((TokenException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.TOKEN_INVALID_AUD);
+    }
+
+    @Test
+    @DisplayName("aud 형식이 문자열/배열이 아니면 T07 예외를 던진다")
+    void validateClaimsThrowsWhenAudienceFormatIsInvalid() {
+        Claims claims = validClaims(12345);
+
+        assertThatThrownBy(() -> invokeValidateClaims(RAW_NONCE, claims))
+                .isInstanceOf(TokenException.class)
+                .extracting(ex -> ((TokenException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.TOKEN_INVALID_AUD_FORMAT);
+    }
+
+    private Claims validClaims(Object audClaim) {
+        DefaultClaims claims = new DefaultClaims();
+        claims.setExpiration(new Date(System.currentTimeMillis() + 60_000));
+        claims.setIssuer("https://kauth.kakao.com");
+        claims.put("aud", audClaim);
+        claims.put("nonce", hashSha256(RAW_NONCE));
+        return claims;
+    }
+
+    private void invokeValidateClaims(String expectedNonce, Claims claims) {
+        try {
+            validateClaimsMethod.invoke(kakaoOidcService, expectedNonce, claims);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new RuntimeException(cause);
+        }
+    }
+
+    private void setPrivateField(String fieldName, String value) throws Exception {
+        Field field = KakaoOidcService.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(kakaoOidcService, value);
+    }
+
+    private String hashSha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 카카오 OIDC `aud` 검증을 단일 키(`APP_KEY`)에서 다중 키(`APP_KEY`, `APP_NATIVE_KEY`) 허용 방식으로 확장
- `security.nativeAppKey: ${APP_NATIVE_KEY:}` 설정 추가 (미설정 시 기존 동작 유지)
- `aud`가 문자열/배열인 경우 모두 허용 키 집합 기준으로 검증
- `aud` 형식 오류는 기존처럼 `T07`, 불일치는 `T06` 유지
- `nonce` 검증 로직은 변경 없음 (`SHA-256(body.nonce) == id_token.nonce`)

### 테스트
- `./gradlew test` 통과
- 신규 테스트 추가:
    - `aud=APP_KEY` 통과
    - `aud=APP_NATIVE_KEY` 통과
    - `aud` 배열에 허용 키 포함 시 통과
    - 불일치 시 `T06`
    - 비정상 형식 시 `T07`

### 운영 반영 사항
- GitHub Actions 배포 워크플로우(dev/prod)에 `APP_NATIVE_KEY` secret 추가
- README에 OIDC 배포 환경변수(`APP_KEY`, `APP_NATIVE_KEY`) 안내 추가

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue
Closes #182 