### PR TITLE
192 feat: 포털 sync batch 최적화 및 회귀 수정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
 - Lite 경로: Scope < 1 day & 외부 API/계약 수정 없음 & 도메인 영향이 제한적일 때만 허용하며 `spec-lite.md`만 작성한다.
 - Lite로 시작했다가 조건을 벗어나면 즉시 Standard 구조로 승격해 네 개 파일을 채운다.
 - 브랜치명과 `docs/specs` 폴더명은 1:1 매핑한다(`YYYYMMDD-slug`).
+- Spec/Lite 문서 작성 후에는 담당자 승인(“OK to implement”)을 명시적으로 받은 뒤에만 Phase 2(구현)로 진행한다. 승인 근거는 `clarify.md`나 spec에 기록한다.
 
 ### 1. Absolute Rules (Non-negotiable)
 - Do not commit with failing tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@
 - Lite 경로: Scope < 1 day & 외부 API/계약 수정 없음 & 도메인 영향이 제한적일 때만 허용하며 `spec-lite.md`만 작성한다.
 - Lite로 시작했다가 조건을 벗어나면 즉시 Standard 구조로 승격해 네 개 파일을 채운다.
 - 브랜치명과 `docs/specs` 폴더명은 1:1 매핑한다(`YYYYMMDD-slug`).
-- Spec/Lite 문서 작성 후에는 담당자 승인(“OK to implement”)을 명시적으로 받은 뒤에만 Phase 2(구현)로 진행한다. 승인 근거는 `clarify.md`나 spec에 기록한다.
+- Spec/Lite 문서 작성 후에는 담당자의 승인(“OK to implement”)을 명시적으로 받은 뒤에만 Phase 2(구현)로 진행한다. 승인 근거는 `clarify.md`나 spec에 기록한다.
 
 ### 1. Absolute Rules (Non-negotiable)
 - Do not commit with failing tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,7 @@
 - Move business logic gradually into the domain layer.
 - Gradually reduce transaction scope.
 - Split commits by meaningful units (feature, refactor, test).
+
+### Git Branch Naming
+- 모든 작업 브랜치는 사용자가 지정한 GitHub Issue 번호와 1:1로 매핑되며, 브랜치명은 항상 `feat/{github-issue-number}` 형식을 따른다. (예: `feat/123`)
+- 만약 이슈 번호가 제공되지 않았다면 작업을 시작하기 전에 사용자에게 이슈 번호를 물어보고 기록한다.

--- a/codex/skills/SKILL.md
+++ b/codex/skills/SKILL.md
@@ -43,6 +43,7 @@ Lower-level documents must not violate higher-level documents.
 - Standard: `spec.md`, `clarify.md`, `plan.md`, `tasks.md` 4개 파일이 모두 있어야 Phase 1이 완료된다.
 - Lite: Scope < 1 day 및 API 미변경 조건에서만 `spec-lite.md` 단일 파일로 시작할 수 있으며, 조건을 벗어나면 즉시 Standard로 승격한다.
 - 명세에 없는 요구사항은 존재하지 않는 것으로 취급한다. 모호점이 생기면 `clarify.md`에 기록하고 해결 후에만 다음 Phase로 이동한다.
+- Spec/Lite가 작성된 뒤에는 담당자의 승인(“OK to implement”)을 받고 해당 근거를 명시한 후에만 Phase 2로 넘어갈 수 있다.
 
 ---
 

--- a/codex/skills/SKILL.md
+++ b/codex/skills/SKILL.md
@@ -112,7 +112,7 @@ Layer access rules:
 ## 9. Git Rules
 
 - All work must be done on a branch.
-  Example: `feat/20260327-auth-studentid-separation`
+- Branch names must always follow `feat/{github-issue-number}` (e.g., `feat/123`) and map 1:1 to the user-specified GitHub Issue number. If the issue number has not been provided, stop and ask the user for it before creating or switching branches.
 - Each branch must have exactly one matching `docs/specs/<YYYYMMDD-slug>` directory.
 - Commit messages must include the branch identifier.
 - Commit messages must be written in Korean.

--- a/docs/specs/20260327-issue-192-portal-bulk/clarify.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/clarify.md
@@ -10,6 +10,7 @@
 |---|----------|--------|------|
 | 1 | Hibernate JDBC batch 설정을 전역으로 적용한다. | Bulk insert/delete가 주요 병목으로 지목되었기 때문 | 2026-03-27 |
 | 2 | 수강 이력 삭제는 `deleteAllByIdInBatch`로 대체하고, 업데이트는 dirty checking에 맡긴다. | JPA가 동일 트랜잭션에서 관리 중이므로 별도 saveAll 불필요 | 2026-03-27 |
+| 3 | 포털 성적 데이터 병합 시에는 과목/연도/학기 단위로 기존 offering 정보를 재사용하고, 누락된 평가/이수구분 값은 안전하게 기본 처리한다. | 신규 key 추가 후 academic-only entry가 별도 커맨드로 생성되면서 NullPointerException이 발생했기 때문 | 2026-03-28 |
 
 ## Risks / Unknowns
 - Item: 실제 지연 원인이 batch 외 다른 I/O(예: Course/Professor getOrCreate)일 가능성

--- a/docs/specs/20260327-issue-192-portal-bulk/clarify.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/clarify.md
@@ -12,6 +12,7 @@
 | 2 | 수강 이력 삭제는 `deleteAllByIdInBatch`로 대체하고, 업데이트는 dirty checking에 맡긴다. | JPA가 동일 트랜잭션에서 관리 중이므로 별도 saveAll 불필요 | 2026-03-27 |
 | 3 | 포털 성적 데이터 병합 시에는 과목/연도/학기 단위로 기존 offering 정보를 재사용하고, 누락된 평가/이수구분 값은 안전하게 기본 처리한다. | 신규 key 추가 후 academic-only entry가 별도 커맨드로 생성되면서 NullPointerException이 발생했기 때문 | 2026-03-28 |
 | 4 | Portal sync 중 예기치 못한 런타임 예외가 발생해도 ScrapeJob 상태와 error_code를 FAILED/INTERNAL_ERROR로 즉시 기록한다. | 상태가 `queued`로 남아 프런트가 실패 여부를 알 수 없는 문제가 있었음 | 2026-03-28 |
+| 5 | StudentCourse 저장은 JPA `saveAll` 대신 JDBC 다중 값 INSERT로 처리한다. | IDENTITY + saveAll 조합이 행마다 INSERT를 실행하여 `insert_ms`가 3.6초 이상 지연됨 | 2026-03-28 |
 
 ## Risks / Unknowns
 - Item: 실제 지연 원인이 batch 외 다른 I/O(예: Course/Professor getOrCreate)일 가능성

--- a/docs/specs/20260327-issue-192-portal-bulk/clarify.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/clarify.md
@@ -1,0 +1,20 @@
+# Clarify
+
+## Open Questions
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | 목표 성능 수치(16초 → ?)를 명시적으로 확인할 필요가 있는가? | PO | Closed – 목표 5초 이하로 가정 |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | Hibernate JDBC batch 설정을 전역으로 적용한다. | Bulk insert/delete가 주요 병목으로 지목되었기 때문 | 2026-03-27 |
+| 2 | 수강 이력 삭제는 `deleteAllByIdInBatch`로 대체하고, 업데이트는 dirty checking에 맡긴다. | JPA가 동일 트랜잭션에서 관리 중이므로 별도 saveAll 불필요 | 2026-03-27 |
+
+## Risks / Unknowns
+- Item: 실제 지연 원인이 batch 외 다른 I/O(예: Course/Professor getOrCreate)일 가능성
+  - Impact: 성능 개선폭이 제한될 수 있음
+  - Mitigation: 단계별 로그/메트릭 추가하여 병목 지점을 추후 추적
+
+## Follow-ups
+- [ ] 포털 sync 단계별 실행 시간을 micrometer metric으로 계측 (Owner: TBD)

--- a/docs/specs/20260327-issue-192-portal-bulk/clarify.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/clarify.md
@@ -11,6 +11,7 @@
 | 1 | Hibernate JDBC batch 설정을 전역으로 적용한다. | Bulk insert/delete가 주요 병목으로 지목되었기 때문 | 2026-03-27 |
 | 2 | 수강 이력 삭제는 `deleteAllByIdInBatch`로 대체하고, 업데이트는 dirty checking에 맡긴다. | JPA가 동일 트랜잭션에서 관리 중이므로 별도 saveAll 불필요 | 2026-03-27 |
 | 3 | 포털 성적 데이터 병합 시에는 과목/연도/학기 단위로 기존 offering 정보를 재사용하고, 누락된 평가/이수구분 값은 안전하게 기본 처리한다. | 신규 key 추가 후 academic-only entry가 별도 커맨드로 생성되면서 NullPointerException이 발생했기 때문 | 2026-03-28 |
+| 4 | Portal sync 중 예기치 못한 런타임 예외가 발생해도 ScrapeJob 상태와 error_code를 FAILED/INTERNAL_ERROR로 즉시 기록한다. | 상태가 `queued`로 남아 프런트가 실패 여부를 알 수 없는 문제가 있었음 | 2026-03-28 |
 
 ## Risks / Unknowns
 - Item: 실제 지연 원인이 batch 외 다른 I/O(예: Course/Professor getOrCreate)일 가능성

--- a/docs/specs/20260327-issue-192-portal-bulk/plan.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/plan.md
@@ -1,0 +1,23 @@
+# Plan
+
+## Architecture / Layering
+- Domain impact: 없음. Domain 모델/규칙은 그대로 유지.
+- Application orchestration: `SyncAcademicRecordService` 내부 diff 로직을 정리하여 dirty checking / batch delete 사용. 필요 시 보조 메서드 가시성 조정.
+- Infrastructure touchpoints: `StudentCourseRepository` (batch delete 메서드 활용), Hibernate 설정.
+- Global/config changes: `application.yml`에 JDBC batch, ordered insert/update 설정 추가.
+
+## Data / Transactions
+- Repositories touched: `StudentCourseRepository`, `StudentCourseRepositoryCustom`(필요시), `AcademicRecordRepository` (간접 영향 없음), Spring JPA EntityManager.
+- Transaction scope: 기존과 동일하게 학생 단위 @Transactional 유지. Batch delete/flush도 동일 트랜잭션 내에서 수행.
+- Consistency expectations: diff 계산 후 insert/update/delete 모두 동일 트랜잭션에서 커밋되어야 하며 실패 시 전체 롤백.
+
+## Testing Strategy
+- Domain tests: N/A
+- Application tests: `SyncAcademicRecordService` 단위 테스트 추가 – 삭제 diff 시 `deleteAllByIdInBatch` 호출, dirty checking으로 업데이트 되는지 검증(mock 기반).
+- Integration/API tests: 필요 시 `@DataJpaTest`로 batch 설정이 정상 기동되는지 검증(시간상 생략 가능, 수동 확인).
+- Additional commands: `./gradlew test`
+
+## Rollout Considerations
+- Backward compatibility: 데이터 정합성 불변. batch 설정 미지원 DB에서 fallback하여 단건 처리되므로 안정성 확보.
+- Observability / metrics: 성능 개선 후 scrape job 작업 시간 log/metrics를 모니터링.
+- Feature flags / toggles: 필요 없음.

--- a/docs/specs/20260327-issue-192-portal-bulk/spec.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/spec.md
@@ -1,0 +1,64 @@
+# 포털 연동 Bulk I/O 최적화 스펙 (Issue #192)
+
+## 1. Feature Overview
+- Purpose: 포털 연동 후 수행되는 학업 이력 동기화 과정의 bulk insert/delete 구간을 최적화하여 현재 16초까지 지연되는 내부 I/O를 5초 이하로 단축한다.
+- Scope
+  - In: `SyncAcademicRecordService` 내 수강 이력 업데이트/삭제 로직, `AcademicRecordRepository` 중 포털 연동 경로에서 호출되는 bulk 저장, Spring JPA/Hibernate 글로벌 설정.
+  - Out: 포털 크롤러(API)·스케줄러·ScrapeJob 큐잉 로직, 사용자-facing API 스펙 변경, DB 스키마 변경.
+- Expected Impact: JDBC batch와 in-place dirty checking을 활용해 대량 insert/update/delete의 round-trip 횟수를 최소화하고, 16초 → 5초 이하(목표)로 포털 연동 완료 시간을 단축한다.
+- Stakeholder Confirmation: 사용자(PO) 구두 요청 – Issue #192 코멘트.
+
+## 2. Domain Rules
+- Rule 1: 포털 데이터는 여전히 소스 오브 트루스로 간주되어 DB 기록과 정확히 동기화되어야 한다.
+- Rule 2: 삭제 정책(포털에 존재하지 않는 수강 기록 삭제)과 재수강/성적 로직은 변경되지 않는다.
+- Rule 3: 동기화 트랜잭션은 학생 단위로 atomic 해야 한다.
+- Mutable Rules: JDBC batch 크기, flush 주기.
+- Immutable Rules: 학업 이력 합산 규칙, CourseOffering/Professor 생성 규칙.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: 포털 최초 연동 (LINK)
+  - Trigger: 학생이 포털 계정으로 최초 연동
+  - Actor: PortalSyncService
+  - Steps:
+    1. Scrape 결과를 PortalSyncService가 전달받음
+    2. InitializePortalConnectionService가 기본 정보 저장
+    3. SyncAcademicRecordService가 신규/변경/삭제 diff 처리
+  - Expected Result: sync 단계가 5초 이하로 완료되며 기존 데이터와 정확히 일치
+
+- Scenario Name: 포털 재연동 (REFRESH)
+  - Trigger: 이미 연동된 사용자가 재동기화 수행
+  - Actor: PortalSyncService
+  - Steps: LINK와 동일하나 RefreshPortalConnectionService 경로 사용
+  - Expected Result: 변경 사항만 빠르게 반영, 캐시 무효화 유지
+
+### Exception / Boundary Flow
+- Scenario Name: Batch 설정 오류
+  - Condition: Hibernate batch 설정이 미적용/오류
+  - Expected Behavior: 안전하게 단건 모드로 동작하되 로그 경고로 추적
+
+## 4. Transaction / Consistency
+- Transaction Start Point: `SyncAcademicRecordService.executeWithPortalData/executeForRefreshPortalData`
+- Transaction End Point: 서비스 메서드 종료 시점 (Spring @Transactional)
+- Atomicity Scope: 학생 단위 (studentId별)
+- Eventual Consistency Allowed: 불허 – 실패 시 전체 롤백
+
+## 5. API List
+- N/A (내부 배치/서비스 로직만 변경)
+
+## 6. Exception Policy
+- 기존 ErrorCode 유지. 작업 실패 시 `PortalScrapeException` 혹은 `CommonException` 경로 동일
+- 추가: batch 설정 문제 감지 시 warn 로그 남기고 fallback
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed
+- [ ] Phase 2 Domain complete (영향 없음)
+- [ ] Phase 3 Application complete
+- [ ] Phase 4 Infrastructure complete (Repository batch 활용)
+- [ ] Phase 5 Global/Config complete
+- [ ] Phase 6 API/Controller complete (영향 없음)
+
+## 8. Generated File List
+- docs/specs/20260327-issue-192-portal-bulk/
+  - Description: Issue #192 스펙 번들
+  - Layer: Docs

--- a/docs/specs/20260327-issue-192-portal-bulk/tasks.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/tasks.md
@@ -13,6 +13,7 @@
 |------|---------|--------|------|
 | 1 | `./gradlew test` | PASS | 2026-03-27 |
 | 2 | `./gradlew test` | PASS | 2026-03-28 |
+| 3 | `./gradlew test` | PASS | 2026-03-28 |
 
 ## Notes
 - Observation: batch 속성 적용 후 실제 성능 로그 비교 필요.

--- a/docs/specs/20260327-issue-192-portal-bulk/tasks.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## Checklist
+- [ ] Domain tests written (N/A)
+- [ ] Application layer updated (SyncAcademicRecordService diff 최적화)
+- [ ] Infrastructure layer updated (StudentCourseRepository batch delete)
+- [ ] Global/config reviewed (hibernate jdbc batch 설정)
+- [ ] API/controller updated (N/A)
+- [x] Documentation updated (spec bundle)
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test` | PASS | 2026-03-27 |
+
+## Notes
+- Observation: batch 속성 적용 후 실제 성능 로그 비교 필요.

--- a/docs/specs/20260327-issue-192-portal-bulk/tasks.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/tasks.md
@@ -14,6 +14,7 @@
 | 1 | `./gradlew test` | PASS | 2026-03-27 |
 | 2 | `./gradlew test` | PASS | 2026-03-28 |
 | 3 | `./gradlew test` | PASS | 2026-03-28 |
+| 4 | `./gradlew test` | PASS | 2026-03-28 |
 
 ## Notes
 - Observation: batch 속성 적용 후 실제 성능 로그 비교 필요.

--- a/docs/specs/20260327-issue-192-portal-bulk/tasks.md
+++ b/docs/specs/20260327-issue-192-portal-bulk/tasks.md
@@ -12,6 +12,7 @@
 | Step | Command | Result | Date |
 |------|---------|--------|------|
 | 1 | `./gradlew test` | PASS | 2026-03-27 |
+| 2 | `./gradlew test` | PASS | 2026-03-28 |
 
 ## Notes
 - Observation: batch 속성 적용 후 실제 성능 로그 비교 필요.

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -150,7 +150,6 @@ public class ScrapeResultCallbackService {
             recordQueuedAge(job, finishedAt);
             log.error("[BIZ] scrape.job.callback.unexpected_fail jobId={} operationType={} ex={}",
                     job.getJobId(), job.getOperationType(), e.getClass().getSimpleName(), e);
-            throw e;
         }
     }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -145,6 +145,12 @@ public class ScrapeResultCallbackService {
             log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_mapping jobId={} rawBodyHash={} resultPayloadKeys={} message={}",
                     job.getJobId(), bodyHash, topLevelFieldNames(request.result_payload()), e.getOriginalMessage());
             throw new CommonException(ErrorCode.INVALID_ARGUMENT, e);
+        } catch (RuntimeException e) {
+            job.markFailed("INTERNAL_ERROR", e.getMessage(), false, finishedAt);
+            recordQueuedAge(job, finishedAt);
+            log.error("[BIZ] scrape.job.callback.unexpected_fail jobId={} operationType={} ex={}",
+                    job.getJobId(), job.getOperationType(), e.getClass().getSimpleName(), e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -7,9 +7,11 @@ import com.chukchuk.haksa.application.academic.repository.AcademicRecordReposito
 import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
 import com.chukchuk.haksa.domain.course.dto.CreateOfferingCommand;
+import com.chukchuk.haksa.domain.course.model.Course;
 import com.chukchuk.haksa.domain.course.model.CourseOffering;
 import com.chukchuk.haksa.domain.course.service.CourseOfferingService;
 import com.chukchuk.haksa.domain.course.service.CourseService;
+import com.chukchuk.haksa.domain.professor.model.Professor;
 import com.chukchuk.haksa.domain.professor.service.ProfessorService;
 import com.chukchuk.haksa.domain.student.model.Grade;
 import com.chukchuk.haksa.domain.student.model.GradeType;
@@ -42,6 +44,7 @@ public class SyncAcademicRecordService {
     private final CourseOfferingService courseOfferingService;
     private final ProfessorService professorService;
     private final CourseService courseService;
+    private static final String DEFAULT_PROFESSOR_NAME = "미확인 교수";
 
     @Transactional
     public SyncAcademicRecordResult executeWithPortalData(UUID userId, PortalData portalData) {
@@ -95,15 +98,8 @@ public class SyncAcademicRecordService {
         CurriculumProcessingResult processingResult =
                 processCurriculumData(portalData.curriculum(), portalData.academic(), studentId);
         List<CourseEnrollment> newEnrollments = processingResult.enrollments();
-
-        List<Long> offeringIds = newEnrollments.stream()
-                .map(e -> (long) e.getOfferingId())
-                .distinct()
-                .toList();
-
-        long offeringFetchStartNs = System.nanoTime();
-        Map<Long, CourseOffering> offerings = courseOfferingService.getOfferingMapByIds(offeringIds);
-        long offeringFetchMs = elapsedMs(offeringFetchStartNs);
+        Map<Long, CourseOffering> offerings = processingResult.offeringById();
+        long offeringFetchMs = processingResult.offeringFetchMs();
 
         // 2) 기존 수강 기록
         List<StudentCourse> existingEnrollments = studentCourseRepository.findByStudent(student);
@@ -187,82 +183,106 @@ public class SyncAcademicRecordService {
         return stats;
     }
 
-    /* offerings(교과)와 academic(학업 성적)을 합쳐서
-     *  최종적으로 CourseEnrollment를 만드는 메서드
-     *  */
     private CurriculumProcessingResult processCurriculumData(PortalCurriculumData curriculumData, PortalAcademicData academicData, UUID studentId) {
         long curriculumMergeStartNs = System.nanoTime();
-        Map<String, MergedOfferingAcademic> mergedList = mergeOfferingsAndAcademic(curriculumData, academicData);
+        Map<OfferingKey, MergedOfferingAcademic> mergedOfferings = mergeOfferingsAndAcademic(curriculumData, academicData);
         long curriculumMergeMs = elapsedMs(curriculumMergeStartNs);
 
-        // 교수/과목 정보 미리 조회
-        long professorMapStartNs = System.nanoTime();
-        Map<String, Long> professorMap = buildProfessorMap(curriculumData);
-        long professorMapMs = elapsedMs(professorMapStartNs);
+        Set<String> professorNames = mergedOfferings.keySet().stream()
+                .map(OfferingKey::professorName)
+                .collect(Collectors.toSet());
+        professorNames.add(DEFAULT_PROFESSOR_NAME);
+        long professorLoadStart = System.nanoTime();
+        Map<String, Professor> professors = professorService.getOrCreateAll(professorNames);
+        long professorMapMs = elapsedMs(professorLoadStart);
 
-        long courseMapStartNs = System.nanoTime();
-        Map<String, Long> courseMap = buildCourseMap(curriculumData);
-        long courseMapMs = elapsedMs(courseMapStartNs);
+        Map<String, String> courseCodeToName = extractCourseNames(curriculumData, mergedOfferings);
+        long courseLoadStart = System.nanoTime();
+        Map<String, Course> courses = courseService.getOrCreateCourses(courseCodeToName);
+        long courseMapMs = elapsedMs(courseLoadStart);
 
-        List<CourseEnrollment> enrollments = new ArrayList<>();
-        long courseGetOrCreateMs = 0L;
+        List<CreateOfferingCommand> offeringCommands = new ArrayList<>();
+        Map<OfferingKey, CourseOfferingService.CourseOfferingKey> offeringKeyMap = new HashMap<>();
+        for (Map.Entry<OfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
+            OfferingKey key = entry.getKey();
+            PortalOfferingCreationData offering = entry.getValue().getOffering();
+            Long courseId = Optional.ofNullable(courses.get(offering.getCourseCode()))
+                    .map(Course::getId)
+                    .orElseThrow(() -> new IllegalStateException("Course not found for code " + offering.getCourseCode()));
+            Long professorId = Optional.ofNullable(professors.get(key.professorName()))
+                    .map(Professor::getId)
+                    .orElseThrow(() -> new IllegalStateException("Professor not found for name " + key.professorName()));
 
-        for (MergedOfferingAcademic item : mergedList.values()) {
-            PortalOfferingCreationData offering = item.getOffering();
-            PortalCourseInfo academic = item.getAcademic();
-
-            // 과목 ID 및 교수 ID 구하기
-            Long courseId = courseMap.get(offering.getCourseCode());
-            String professorName = offering.getProfessorName() != null ? offering.getProfessorName() : "미확인 교수";
-            Long professorId = professorMap.get(professorName);
-
-            CreateOfferingCommand createOfferingCommand = new CreateOfferingCommand(
+            CreateOfferingCommand command = new CreateOfferingCommand(
                     courseId,
                     offering.getYear(),
                     offering.getSemester(),
-                    offering.getClassSection(),
+                    key.classSection(),
                     professorId,
-                    null, // departmentId → 확장 가능
+                    null,
                     offering.getScheduleSummary(),
                     offering.getEvaluationType(),
                     offering.getIsVideoLecture(),
                     offering.getSubjectEstablishmentSemester(),
-                    offering.getFacultyDivisionName(),
+                    key.facultyDivisionName(),
                     offering.getAreaCode(),
                     offering.getOriginalAreaCode(),
                     offering.getPoints(),
-                    offering.getHostDepartment()
+                    key.hostDepartment()
             );
-
-            long offeringCreateStartNs = System.nanoTime();
-            CourseOffering courseOffering = courseOfferingService.getOrCreateOffering(createOfferingCommand);
-            courseGetOrCreateMs += elapsedMs(offeringCreateStartNs);
-
-            Grade grade = academic != null
-                    ? new Grade(GradeType.from(academic.getGrade()))
-                    : Grade.createInProgress();
-
-            boolean isRetake = academic != null && academic.isRetake();
-            double originalScore = Optional.ofNullable(academic.getOriginalScore()).orElse(0.0);
-
-            CourseEnrollment enrollment = new CourseEnrollment(studentId, courseOffering.getId(), grade, offering.getPoints(), isRetake, originalScore, academic.isRetakeDeleted());
-            enrollments.add(enrollment);
+            offeringCommands.add(command);
+            offeringKeyMap.put(key, CourseOfferingService.CourseOfferingKey.from(command));
         }
 
-        return new CurriculumProcessingResult(enrollments, professorMapMs, courseMapMs, curriculumMergeMs, courseGetOrCreateMs);
+        long offeringLoadStart = System.nanoTime();
+        Map<CourseOfferingService.CourseOfferingKey, CourseOffering> offeringEntities =
+                courseOfferingService.getOrCreateAll(offeringCommands);
+        long courseGetOrCreateMs = elapsedMs(offeringLoadStart);
+
+        long offeringFetchStart = System.nanoTime();
+        Map<Long, CourseOffering> offeringById = new HashMap<>();
+        List<CourseEnrollment> enrollments = new ArrayList<>();
+        for (Map.Entry<OfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
+            CourseOfferingService.CourseOfferingKey serviceKey = offeringKeyMap.get(entry.getKey());
+            CourseOffering courseOffering = offeringEntities.get(serviceKey);
+            if (courseOffering == null) {
+                log.error("CourseOffering not found for key {}", entry.getKey());
+                continue;
+            }
+            PortalOfferingCreationData offering = entry.getValue().getOffering();
+            PortalCourseInfo academic = entry.getValue().getAcademic();
+            Grade grade = academic != null ? new Grade(GradeType.from(academic.getGrade())) : Grade.createInProgress();
+            boolean isRetake = academic != null && academic.isRetake();
+            double originalScore = academic != null && academic.getOriginalScore() != null ? academic.getOriginalScore() : 0.0;
+            boolean isRetakeDeleted = academic != null && academic.isRetakeDeleted();
+
+            CourseEnrollment enrollment = new CourseEnrollment(
+                    studentId,
+                    courseOffering.getId(),
+                    grade,
+                    offering.getPoints(),
+                    isRetake,
+                    originalScore,
+                    isRetakeDeleted
+            );
+            enrollments.add(enrollment);
+            offeringById.put(courseOffering.getId(), courseOffering);
+        }
+        long offeringFetchMs = elapsedMs(offeringFetchStart);
+
+        return new CurriculumProcessingResult(enrollments, offeringById, professorMapMs, courseMapMs, curriculumMergeMs, courseGetOrCreateMs, offeringFetchMs);
     }
 
-    private Map<String, MergedOfferingAcademic> mergeOfferingsAndAcademic(
+    private Map<OfferingKey, MergedOfferingAcademic> mergeOfferingsAndAcademic(
             PortalCurriculumData curriculumData,
             PortalAcademicData academicData
     ) {
-        Map<String, MergedOfferingAcademic> map = new HashMap<>();
+        Map<OfferingKey, MergedOfferingAcademic> map = new HashMap<>();
 
         // 1. offerings 삽입
         for (OfferingInfo offering : curriculumData.offerings()) {
-            String key = makeKey(offering.year(), offering.semester(), offering.courseCode());
             PortalOfferingCreationData converted = toCreationData(offering);
-            map.put(key, new MergedOfferingAcademic(converted, null));
+            map.put(toOfferingKey(converted), new MergedOfferingAcademic(converted, null));
         }
 
         // 2. academicData로 병합
@@ -271,26 +291,21 @@ public class SyncAcademicRecordService {
             int semesterNum = semester.semester();
 
             for (CourseInfo course : semester.courses()) {
-                String key = makeKey(year, semesterNum, course.code());
-
+                PortalOfferingCreationData inferredOffering = new PortalOfferingCreationData();
+                inferredOffering.setCourseCode(course.code());
+                inferredOffering.setYear(year);
+                inferredOffering.setSemester(semesterNum);
+                inferredOffering.setProfessorName(course.professor());
+                inferredOffering.setScheduleSummary(course.schedule());
+                inferredOffering.setPoints(course.credits());
+                inferredOffering.setSubjectEstablishmentSemester(course.establishmentSemester());
+                OfferingKey key = toOfferingKey(inferredOffering);
                 PortalCourseInfo convertedCourse = toPortalCourseInfo(course);
 
                 if (map.containsKey(key)) {
-                    // 이미 존재하는 offering에 academic만 추가
                     PortalOfferingCreationData existingOffering = map.get(key).getOffering();
                     map.put(key, new MergedOfferingAcademic(existingOffering, convertedCourse));
                 } else {
-                    // academic만 존재하는 경우 → offering은 기본값 생성
-                    PortalOfferingCreationData inferredOffering = new PortalOfferingCreationData();
-                    inferredOffering.setCourseCode(course.code());
-                    inferredOffering.setYear(year);
-                    inferredOffering.setSemester(semesterNum);
-                    inferredOffering.setProfessorName(course.professor());
-                    inferredOffering.setScheduleSummary(course.schedule());
-                    inferredOffering.setPoints(course.credits());
-                    inferredOffering.setSubjectEstablishmentSemester(course.establishmentSemester());
-                    // 다른 필드는 null로 유지
-
                     map.put(key, new MergedOfferingAcademic(inferredOffering, convertedCourse));
                 }
             }
@@ -324,47 +339,20 @@ public class SyncAcademicRecordService {
         return toRemove.size();
     }
 
-    private Map<String, Long> buildProfessorMap(PortalCurriculumData curriculumData) {
-        Map<String, Long> professorMap = new HashMap<>();
-
-        for (ProfessorInfo prof : curriculumData.professors()) {
-            String name = prof.professorName() != null ? prof.professorName() : "미확인 교수";
-
-            // DB에서 getOrCreate
-            Long id = professorService.getOrCreate(name).getId();
-            professorMap.put(name, id);
+    private Map<String, String> extractCourseNames(PortalCurriculumData curriculumData, Map<OfferingKey, MergedOfferingAcademic> mergedOfferings) {
+        Map<String, String> courseNames = new HashMap<>();
+        if (curriculumData.courses() != null) {
+            for (CourseInfo course : curriculumData.courses()) {
+                if (course.code() != null) {
+                    courseNames.put(course.code(), course.name());
+                }
+            }
         }
-
-        // 명시적으로 "미확인 교수"도 포함
-        if (!professorMap.containsKey("미확인 교수")) {
-            Long id = professorService.getOrCreate("미확인 교수").getId();
-            professorMap.put("미확인 교수", id);
+        for (MergedOfferingAcademic offering : mergedOfferings.values()) {
+            String code = offering.getOffering().getCourseCode();
+            courseNames.putIfAbsent(code, code);
         }
-
-
-        return professorMap;
-    }
-
-    private Map<String, Long> buildCourseMap(PortalCurriculumData curriculumData) {
-        Map<String, Long> courseMap = new HashMap<>();
-
-        for (CourseInfo course : curriculumData.courses()) {
-            String courseCode = course.code();
-
-            // DB에서 getOrCreate
-            Long id = courseService.getOrCreateCourse(
-                    courseCode,
-                    course.name()
-            ).getId();
-
-            courseMap.put(courseCode, id);
-        }
-
-        return courseMap;
-    }
-
-    private String makeKey(int year, int semester, String courseCode) {
-        return year + "-" + semester + "-" + courseCode;
+        return courseNames;
     }
 
     private PortalOfferingCreationData toCreationData(OfferingInfo info) {
@@ -389,6 +377,26 @@ public class SyncAcademicRecordService {
         data.setIsVideoLecture(info.isVideoLecture());
 
         return data;
+    }
+
+    private OfferingKey toOfferingKey(PortalOfferingCreationData data) {
+        return new OfferingKey(
+                data.getCourseCode(),
+                data.getYear(),
+                data.getSemester(),
+                defaultString(data.getClassSection()),
+                normalizeProfessorName(data.getProfessorName()),
+                defaultString(data.getFacultyDivisionName()),
+                defaultString(data.getHostDepartment())
+        );
+    }
+
+    private String normalizeProfessorName(String name) {
+        return (name == null || name.isBlank()) ? DEFAULT_PROFESSOR_NAME : name.trim();
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
     }
 
     private PortalCourseInfo toPortalCourseInfo(CourseInfo info) {
@@ -448,12 +456,24 @@ public class SyncAcademicRecordService {
 
     private static class SyncStats { int inserted, updated, deleted; }
 
+    private record OfferingKey(
+            String courseCode,
+            int year,
+            int semester,
+            String classSection,
+            String professorName,
+            String facultyDivisionName,
+            String hostDepartment
+    ) {}
+
     private record CurriculumProcessingResult(
             List<CourseEnrollment> enrollments,
+            Map<Long, CourseOffering> offeringById,
             long professorMapMs,
             long courseMapMs,
             long curriculumMergeMs,
-            long courseGetOrCreateMs
+            long courseGetOrCreateMs,
+            long offeringFetchMs
     ) {}
 
     private long elapsedMs(long startNs) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -278,40 +278,67 @@ public class SyncAcademicRecordService {
             PortalAcademicData academicData
     ) {
         Map<OfferingKey, MergedOfferingAcademic> map = new HashMap<>();
+        Map<SimpleOfferingKey, OfferingKey> simpleKeyIndex = new HashMap<>();
 
         // 1. offerings 삽입
-        for (OfferingInfo offering : curriculumData.offerings()) {
-            PortalOfferingCreationData converted = toCreationData(offering);
-            map.put(toOfferingKey(converted), new MergedOfferingAcademic(converted, null));
+        if (curriculumData.offerings() != null) {
+            for (OfferingInfo offering : curriculumData.offerings()) {
+                PortalOfferingCreationData converted = toCreationData(offering);
+                OfferingKey key = toOfferingKey(converted);
+                map.put(key, new MergedOfferingAcademic(converted, null));
+                simpleKeyIndex.put(toSimpleKey(converted), key);
+            }
         }
 
         // 2. academicData로 병합
-        for (SemesterCourseInfo semester : academicData.semesters()) {
-            int year = semester.year();
-            int semesterNum = semester.semester();
+        if (academicData.semesters() != null) {
+            for (SemesterCourseInfo semester : academicData.semesters()) {
+                int year = semester.year();
+                int semesterNum = semester.semester();
 
-            for (CourseInfo course : semester.courses()) {
-                PortalOfferingCreationData inferredOffering = new PortalOfferingCreationData();
-                inferredOffering.setCourseCode(course.code());
-                inferredOffering.setYear(year);
-                inferredOffering.setSemester(semesterNum);
-                inferredOffering.setProfessorName(course.professor());
-                inferredOffering.setScheduleSummary(course.schedule());
-                inferredOffering.setPoints(course.credits());
-                inferredOffering.setSubjectEstablishmentSemester(course.establishmentSemester());
-                OfferingKey key = toOfferingKey(inferredOffering);
-                PortalCourseInfo convertedCourse = toPortalCourseInfo(course);
+                if (semester.courses() == null) {
+                    continue;
+                }
 
-                if (map.containsKey(key)) {
-                    PortalOfferingCreationData existingOffering = map.get(key).getOffering();
-                    map.put(key, new MergedOfferingAcademic(existingOffering, convertedCourse));
-                } else {
-                    map.put(key, new MergedOfferingAcademic(inferredOffering, convertedCourse));
+                for (CourseInfo course : semester.courses()) {
+                    if (course.code() == null) {
+                        continue;
+                    }
+                    SimpleOfferingKey simpleKey = new SimpleOfferingKey(course.code(), year, semesterNum);
+                    PortalCourseInfo convertedCourse = toPortalCourseInfo(course);
+                    OfferingKey matchedKey = simpleKeyIndex.get(simpleKey);
+
+                    if (matchedKey != null && map.containsKey(matchedKey)) {
+                        PortalOfferingCreationData existingOffering = map.get(matchedKey).getOffering();
+                        map.put(matchedKey, new MergedOfferingAcademic(existingOffering, convertedCourse));
+                        continue;
+                    }
+
+                    PortalOfferingCreationData inferredOffering = createInferredOffering(course, year, semesterNum);
+                    OfferingKey inferredKey = toOfferingKey(inferredOffering);
+                    map.put(inferredKey, new MergedOfferingAcademic(inferredOffering, convertedCourse));
+                    simpleKeyIndex.put(simpleKey, inferredKey);
                 }
             }
         }
 
         return map;
+    }
+
+    private SimpleOfferingKey toSimpleKey(PortalOfferingCreationData data) {
+        return new SimpleOfferingKey(data.getCourseCode(), data.getYear(), data.getSemester());
+    }
+
+    private PortalOfferingCreationData createInferredOffering(CourseInfo course, int year, int semesterNum) {
+        PortalOfferingCreationData inferredOffering = new PortalOfferingCreationData();
+        inferredOffering.setCourseCode(course.code());
+        inferredOffering.setYear(year);
+        inferredOffering.setSemester(semesterNum);
+        inferredOffering.setProfessorName(course.professor());
+        inferredOffering.setScheduleSummary(course.schedule());
+        inferredOffering.setPoints(course.credits());
+        inferredOffering.setSubjectEstablishmentSemester(course.establishmentSemester());
+        return inferredOffering;
     }
 
     int removeDeletedEnrollments(Student student, List<CourseEnrollment> newEnrollments, List<StudentCourse> existingEnrollments) {
@@ -474,6 +501,12 @@ public class SyncAcademicRecordService {
             long curriculumMergeMs,
             long courseGetOrCreateMs,
             long offeringFetchMs
+    ) {}
+
+    private record SimpleOfferingKey(
+            String courseCode,
+            int year,
+            int semester
     ) {}
 
     private long elapsedMs(long startNs) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -185,11 +185,13 @@ public class SyncAcademicRecordService {
 
     private CurriculumProcessingResult processCurriculumData(PortalCurriculumData curriculumData, PortalAcademicData academicData, UUID studentId) {
         long curriculumMergeStartNs = System.nanoTime();
-        Map<OfferingKey, MergedOfferingAcademic> mergedOfferings = mergeOfferingsAndAcademic(curriculumData, academicData);
+        Map<SimpleOfferingKey, MergedOfferingAcademic> mergedOfferings = mergeOfferingsAndAcademic(curriculumData, academicData);
         long curriculumMergeMs = elapsedMs(curriculumMergeStartNs);
 
-        Set<String> professorNames = mergedOfferings.keySet().stream()
-                .map(OfferingKey::professorName)
+        Set<String> professorNames = mergedOfferings.values().stream()
+                .map(MergedOfferingAcademic::getOffering)
+                .map(PortalOfferingCreationData::getProfessorName)
+                .map(this::normalizeProfessorName)
                 .collect(Collectors.toSet());
         professorNames.add(DEFAULT_PROFESSOR_NAME);
         long professorLoadStart = System.nanoTime();
@@ -202,16 +204,17 @@ public class SyncAcademicRecordService {
         long courseMapMs = elapsedMs(courseLoadStart);
 
         List<CreateOfferingCommand> offeringCommands = new ArrayList<>();
-        Map<OfferingKey, CourseOfferingService.CourseOfferingKey> offeringKeyMap = new HashMap<>();
-        for (Map.Entry<OfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
-            OfferingKey key = entry.getKey();
+        Map<SimpleOfferingKey, OfferingKey> resolvedOfferingKeys = new HashMap<>();
+        Map<SimpleOfferingKey, CourseOfferingService.CourseOfferingKey> offeringKeyMap = new HashMap<>();
+        for (Map.Entry<SimpleOfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
             PortalOfferingCreationData offering = entry.getValue().getOffering();
+            OfferingKey key = toOfferingKey(offering);
             Long courseId = Optional.ofNullable(courses.get(offering.getCourseCode()))
                     .map(Course::getId)
                     .orElseThrow(() -> new IllegalStateException("Course not found for code " + offering.getCourseCode()));
-            Long professorId = Optional.ofNullable(professors.get(key.professorName()))
+            Long professorId = Optional.ofNullable(professors.get(normalizeProfessorName(offering.getProfessorName())))
                     .map(Professor::getId)
-                    .orElseThrow(() -> new IllegalStateException("Professor not found for name " + key.professorName()));
+                    .orElseThrow(() -> new IllegalStateException("Professor not found for name " + normalizeProfessorName(offering.getProfessorName())));
 
             CreateOfferingCommand command = new CreateOfferingCommand(
                     courseId,
@@ -231,7 +234,8 @@ public class SyncAcademicRecordService {
                     key.hostDepartment()
             );
             offeringCommands.add(command);
-            offeringKeyMap.put(key, CourseOfferingService.CourseOfferingKey.from(command));
+            resolvedOfferingKeys.put(entry.getKey(), key);
+            offeringKeyMap.put(entry.getKey(), CourseOfferingService.CourseOfferingKey.from(command));
         }
 
         long offeringLoadStart = System.nanoTime();
@@ -242,11 +246,11 @@ public class SyncAcademicRecordService {
         long offeringFetchStart = System.nanoTime();
         Map<Long, CourseOffering> offeringById = new HashMap<>();
         List<CourseEnrollment> enrollments = new ArrayList<>();
-        for (Map.Entry<OfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
+        for (Map.Entry<SimpleOfferingKey, MergedOfferingAcademic> entry : mergedOfferings.entrySet()) {
             CourseOfferingService.CourseOfferingKey serviceKey = offeringKeyMap.get(entry.getKey());
             CourseOffering courseOffering = offeringEntities.get(serviceKey);
             if (courseOffering == null) {
-                log.error("CourseOffering not found for key {}", entry.getKey());
+                log.error("CourseOffering not found for key {}", resolvedOfferingKeys.get(entry.getKey()));
                 continue;
             }
             PortalOfferingCreationData offering = entry.getValue().getOffering();
@@ -273,24 +277,19 @@ public class SyncAcademicRecordService {
         return new CurriculumProcessingResult(enrollments, offeringById, professorMapMs, courseMapMs, curriculumMergeMs, courseGetOrCreateMs, offeringFetchMs);
     }
 
-    private Map<OfferingKey, MergedOfferingAcademic> mergeOfferingsAndAcademic(
+    private Map<SimpleOfferingKey, MergedOfferingAcademic> mergeOfferingsAndAcademic(
             PortalCurriculumData curriculumData,
             PortalAcademicData academicData
     ) {
-        Map<OfferingKey, MergedOfferingAcademic> map = new HashMap<>();
-        Map<SimpleOfferingKey, OfferingKey> simpleKeyIndex = new HashMap<>();
+        Map<SimpleOfferingKey, MergedOfferingAcademic> map = new HashMap<>();
 
-        // 1. offerings 삽입
         if (curriculumData.offerings() != null) {
             for (OfferingInfo offering : curriculumData.offerings()) {
                 PortalOfferingCreationData converted = toCreationData(offering);
-                OfferingKey key = toOfferingKey(converted);
-                map.put(key, new MergedOfferingAcademic(converted, null));
-                simpleKeyIndex.put(toSimpleKey(converted), key);
+                map.put(toSimpleKey(converted), new MergedOfferingAcademic(converted, null));
             }
         }
 
-        // 2. academicData로 병합
         if (academicData.semesters() != null) {
             for (SemesterCourseInfo semester : academicData.semesters()) {
                 int year = semester.year();
@@ -306,18 +305,15 @@ public class SyncAcademicRecordService {
                     }
                     SimpleOfferingKey simpleKey = new SimpleOfferingKey(course.code(), year, semesterNum);
                     PortalCourseInfo convertedCourse = toPortalCourseInfo(course);
-                    OfferingKey matchedKey = simpleKeyIndex.get(simpleKey);
 
-                    if (matchedKey != null && map.containsKey(matchedKey)) {
-                        PortalOfferingCreationData existingOffering = map.get(matchedKey).getOffering();
-                        map.put(matchedKey, new MergedOfferingAcademic(existingOffering, convertedCourse));
+                    if (map.containsKey(simpleKey)) {
+                        PortalOfferingCreationData existingOffering = map.get(simpleKey).getOffering();
+                        map.put(simpleKey, new MergedOfferingAcademic(existingOffering, convertedCourse));
                         continue;
                     }
 
                     PortalOfferingCreationData inferredOffering = createInferredOffering(course, year, semesterNum);
-                    OfferingKey inferredKey = toOfferingKey(inferredOffering);
-                    map.put(inferredKey, new MergedOfferingAcademic(inferredOffering, convertedCourse));
-                    simpleKeyIndex.put(simpleKey, inferredKey);
+                    map.put(simpleKey, new MergedOfferingAcademic(inferredOffering, convertedCourse));
                 }
             }
         }
@@ -366,7 +362,7 @@ public class SyncAcademicRecordService {
         return toRemove.size();
     }
 
-    private Map<String, String> extractCourseNames(PortalCurriculumData curriculumData, Map<OfferingKey, MergedOfferingAcademic> mergedOfferings) {
+    private Map<String, String> extractCourseNames(PortalCurriculumData curriculumData, Map<SimpleOfferingKey, MergedOfferingAcademic> mergedOfferings) {
         Map<String, String> courseNames = new HashMap<>();
         if (curriculumData.courses() != null) {
             for (CourseInfo course : curriculumData.courses()) {
@@ -411,10 +407,10 @@ public class SyncAcademicRecordService {
                 data.getCourseCode(),
                 data.getYear(),
                 data.getSemester(),
-                defaultString(data.getClassSection()),
+                normalizeNullableString(data.getClassSection()),
                 normalizeProfessorName(data.getProfessorName()),
-                defaultString(data.getFacultyDivisionName()),
-                defaultString(data.getHostDepartment())
+                normalizeNullableString(data.getFacultyDivisionName()),
+                normalizeNullableString(data.getHostDepartment())
         );
     }
 
@@ -422,8 +418,11 @@ public class SyncAcademicRecordService {
         return (name == null || name.isBlank()) ? DEFAULT_PROFESSOR_NAME : name.trim();
     }
 
-    private String defaultString(String value) {
-        return value == null ? "" : value;
+    private String normalizeNullableString(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 
     private PortalCourseInfo toPortalCourseInfo(CourseInfo info) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -92,15 +92,18 @@ public class SyncAcademicRecordService {
         long academicMs = elapsedMs(academicStartNs);
 
         // 1) 포털 수강 기록 수집
-        List<CourseEnrollment> newEnrollments =
+        CurriculumProcessingResult processingResult =
                 processCurriculumData(portalData.curriculum(), portalData.academic(), studentId);
+        List<CourseEnrollment> newEnrollments = processingResult.enrollments();
 
         List<Long> offeringIds = newEnrollments.stream()
                 .map(e -> (long) e.getOfferingId())
                 .distinct()
                 .toList();
 
+        long offeringFetchStartNs = System.nanoTime();
         Map<Long, CourseOffering> offerings = courseOfferingService.getOfferingMapByIds(offeringIds);
+        long offeringFetchMs = elapsedMs(offeringFetchStartNs);
 
         // 2) 기존 수강 기록
         List<StudentCourse> existingEnrollments = studentCourseRepository.findByStudent(student);
@@ -129,6 +132,7 @@ public class SyncAcademicRecordService {
                 .toList();
 
         // 3) 신규 수강 기록 저장 (offeringId 기준 중복 방지)
+        long offeringMappingStartNs = System.nanoTime();
         List<StudentCourse> newStudentCourses = newEnrollments.stream()
                 .filter(e -> !existingOfferingIds.contains((long) e.getOfferingId()))
                 .map(e -> {
@@ -142,6 +146,7 @@ public class SyncAcademicRecordService {
                 })
                 .filter(Objects::nonNull)
                 .toList();
+        offeringFetchMs += elapsedMs(offeringMappingStartNs);
 
         long insertMs = 0L;
         newStudentCourses.forEach(student::addStudentCourse);
@@ -165,21 +170,42 @@ public class SyncAcademicRecordService {
         stats.deleted += removed;
 
         long totalMs = elapsedMs(totalStartNs);
-        log.info("[PERF] portal.sync studentId={} academic_ms={} insert_ms={} delete_ms={} total_ms={} ins_cnt={} upd_cnt={} del_cnt={}",
-                studentId, academicMs, insertMs, deleteMs, totalMs, newStudentCourses.size(), toUpdate.size(), removed);
+        log.info("[PERF] portal.sync studentId={} academic_ms={} professor_map_ms={} course_map_ms={} curriculum_merge_ms={} course_get_or_create_ms={} offering_fetch_ms={} insert_ms={} delete_ms={} total_ms={} ins_cnt={} upd_cnt={} del_cnt={}",
+                studentId,
+                academicMs,
+                processingResult.professorMapMs(),
+                processingResult.courseMapMs(),
+                processingResult.curriculumMergeMs(),
+                processingResult.courseGetOrCreateMs(),
+                offeringFetchMs,
+                insertMs,
+                deleteMs,
+                totalMs,
+                newStudentCourses.size(),
+                toUpdate.size(),
+                removed);
         return stats;
     }
 
     /* offerings(교과)와 academic(학업 성적)을 합쳐서
      *  최종적으로 CourseEnrollment를 만드는 메서드
      *  */
-    private List<CourseEnrollment> processCurriculumData(PortalCurriculumData curriculumData, PortalAcademicData academicData, UUID studentId) {
-        List<CourseEnrollment> enrollments = new ArrayList<>();
+    private CurriculumProcessingResult processCurriculumData(PortalCurriculumData curriculumData, PortalAcademicData academicData, UUID studentId) {
+        long curriculumMergeStartNs = System.nanoTime();
         Map<String, MergedOfferingAcademic> mergedList = mergeOfferingsAndAcademic(curriculumData, academicData);
+        long curriculumMergeMs = elapsedMs(curriculumMergeStartNs);
 
         // 교수/과목 정보 미리 조회
+        long professorMapStartNs = System.nanoTime();
         Map<String, Long> professorMap = buildProfessorMap(curriculumData);
+        long professorMapMs = elapsedMs(professorMapStartNs);
+
+        long courseMapStartNs = System.nanoTime();
         Map<String, Long> courseMap = buildCourseMap(curriculumData);
+        long courseMapMs = elapsedMs(courseMapStartNs);
+
+        List<CourseEnrollment> enrollments = new ArrayList<>();
+        long courseGetOrCreateMs = 0L;
 
         for (MergedOfferingAcademic item : mergedList.values()) {
             PortalOfferingCreationData offering = item.getOffering();
@@ -208,8 +234,10 @@ public class SyncAcademicRecordService {
                     offering.getHostDepartment()
             );
 
-            // 개설강좌 및 성적 처리
+            long offeringCreateStartNs = System.nanoTime();
             CourseOffering courseOffering = courseOfferingService.getOrCreateOffering(createOfferingCommand);
+            courseGetOrCreateMs += elapsedMs(offeringCreateStartNs);
+
             Grade grade = academic != null
                     ? new Grade(GradeType.from(academic.getGrade()))
                     : Grade.createInProgress();
@@ -221,7 +249,7 @@ public class SyncAcademicRecordService {
             enrollments.add(enrollment);
         }
 
-        return enrollments;
+        return new CurriculumProcessingResult(enrollments, professorMapMs, courseMapMs, curriculumMergeMs, courseGetOrCreateMs);
     }
 
     private Map<String, MergedOfferingAcademic> mergeOfferingsAndAcademic(
@@ -419,6 +447,14 @@ public class SyncAcademicRecordService {
     }
 
     private static class SyncStats { int inserted, updated, deleted; }
+
+    private record CurriculumProcessingResult(
+            List<CourseEnrollment> enrollments,
+            long professorMapMs,
+            long courseMapMs,
+            long curriculumMergeMs,
+            long courseGetOrCreateMs
+    ) {}
 
     private long elapsedMs(long startNs) {
         return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -211,10 +211,21 @@ public class SyncAcademicRecordService {
             OfferingKey key = toOfferingKey(offering);
             Long courseId = Optional.ofNullable(courses.get(offering.getCourseCode()))
                     .map(Course::getId)
-                    .orElseThrow(() -> new IllegalStateException("Course not found for code " + offering.getCourseCode()));
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Course not found for code=%s year=%s semester=%s".formatted(
+                                    offering.getCourseCode(),
+                                    offering.getYear(),
+                                    offering.getSemester()
+                            )));
             Long professorId = Optional.ofNullable(professors.get(normalizeProfessorName(offering.getProfessorName())))
                     .map(Professor::getId)
-                    .orElseThrow(() -> new IllegalStateException("Professor not found for name " + normalizeProfessorName(offering.getProfessorName())));
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Professor not found for name=%s courseCode=%s year=%s semester=%s".formatted(
+                                    normalizeProfessorName(offering.getProfessorName()),
+                                    offering.getCourseCode(),
+                                    offering.getYear(),
+                                    offering.getSemester()
+                            )));
 
             CreateOfferingCommand command = new CreateOfferingCommand(
                     courseId,

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -379,8 +379,6 @@ public class SyncAcademicRecordService {
     }
 
     private PortalOfferingCreationData toCreationData(OfferingInfo info) {
-        log.debug("from OfferingInfo, facultyDivisionName: {}, evaluationType:{}", info.facultyDivisionName(), info.evaluationType());
-
         PortalOfferingCreationData data = new PortalOfferingCreationData();
         data.setCourseCode(info.courseCode());
         data.setYear(info.year());

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -6,6 +6,8 @@ import com.chukchuk.haksa.application.academic.enrollment.CourseEnrollment;
 import com.chukchuk.haksa.application.academic.repository.AcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseBulkRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseBulkRow;
 import com.chukchuk.haksa.domain.course.dto.CreateOfferingCommand;
 import com.chukchuk.haksa.domain.course.model.Course;
 import com.chukchuk.haksa.domain.course.model.CourseOffering;
@@ -19,7 +21,6 @@ import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.service.StudentService;
 import com.chukchuk.haksa.global.logging.annotation.LogTime;
 import com.chukchuk.haksa.infrastructure.portal.mapper.AcademicRecordMapperFromPortal;
-import com.chukchuk.haksa.infrastructure.portal.mapper.StudentCourseMapper;
 import com.chukchuk.haksa.infrastructure.portal.model.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +45,7 @@ public class SyncAcademicRecordService {
     private final CourseOfferingService courseOfferingService;
     private final ProfessorService professorService;
     private final CourseService courseService;
+    private final StudentCourseBulkRepository studentCourseBulkRepository;
     private static final String DEFAULT_PROFESSOR_NAME = "미확인 교수";
 
     @Transactional
@@ -129,7 +131,7 @@ public class SyncAcademicRecordService {
 
         // 3) 신규 수강 기록 저장 (offeringId 기준 중복 방지)
         long offeringMappingStartNs = System.nanoTime();
-        List<StudentCourse> newStudentCourses = newEnrollments.stream()
+        List<StudentCourseBulkRow> newStudentCourses = newEnrollments.stream()
                 .filter(e -> !existingOfferingIds.contains((long) e.getOfferingId()))
                 .map(e -> {
                     CourseOffering off = offerings.get((long) e.getOfferingId());
@@ -137,18 +139,16 @@ public class SyncAcademicRecordService {
                         log.error("CourseOffering이 존재하지 않는 과목 정보입니다. offeringId={}", e.getOfferingId());
                         return null;
                     }
-                    // Mapper가 isRetakeDeleted/grade/score 등을 세팅해야 함
-                    return StudentCourseMapper.toEntity(e, student, off);
+                    return StudentCourseBulkRow.from(e);
                 })
                 .filter(Objects::nonNull)
                 .toList();
         offeringFetchMs += elapsedMs(offeringMappingStartNs);
 
         long insertMs = 0L;
-        newStudentCourses.forEach(student::addStudentCourse);
         if (!newStudentCourses.isEmpty()) {
             long insertStartNs = System.nanoTime();
-            studentCourseRepository.saveAll(newStudentCourses);
+            studentCourseBulkRepository.insertAll(newStudentCourses);
             insertMs = elapsedMs(insertStartNs);
         }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.chukchuk.haksa.global.logging.config.LoggingThresholds.SLOW_MS;
@@ -77,15 +78,18 @@ public class SyncAcademicRecordService {
     }
 
     private SyncStats sync(UUID userId, PortalData portalData, boolean isInitial) {
+        long totalStartNs = System.nanoTime();
         Student student = studentService.getStudentByUserId(userId);
         UUID studentId = student.getId();
 
+        long academicStartNs = System.nanoTime();
         AcademicRecord academicRecord = AcademicRecordMapperFromPortal.fromPortalAcademicData(studentId, portalData.academic());
         if (isInitial) {
             academicRecordRepository.insertAllAcademicRecords(academicRecord, student);
         } else {
             academicRecordRepository.updateChangedAcademicRecords(academicRecord, student);
         }
+        long academicMs = elapsedMs(academicStartNs);
 
         // 1) 포털 수강 기록 수집
         List<CourseEnrollment> newEnrollments =
@@ -124,10 +128,6 @@ public class SyncAcademicRecordService {
                 .filter(Objects::nonNull)
                 .toList();
 
-        if (!toUpdate.isEmpty()) {
-            studentCourseRepository.saveAll(toUpdate);
-        }
-
         // 3) 신규 수강 기록 저장 (offeringId 기준 중복 방지)
         List<StudentCourse> newStudentCourses = newEnrollments.stream()
                 .filter(e -> !existingOfferingIds.contains((long) e.getOfferingId()))
@@ -143,21 +143,30 @@ public class SyncAcademicRecordService {
                 .filter(Objects::nonNull)
                 .toList();
 
+        long insertMs = 0L;
         newStudentCourses.forEach(student::addStudentCourse);
         if (!newStudentCourses.isEmpty()) {
+            long insertStartNs = System.nanoTime();
             studentCourseRepository.saveAll(newStudentCourses);
+            insertMs = elapsedMs(insertStartNs);
         }
 
         // (삭제) 이전 수강기록 마킹 로직: 포털 값이 진실이므로 더 이상 사용 안 함
         // existingEnrollments.stream() ... markDeletedForRetake()
 
         // 4) 포털에 없는 offeringId는 제거 (기존 로직 유지)
+        long deleteStartNs = System.nanoTime();
         int removed = removeDeletedEnrollments(student, newEnrollments, existingEnrollments);
+        long deleteMs = elapsedMs(deleteStartNs);
 
         SyncStats stats = new SyncStats();
         stats.inserted += newStudentCourses.size();
         stats.updated  += toUpdate.size();
         stats.deleted += removed;
+
+        long totalMs = elapsedMs(totalStartNs);
+        log.info("[PERF] portal.sync studentId={} academic_ms={} insert_ms={} delete_ms={} total_ms={} ins_cnt={} upd_cnt={} del_cnt={}",
+                studentId, academicMs, insertMs, deleteMs, totalMs, newStudentCourses.size(), toUpdate.size(), removed);
         return stats;
     }
 
@@ -262,7 +271,7 @@ public class SyncAcademicRecordService {
         return map;
     }
 
-    private int removeDeletedEnrollments(Student student, List<CourseEnrollment> newEnrollments, List<StudentCourse> existingEnrollments) {
+    int removeDeletedEnrollments(Student student, List<CourseEnrollment> newEnrollments, List<StudentCourse> existingEnrollments) {
         //  새로운 수강 기록의 offeringId 목록 추출
         Set<Long> newOfferingIds = newEnrollments.stream()
                 .map(CourseEnrollment::getOfferingId)
@@ -275,7 +284,13 @@ public class SyncAcademicRecordService {
 
         //  제거
         if (!toRemove.isEmpty()) {
-            studentCourseRepository.deleteAll(toRemove);
+            List<Long> ids = toRemove.stream()
+                    .map(StudentCourse::getId)
+                    .filter(Objects::nonNull)
+                    .toList();
+            if (!ids.isEmpty()) {
+                studentCourseRepository.deleteAllByIdInBatch(ids);
+            }
         }
 
         return toRemove.size();
@@ -404,4 +419,8 @@ public class SyncAcademicRecordService {
     }
 
     private static class SyncStats { int inserted, updated, deleted; }
+
+    private long elapsedMs(long startNs) {
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+    }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepository.java
@@ -1,0 +1,8 @@
+package com.chukchuk.haksa.domain.academic.record.repository;
+
+import java.util.List;
+
+public interface StudentCourseBulkRepository {
+
+    void insertAll(List<StudentCourseBulkRow> rows);
+}

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepositoryImpl.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.chukchuk.haksa.domain.academic.record.repository;
+
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public class StudentCourseBulkRepositoryImpl implements StudentCourseBulkRepository {
+
+    private static final String INSERT_SQL = """
+            INSERT INTO student_courses
+            (student_id, offering_id, grade, points, is_retake, original_score, is_retake_deleted, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public StudentCourseBulkRepositoryImpl(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void insertAll(List<StudentCourseBulkRow> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Instant createdAt = Instant.now();
+        jdbcTemplate.batchUpdate(INSERT_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                StudentCourseBulkRow row = rows.get(i);
+                ps.setObject(1, row.studentId());
+                ps.setLong(2, row.offeringId());
+                GradeType gradeType = row.gradeType();
+                if (gradeType != null) {
+                    ps.setString(3, gradeType.getValue());
+                } else {
+                    ps.setNull(3, java.sql.Types.VARCHAR);
+                }
+                if (row.points() != null) {
+                    ps.setInt(4, row.points());
+                } else {
+                    ps.setNull(4, java.sql.Types.INTEGER);
+                }
+                ps.setBoolean(5, row.isRetake());
+                if (row.originalScore() != null) {
+                    ps.setInt(6, row.originalScore());
+                } else {
+                    ps.setNull(6, java.sql.Types.INTEGER);
+                }
+                ps.setBoolean(7, row.isRetakeDeleted());
+                ps.setTimestamp(8, Timestamp.from(createdAt));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return rows.size();
+            }
+        });
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRow.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRow.java
@@ -1,0 +1,32 @@
+package com.chukchuk.haksa.domain.academic.record.repository;
+
+import com.chukchuk.haksa.application.academic.enrollment.CourseEnrollment;
+import com.chukchuk.haksa.domain.student.model.GradeType;
+
+import java.util.UUID;
+
+public record StudentCourseBulkRow(
+        UUID studentId,
+        Long offeringId,
+        GradeType gradeType,
+        Integer points,
+        boolean isRetake,
+        Integer originalScore,
+        boolean isRetakeDeleted
+) {
+
+    public static StudentCourseBulkRow from(CourseEnrollment enrollment) {
+        Integer normalizedScore = enrollment.getOriginalScore() != null
+                ? enrollment.getOriginalScore().intValue()
+                : null;
+        return new StudentCourseBulkRow(
+                enrollment.getStudentId(),
+                enrollment.getOfferingId(),
+                enrollment.getGradeType(),
+                enrollment.getPoints(),
+                enrollment.isRetake(),
+                normalizedScore,
+                enrollment.isRetakeDeleted()
+        );
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
@@ -5,6 +5,8 @@ import com.chukchuk.haksa.domain.course.model.FacultyDivision;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface CourseOfferingRepository extends JpaRepository<CourseOffering, Long> {
@@ -20,5 +22,17 @@ public interface CourseOfferingRepository extends JpaRepository<CourseOffering, 
 """)
     Optional<CourseOffering> findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
             Long courseId, Integer year, Integer semester, String classSection, Long professorId, FacultyDivision facultyDivisionName, String hostDepartment
+    );
+
+    @Query("""
+    SELECT o FROM CourseOffering o
+    WHERE o.course.id IN :courseIds
+      AND o.year IN :years
+      AND o.semester IN :semesters
+""")
+    List<CourseOffering> findByCourseIdInAndYearInAndSemesterIn(
+            Collection<Long> courseIds,
+            Collection<Integer> years,
+            Collection<Integer> semesters
     );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseRepository.java
@@ -4,9 +4,13 @@ import com.chukchuk.haksa.domain.course.model.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByCourseCode(String courseCode);
+
+    List<Course> findByCourseCodeIn(Collection<String> courseCodes);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
@@ -96,6 +96,9 @@ public class CourseOfferingService {
             liberalArtsAreaCode = liberalArtsAreaCodeRepository.getReferenceById(cmd.areaCode());
         }
 
+        EvaluationType evaluationType = resolveEvaluationType(cmd.evaluationType());
+        FacultyDivision facultyDivision = resolveFacultyDivision(cmd.facultyDivisionName());
+
         return new CourseOffering(
                 cmd.subjectEstablishmentSemester(),
                 cmd.isVideoLecture(),
@@ -106,13 +109,27 @@ public class CourseOfferingService {
                 cmd.scheduleSummary(),
                 cmd.originalAreaCode(),
                 cmd.points(),
-                EvaluationType.valueOf(cmd.evaluationType()),
-                FacultyDivision.valueOf(cmd.facultyDivisionName()),
+                evaluationType,
+                facultyDivision,
                 course,
                 professor,
                 department,
                 liberalArtsAreaCode
         );
+    }
+
+    private EvaluationType resolveEvaluationType(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return EvaluationType.UNKNOWN;
+        }
+        return EvaluationType.valueOf(rawValue);
+    }
+
+    private FacultyDivision resolveFacultyDivision(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+        return FacultyDivision.valueOf(rawValue);
     }
 
     public record CourseOfferingKey(

--- a/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
@@ -13,9 +13,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,14 +34,56 @@ public class CourseOfferingService {
 
     @Transactional
     public CourseOffering getOrCreateOffering(CreateOfferingCommand cmd) {
-        // 1. 존재하는지 확인
-        Optional<CourseOffering> existing = courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
-                cmd.courseId(), cmd.year(), cmd.semester(), cmd.classSection(), cmd.professorId(), FacultyDivision.valueOf(cmd.facultyDivisionName()), cmd.hostDepartment()
-        );
+        return getOrCreateAll(List.of(cmd)).get(CourseOfferingKey.from(cmd));
+    }
 
-        if (existing.isPresent()) return existing.get();
+    @Transactional
+    public Map<CourseOfferingKey, CourseOffering> getOrCreateAll(List<CreateOfferingCommand> commands) {
+        if (commands == null || commands.isEmpty()) {
+            return Map.of();
+        }
 
-        // 2. 없으면 새로 생성
+        Map<CourseOfferingKey, CreateOfferingCommand> commandByKey = new HashMap<>();
+        for (CreateOfferingCommand command : commands) {
+            commandByKey.put(CourseOfferingKey.from(command), command);
+        }
+
+        Set<Long> courseIds = commandByKey.keySet().stream().map(CourseOfferingKey::courseId).collect(Collectors.toSet());
+        Set<Integer> years = commandByKey.keySet().stream().map(CourseOfferingKey::year).collect(Collectors.toSet());
+        Set<Integer> semesters = commandByKey.keySet().stream().map(CourseOfferingKey::semester).collect(Collectors.toSet());
+
+        List<CourseOffering> existing = courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(courseIds, years, semesters);
+        Map<CourseOfferingKey, CourseOffering> result = new HashMap<>();
+        for (CourseOffering offering : existing) {
+            CourseOfferingKey key = CourseOfferingKey.from(offering);
+            if (commandByKey.containsKey(key)) {
+                result.putIfAbsent(key, offering);
+            }
+        }
+
+        List<CourseOffering> toInsert = new ArrayList<>();
+        for (Map.Entry<CourseOfferingKey, CreateOfferingCommand> entry : commandByKey.entrySet()) {
+            if (!result.containsKey(entry.getKey())) {
+                CourseOffering created = createCourseOffering(entry.getValue());
+                toInsert.add(created);
+                result.put(entry.getKey(), created);
+            }
+        }
+
+        if (!toInsert.isEmpty()) {
+            courseOfferingRepository.saveAll(toInsert);
+        }
+
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, CourseOffering> getOfferingMapByIds(List<Long> offeringIds) {
+        return courseOfferingRepository.findAllById(offeringIds).stream()
+                .collect(Collectors.toMap(CourseOffering::getId, o -> o));
+    }
+
+    private CourseOffering createCourseOffering(CreateOfferingCommand cmd) {
         Course course = courseRepository.getReferenceById(cmd.courseId());
         Professor professor = professorRepository.getReferenceById(cmd.professorId());
         Department department = cmd.departmentId() != null
@@ -50,7 +96,7 @@ public class CourseOfferingService {
             liberalArtsAreaCode = liberalArtsAreaCodeRepository.getReferenceById(cmd.areaCode());
         }
 
-        CourseOffering newOffering = new CourseOffering(
+        return new CourseOffering(
                 cmd.subjectEstablishmentSemester(),
                 cmd.isVideoLecture(),
                 cmd.year(),
@@ -67,15 +113,39 @@ public class CourseOfferingService {
                 department,
                 liberalArtsAreaCode
         );
-
-        return courseOfferingRepository.save(newOffering);
     }
 
+    public record CourseOfferingKey(
+            Long courseId,
+            Integer year,
+            Integer semester,
+            String classSection,
+            Long professorId,
+            String facultyDivisionName,
+            String hostDepartment
+    ) {
+        public static CourseOfferingKey from(CreateOfferingCommand cmd) {
+            return new CourseOfferingKey(
+                    cmd.courseId(),
+                    cmd.year(),
+                    cmd.semester(),
+                    cmd.classSection(),
+                    cmd.professorId(),
+                    cmd.facultyDivisionName(),
+                    cmd.hostDepartment()
+            );
+        }
 
-    @Transactional(readOnly = true)
-    public Map<Long, CourseOffering> getOfferingMapByIds(List<Long> offeringIds) {
-        return courseOfferingRepository.findAllById(offeringIds).stream()
-                .collect(Collectors.toMap(CourseOffering::getId, o -> o));
+        public static CourseOfferingKey from(CourseOffering offering) {
+            return new CourseOfferingKey(
+                    offering.getCourse().getId(),
+                    offering.getYear(),
+                    offering.getSemester(),
+                    offering.getClassSection(),
+                    offering.getProfessor().getId(),
+                    offering.getFacultyDivisionName().name(),
+                    offering.getHostDepartment()
+            );
+        }
     }
-
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
@@ -15,10 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -146,10 +144,10 @@ public class CourseOfferingService {
                     cmd.courseId(),
                     cmd.year(),
                     cmd.semester(),
-                    cmd.classSection(),
+                    normalizeBlank(cmd.classSection()),
                     cmd.professorId(),
-                    cmd.facultyDivisionName(),
-                    cmd.hostDepartment()
+                    normalizeBlank(cmd.facultyDivisionName()),
+                    normalizeBlank(cmd.hostDepartment())
             );
         }
 
@@ -158,11 +156,18 @@ public class CourseOfferingService {
                     offering.getCourse().getId(),
                     offering.getYear(),
                     offering.getSemester(),
-                    offering.getClassSection(),
+                    normalizeBlank(offering.getClassSection()),
                     offering.getProfessor().getId(),
-                    offering.getFacultyDivisionName().name(),
-                    offering.getHostDepartment()
+                    offering.getFacultyDivisionName() != null ? normalizeBlank(offering.getFacultyDivisionName().name()) : null,
+                    normalizeBlank(offering.getHostDepartment())
             );
+        }
+
+        private static String normalizeBlank(String value) {
+            if (value == null || value.isBlank()) {
+                return null;
+            }
+            return value.trim();
         }
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/service/CourseService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/service/CourseService.java
@@ -6,6 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CourseService {
@@ -18,5 +26,39 @@ public class CourseService {
                     Course newCourse = new Course(courseCode, courseName);
                     return courseRepository.save(newCourse);
                 });
+    }
+
+    @Transactional
+    public Map<String, Course> getOrCreateCourses(Map<String, String> courseCodeToName) {
+        if (courseCodeToName == null || courseCodeToName.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<String> codes = courseCodeToName.keySet().stream()
+                .filter(code -> code != null && !code.isBlank())
+                .collect(Collectors.toSet());
+        if (codes.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Course> existing = courseRepository.findByCourseCodeIn(codes);
+        Map<String, Course> result = new HashMap<>();
+        for (Course course : existing) {
+            result.put(course.getCourseCode(), course);
+        }
+
+        List<Course> toCreate = codes.stream()
+                .filter(code -> !result.containsKey(code))
+                .map(code -> new Course(code, courseCodeToName.get(code)))
+                .toList();
+
+        if (!toCreate.isEmpty()) {
+            List<Course> saved = courseRepository.saveAll(toCreate);
+            for (Course course : saved) {
+                result.put(course.getCourseCode(), course);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/professor/repository/ProfessorRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/professor/repository/ProfessorRepository.java
@@ -4,9 +4,13 @@ import com.chukchuk.haksa.domain.professor.model.Professor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProfessorRepository extends JpaRepository<Professor, Long> {
     Optional<Professor> findByProfessorName(String name);
+
+    List<Professor> findByProfessorNameIn(Collection<String> names);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/professor/service/ProfessorService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/professor/service/ProfessorService.java
@@ -6,6 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ProfessorService {
@@ -18,5 +26,39 @@ public class ProfessorService {
                     Professor newProfessor = new Professor(professorName);
                     return professorRepository.save(newProfessor);
                 });
+    }
+
+    @Transactional
+    public Map<String, Professor> getOrCreateAll(Collection<String> professorNames) {
+        if (professorNames == null || professorNames.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<String> uniqueNames = professorNames.stream()
+                .filter(name -> name != null && !name.isBlank())
+                .collect(Collectors.toSet());
+        if (uniqueNames.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Professor> existing = professorRepository.findByProfessorNameIn(uniqueNames);
+        Map<String, Professor> result = new HashMap<>();
+        for (Professor professor : existing) {
+            result.put(professor.getProfessorName(), professor);
+        }
+
+        List<Professor> toCreate = uniqueNames.stream()
+                .filter(name -> !result.containsKey(name))
+                .map(Professor::new)
+                .toList();
+
+        if (!toCreate.isEmpty()) {
+            List<Professor> saved = professorRepository.saveAll(toCreate);
+            for (Professor professor : saved) {
+                result.put(professor.getProfessorName(), professor);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/global/config/SchedulingConfig.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/SchedulingConfig.java
@@ -1,11 +1,23 @@
 package com.chukchuk.haksa.global.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
 @ConditionalOnProperty(prefix = "scraping.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class SchedulingConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(2);
+        taskScheduler.setThreadNamePrefix("scheduler-");
+        taskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+        taskScheduler.setAwaitTerminationSeconds(30);
+        return taskScheduler;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,14 @@ spring:
   web:
     resources:
       add-mappings: false
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 100
+          batch_versioned_data: true
+        order_inserts: true
+        order_updates: true
 
 server:
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
     date-format: yyyy-MM-dd HH:mm:ss
   config:
     import: optional:file:.env[.properties]
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   mvc:
     throw-exception-if-no-handler-found: true
   web:
@@ -29,6 +31,7 @@ spring:
 
 server:
   port: 8080
+  shutdown: graceful
   application:
     name: "chukchuk-haksa"
 

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -132,8 +132,7 @@ class ScrapeResultCallbackServiceUnitTests {
         RuntimeException boom = new RuntimeException("unexpected");
         doThrow(boom).when(portalSyncService).syncWithPortal(any(UUID.class), any());
 
-        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody)))
-                .isSameAs(boom);
+        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody));
 
         assertThat(job.getStatus().name()).isEqualTo("FAILED");
         assertThat(job.getErrorCode()).isEqualTo("INTERNAL_ERROR");

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -97,6 +98,45 @@ class ScrapeResultCallbackServiceUnitTests {
         assertThat(job.isCompleted()).isTrue();
         assertThat(job.getStatus().name()).isEqualTo("SUCCEEDED");
         verify(portalSyncService).syncWithPortal(any(UUID.class), any());
+    }
+
+    @Test
+    @DisplayName("성공 callback 처리 중 RuntimeException이 발생해도 FAILED로 마킹된다")
+    void handleCallback_runtimeDuringSync_marksJobFailed() {
+        ScrapeResultCallbackService service = createService();
+        UUID userId = UUID.randomUUID();
+        String timestamp = Instant.now().toString();
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "fingerprint",
+                "{\"username\":\"17019013\",\"password\":\"pw\"}"
+        );
+        String rawBody = """
+                {
+                  "job_id":"%s",
+                  "status":"succeeded",
+                  "result_payload":{
+                    "student":{"sno":"17019013","studNm":"홍길동","univCd":"01","univNm":"수원대학교","dpmjCd":"D1","dpmjNm":"컴퓨터학부","mjorCd":"M1","mjorNm":"컴퓨터학과","the2MjorCd":null,"the2MjorNm":null,"scrgStatNm":"재학","enscYear":"2021","enscSmrCd":"10","enscDvcd":"신입","studGrde":4,"facSmrCnt":8},
+                    "semesters":[{"semester":"2024-10","courses":[{"subjtCd":"C101","subjtNm":"자료구조","ltrPrfsNm":"김교수","estbDpmjNm":"컴퓨터학부","point":3,"cretGrdCd":"A+","refacYearSmr":"-","timtSmryCn":"월1-2","facDvnm":"전공","cltTerrNm":"0영역","cltTerrCd":"0","subjtEstbSmrCd":"10","subjtEstbYearSmr":"2024-10","diclNo":"01","gainPont":"95","cretDelCd":null,"cretDelNm":null}]}],
+                    "academicRecords":{"listSmrCretSumTabYearSmr":[{"cretGainYear":"2024","cretSmrCd":"10","gainPoint":"18","applPoint":"18","gainAvmk":"4.2","gainTavgPont":"95","dpmjOrdp":"1/100"}],"selectSmrCretSumTabSjTotal":{"gainPoint":"120","applPoint":"130","gainAvmk":"3.8","gainTavgPont":"90"}}
+                  },
+                  "finished_at":"2026-03-14T10:01:00Z"
+                }
+                """.formatted(job.getJobId());
+
+        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(userService.tryMergeWithExistingUser(userId, "17019013")).thenReturn(disconnectedUser(userId));
+        RuntimeException boom = new RuntimeException("unexpected");
+        doThrow(boom).when(portalSyncService).syncWithPortal(any(UUID.class), any());
+
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody)))
+                .isSameAs(boom);
+
+        assertThat(job.getStatus().name()).isEqualTo("FAILED");
+        assertThat(job.getErrorCode()).isEqualTo("INTERNAL_ERROR");
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
@@ -142,6 +142,45 @@ class SyncAcademicRecordServiceTest {
         verify(studentCourseRepository, never()).saveAll(any());
     }
 
+    @Test
+    void executeWithPortalData_mergesDuplicateSectionsIntoSingleEnrollment() {
+        UUID userId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        Student student = mock(Student.class);
+        when(student.getId()).thenReturn(studentId);
+        when(studentService.getStudentByUserId(userId)).thenReturn(student);
+        when(studentCourseRepository.findByStudent(student)).thenReturn(List.of());
+        doNothing().when(academicRecordRepository).insertAllAcademicRecords(any(), any());
+
+        Professor professor = mock(Professor.class);
+        when(professor.getId()).thenReturn(11L);
+        when(professorService.getOrCreateAll(any())).thenReturn(Map.of(
+                "홍길동", professor,
+                "미확인 교수", professor
+        ));
+
+        Course course = mock(Course.class);
+        when(course.getId()).thenReturn(21L);
+        when(courseService.getOrCreateCourses(any())).thenReturn(Map.of("CSE101", course));
+
+        when(courseOfferingService.getOrCreateAll(any())).thenAnswer(invocation -> {
+            List<CreateOfferingCommand> commands = invocation.getArgument(0);
+            assertThat(commands).hasSize(1);
+            assertThat(commands.get(0).classSection()).isEqualTo("02");
+            CourseOffering offering = mock(CourseOffering.class);
+            when(offering.getId()).thenReturn(31L);
+            return Map.of(CourseOfferingService.CourseOfferingKey.from(commands.get(0)), offering);
+        });
+
+        service.executeWithPortalData(userId, new PortalData(
+                null,
+                sampleAcademicData(),
+                sampleCurriculumDataWithDuplicateSections()
+        ));
+
+        verify(studentCourseBulkRepository).insertAll(argThat(rows -> rows.size() == 1));
+    }
+
     private PortalCurriculumData sampleCurriculumData() {
         return new PortalCurriculumData(
                 List.of(new CourseInfo(
@@ -209,6 +248,62 @@ class SyncAcademicRecordServiceTest {
                 List.of(semester),
                 grades,
                 new AcademicSummary(3, 3, 4.3, 95.0)
+        );
+    }
+
+    private PortalCurriculumData sampleCurriculumDataWithDuplicateSections() {
+        return new PortalCurriculumData(
+                List.of(new CourseInfo(
+                        "CSE101",
+                        "자료구조",
+                        "홍길동",
+                        "컴퓨터공학과",
+                        3,
+                        "A+",
+                        false,
+                        "월1-2",
+                        "전선",
+                        100,
+                        200,
+                        20241,
+                        4.3,
+                        false
+                )),
+                List.of(new ProfessorInfo("홍길동")),
+                List.of(
+                        new OfferingInfo(
+                                "CSE101",
+                                2024,
+                                1,
+                                "01",
+                                "홍길동",
+                                "월1-2",
+                                3,
+                                "컴퓨터공학과",
+                                "전선",
+                                20241,
+                                100,
+                                200,
+                                "ABSOLUTE",
+                                false
+                        ),
+                        new OfferingInfo(
+                                "CSE101",
+                                2024,
+                                1,
+                                "02",
+                                "홍길동",
+                                "수1-2",
+                                3,
+                                "컴퓨터공학과",
+                                "전선",
+                                20241,
+                                100,
+                                200,
+                                "ABSOLUTE",
+                                false
+                        )
+                )
         );
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
@@ -1,0 +1,67 @@
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.application.academic.enrollment.CourseEnrollment;
+import com.chukchuk.haksa.application.academic.repository.AcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.course.model.CourseOffering;
+import com.chukchuk.haksa.domain.course.service.CourseOfferingService;
+import com.chukchuk.haksa.domain.course.service.CourseService;
+import com.chukchuk.haksa.domain.professor.service.ProfessorService;
+import com.chukchuk.haksa.domain.student.model.Grade;
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.service.StudentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SyncAcademicRecordServiceTest {
+
+    @Mock
+    private AcademicRecordRepository academicRecordRepository;
+    @Mock
+    private StudentCourseRepository studentCourseRepository;
+    @Mock
+    private StudentService studentService;
+    @Mock
+    private CourseOfferingService courseOfferingService;
+    @Mock
+    private ProfessorService professorService;
+    @Mock
+    private CourseService courseService;
+
+    @InjectMocks
+    private SyncAcademicRecordService service;
+
+    @Test
+    void removeDeletedEnrollmentsUsesBatchDelete() {
+        StudentCourse existing = mock(StudentCourse.class);
+        CourseOffering offering = mock(CourseOffering.class);
+        when(offering.getId()).thenReturn(1L);
+        when(existing.getOffering()).thenReturn(offering);
+        when(existing.getId()).thenReturn(10L);
+
+        List<StudentCourse> existingEnrollments = List.of(existing);
+        List<CourseEnrollment> newEnrollments = List.of(
+                new CourseEnrollment(UUID.randomUUID(), 2L, new Grade(GradeType.A0), 3, false, 95.0, false)
+        );
+
+        int removed = service.removeDeletedEnrollments(mock(Student.class), newEnrollments, existingEnrollments);
+
+        ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
+        verify(studentCourseRepository).deleteAllByIdInBatch(captor.capture());
+        assertThat(captor.getValue()).containsExactly(10L);
+        assertThat(removed).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
@@ -4,19 +4,24 @@ import com.chukchuk.haksa.application.academic.enrollment.CourseEnrollment;
 import com.chukchuk.haksa.application.academic.repository.AcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseBulkRepository;
 import com.chukchuk.haksa.domain.course.model.CourseOffering;
 import com.chukchuk.haksa.domain.course.service.CourseOfferingService;
 import com.chukchuk.haksa.domain.course.service.CourseService;
+import com.chukchuk.haksa.domain.course.dto.CreateOfferingCommand;
 import com.chukchuk.haksa.domain.professor.service.ProfessorService;
 import com.chukchuk.haksa.domain.student.model.Grade;
 import com.chukchuk.haksa.domain.student.model.GradeType;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.service.StudentService;
+import com.chukchuk.haksa.domain.professor.model.Professor;
+import com.chukchuk.haksa.domain.course.model.Course;
 import com.chukchuk.haksa.infrastructure.portal.model.AcademicSummary;
 import com.chukchuk.haksa.infrastructure.portal.model.CourseInfo;
 import com.chukchuk.haksa.infrastructure.portal.model.GradeSummary;
 import com.chukchuk.haksa.infrastructure.portal.model.MergedOfferingAcademic;
 import com.chukchuk.haksa.infrastructure.portal.model.OfferingInfo;
+import com.chukchuk.haksa.infrastructure.portal.model.PortalData;
 import com.chukchuk.haksa.infrastructure.portal.model.PortalAcademicData;
 import com.chukchuk.haksa.infrastructure.portal.model.PortalCurriculumData;
 import com.chukchuk.haksa.infrastructure.portal.model.ProfessorInfo;
@@ -53,6 +58,8 @@ class SyncAcademicRecordServiceTest {
     private ProfessorService professorService;
     @Mock
     private CourseService courseService;
+    @Mock
+    private StudentCourseBulkRepository studentCourseBulkRepository;
 
     @InjectMocks
     private SyncAcademicRecordService service;
@@ -80,7 +87,63 @@ class SyncAcademicRecordServiceTest {
 
     @Test
     void mergeOfferingsAndAcademic_mergesByCourseYearSemester() throws Exception {
-        PortalCurriculumData curriculumData = new PortalCurriculumData(
+        PortalCurriculumData curriculumData = sampleCurriculumData();
+        PortalAcademicData academicData = sampleAcademicData();
+
+        Method method = SyncAcademicRecordService.class
+                .getDeclaredMethod("mergeOfferingsAndAcademic", PortalCurriculumData.class, PortalAcademicData.class);
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<Object, MergedOfferingAcademic> merged =
+                (Map<Object, MergedOfferingAcademic>) method.invoke(service, curriculumData, academicData);
+
+        assertThat(merged).hasSize(1);
+        MergedOfferingAcademic mergedEntry = merged.values().iterator().next();
+        assertThat(mergedEntry.getAcademic()).isNotNull();
+        assertThat(mergedEntry.getOffering().getEvaluationType()).isEqualTo("ABSOLUTE");
+    }
+
+    @Test
+    void executeWithPortalData_usesBulkInsertForNewCourses() {
+        UUID userId = UUID.randomUUID();
+        UUID studentId = UUID.randomUUID();
+        Student student = mock(Student.class);
+        when(student.getId()).thenReturn(studentId);
+        when(studentService.getStudentByUserId(userId)).thenReturn(student);
+        when(studentCourseRepository.findByStudent(student)).thenReturn(List.of());
+        doNothing().when(academicRecordRepository).insertAllAcademicRecords(any(), any());
+
+        Professor professor = mock(Professor.class);
+        when(professor.getId()).thenReturn(11L);
+        when(professorService.getOrCreateAll(any())).thenReturn(Map.of(
+                "홍길동", professor,
+                "미확인 교수", professor
+        ));
+
+        Course course = mock(Course.class);
+        when(course.getId()).thenReturn(21L);
+        when(courseService.getOrCreateCourses(any())).thenReturn(Map.of("CSE101", course));
+
+        when(courseOfferingService.getOrCreateAll(any())).thenAnswer(invocation -> {
+            List<CreateOfferingCommand> commands = invocation.getArgument(0);
+            CourseOffering offering = mock(CourseOffering.class);
+            when(offering.getId()).thenReturn(31L);
+            return Map.of(CourseOfferingService.CourseOfferingKey.from(commands.get(0)), offering);
+        });
+
+        service.executeWithPortalData(userId, new PortalData(
+                null,
+                sampleAcademicData(),
+                sampleCurriculumData()
+        ));
+
+        verify(studentCourseBulkRepository).insertAll(argThat(rows -> rows.size() == 1));
+        verify(studentCourseRepository, never()).saveAll(any());
+    }
+
+    private PortalCurriculumData sampleCurriculumData() {
+        return new PortalCurriculumData(
                 List.of(new CourseInfo(
                         "CSE101",
                         "자료구조",
@@ -115,7 +178,9 @@ class SyncAcademicRecordServiceTest {
                         false
                 ))
         );
+    }
 
+    private PortalAcademicData sampleAcademicData() {
         SemesterCourseInfo semester = new SemesterCourseInfo(
                 2024,
                 1,
@@ -140,23 +205,10 @@ class SyncAcademicRecordServiceTest {
                 List.of(new SemesterGrade(2024, 1, "3", "3", "4.3", 95.0, new Ranking(1, 10))),
                 new AcademicSummary(3, 3, 4.3, 95.0)
         );
-        PortalAcademicData academicData = new PortalAcademicData(
+        return new PortalAcademicData(
                 List.of(semester),
                 grades,
                 new AcademicSummary(3, 3, 4.3, 95.0)
         );
-
-        Method method = SyncAcademicRecordService.class
-                .getDeclaredMethod("mergeOfferingsAndAcademic", PortalCurriculumData.class, PortalAcademicData.class);
-        method.setAccessible(true);
-
-        @SuppressWarnings("unchecked")
-        Map<Object, MergedOfferingAcademic> merged =
-                (Map<Object, MergedOfferingAcademic>) method.invoke(service, curriculumData, academicData);
-
-        assertThat(merged).hasSize(1);
-        MergedOfferingAcademic mergedEntry = merged.values().iterator().next();
-        assertThat(mergedEntry.getAcademic()).isNotNull();
-        assertThat(mergedEntry.getOffering().getEvaluationType()).isEqualTo("ABSOLUTE");
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordServiceTest.java
@@ -12,6 +12,17 @@ import com.chukchuk.haksa.domain.student.model.Grade;
 import com.chukchuk.haksa.domain.student.model.GradeType;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.service.StudentService;
+import com.chukchuk.haksa.infrastructure.portal.model.AcademicSummary;
+import com.chukchuk.haksa.infrastructure.portal.model.CourseInfo;
+import com.chukchuk.haksa.infrastructure.portal.model.GradeSummary;
+import com.chukchuk.haksa.infrastructure.portal.model.MergedOfferingAcademic;
+import com.chukchuk.haksa.infrastructure.portal.model.OfferingInfo;
+import com.chukchuk.haksa.infrastructure.portal.model.PortalAcademicData;
+import com.chukchuk.haksa.infrastructure.portal.model.PortalCurriculumData;
+import com.chukchuk.haksa.infrastructure.portal.model.ProfessorInfo;
+import com.chukchuk.haksa.infrastructure.portal.model.Ranking;
+import com.chukchuk.haksa.infrastructure.portal.model.SemesterCourseInfo;
+import com.chukchuk.haksa.infrastructure.portal.model.SemesterGrade;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -19,7 +30,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,5 +76,87 @@ class SyncAcademicRecordServiceTest {
         verify(studentCourseRepository).deleteAllByIdInBatch(captor.capture());
         assertThat(captor.getValue()).containsExactly(10L);
         assertThat(removed).isEqualTo(1);
+    }
+
+    @Test
+    void mergeOfferingsAndAcademic_mergesByCourseYearSemester() throws Exception {
+        PortalCurriculumData curriculumData = new PortalCurriculumData(
+                List.of(new CourseInfo(
+                        "CSE101",
+                        "자료구조",
+                        "홍길동",
+                        "컴퓨터공학과",
+                        3,
+                        "A+",
+                        false,
+                        "월1-2",
+                        "전선",
+                        100,
+                        200,
+                        20241,
+                        4.3,
+                        false
+                )),
+                List.of(new ProfessorInfo("홍길동")),
+                List.of(new OfferingInfo(
+                        "CSE101",
+                        2024,
+                        1,
+                        "01",
+                        "홍길동",
+                        "월1-2",
+                        3,
+                        "컴퓨터공학과",
+                        "전선",
+                        20241,
+                        100,
+                        200,
+                        "ABSOLUTE",
+                        false
+                ))
+        );
+
+        SemesterCourseInfo semester = new SemesterCourseInfo(
+                2024,
+                1,
+                List.of(new CourseInfo(
+                        "CSE101",
+                        "자료구조",
+                        "홍길동",
+                        "컴퓨터공학과",
+                        3,
+                        "A+",
+                        false,
+                        "월1-2",
+                        "전선",
+                        100,
+                        200,
+                        20241,
+                        4.3,
+                        false
+                ))
+        );
+        GradeSummary grades = new GradeSummary(
+                List.of(new SemesterGrade(2024, 1, "3", "3", "4.3", 95.0, new Ranking(1, 10))),
+                new AcademicSummary(3, 3, 4.3, 95.0)
+        );
+        PortalAcademicData academicData = new PortalAcademicData(
+                List.of(semester),
+                grades,
+                new AcademicSummary(3, 3, 4.3, 95.0)
+        );
+
+        Method method = SyncAcademicRecordService.class
+                .getDeclaredMethod("mergeOfferingsAndAcademic", PortalCurriculumData.class, PortalAcademicData.class);
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<Object, MergedOfferingAcademic> merged =
+                (Map<Object, MergedOfferingAcademic>) method.invoke(service, curriculumData, academicData);
+
+        assertThat(merged).hasSize(1);
+        MergedOfferingAcademic mergedEntry = merged.values().iterator().next();
+        assertThat(mergedEntry.getAcademic()).isNotNull();
+        assertThat(mergedEntry.getOffering().getEvaluationType()).isEqualTo("ABSOLUTE");
     }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepositoryImplTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseBulkRepositoryImplTest.java
@@ -1,0 +1,98 @@
+package com.chukchuk.haksa.domain.academic.record.repository;
+
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = StudentCourseBulkRepositoryImplTest.TestConfig.class)
+class StudentCourseBulkRepositoryImplTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        DataSource dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                    .setType(EmbeddedDatabaseType.H2)
+                    .build();
+        }
+
+        @Bean
+        JdbcTemplate jdbcTemplate(DataSource dataSource) {
+            return new JdbcTemplate(dataSource);
+        }
+
+        @Bean
+        StudentCourseBulkRepository studentCourseBulkRepository(JdbcTemplate jdbcTemplate) {
+            return new StudentCourseBulkRepositoryImpl(jdbcTemplate);
+        }
+    }
+
+    @Autowired
+    private StudentCourseBulkRepository studentCourseBulkRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUpSchema() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS student_courses");
+        jdbcTemplate.execute("""
+                CREATE TABLE student_courses (
+                    student_id UUID NOT NULL,
+                    offering_id BIGINT NOT NULL,
+                    grade VARCHAR(255),
+                    points INTEGER,
+                    is_retake BOOLEAN,
+                    original_score INTEGER,
+                    is_retake_deleted BOOLEAN,
+                    created_at TIMESTAMP WITH TIME ZONE
+                )
+                """);
+    }
+
+    @Test
+    void insertAll_insertsAllRowsInSingleBatch() {
+        UUID studentId = UUID.randomUUID();
+        StudentCourseBulkRow row = new StudentCourseBulkRow(
+                studentId,
+                10L,
+                GradeType.A0,
+                3,
+                false,
+                95,
+                false
+        );
+
+        studentCourseBulkRepository.insertAll(List.of(row));
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM student_courses WHERE student_id = ?",
+                Integer.class,
+                studentId
+        );
+        assertThat(count).isEqualTo(1);
+
+        String storedGrade = jdbcTemplate.queryForObject(
+                "SELECT grade FROM student_courses WHERE student_id = ?",
+                String.class,
+                studentId
+        );
+        assertThat(storedGrade).isEqualTo(GradeType.A0.getValue());
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.course.service;
 import com.chukchuk.haksa.domain.course.dto.CreateOfferingCommand;
 import com.chukchuk.haksa.domain.course.model.Course;
 import com.chukchuk.haksa.domain.course.model.CourseOffering;
+import com.chukchuk.haksa.domain.course.model.EvaluationType;
 import com.chukchuk.haksa.domain.course.model.FacultyDivision;
 import com.chukchuk.haksa.domain.course.model.LiberalArtsAreaCode;
 import com.chukchuk.haksa.domain.course.repository.CourseOfferingRepository;
@@ -138,6 +139,43 @@ class CourseOfferingServiceUnitTests {
         Map<Long, CourseOffering> map = courseOfferingService.getOfferingMapByIds(List.of(1L, 2L));
 
         assertThat(map).containsEntry(1L, first).containsEntry(2L, second);
+    }
+
+    @Test
+    @DisplayName("평가 방식/이수구분 값이 없으면 안전한 기본값으로 저장한다")
+    void getOrCreateOffering_whenEnumFieldsMissing_usesSafeDefaults() {
+        CreateOfferingCommand cmd = new CreateOfferingCommand(
+                13L,
+                2024,
+                1,
+                "02",
+                23L,
+                null,
+                "화 1-2",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                3,
+                "소프트웨어학과"
+        );
+
+        Course course = new Course("SWE201", "SW공학");
+        Professor professor = new Professor("이교수");
+
+        when(courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(
+                Set.of(13L), Set.of(2024), Set.of(1)
+        )).thenReturn(List.of());
+        when(courseRepository.getReferenceById(13L)).thenReturn(course);
+        when(professorRepository.getReferenceById(23L)).thenReturn(professor);
+        when(courseOfferingRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CourseOffering result = courseOfferingService.getOrCreateOffering(cmd);
+
+        assertThat(result.getEvaluationTypeCode()).isEqualTo(EvaluationType.UNKNOWN);
+        assertThat(result.getFacultyDivisionName()).isNull();
     }
 
     private CreateOfferingCommand command(Long courseId, Long professorId, Long departmentId, Integer areaCode) {

--- a/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
@@ -22,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -176,6 +175,50 @@ class CourseOfferingServiceUnitTests {
 
         assertThat(result.getEvaluationTypeCode()).isEqualTo(EvaluationType.UNKNOWN);
         assertThat(result.getFacultyDivisionName()).isNull();
+    }
+
+    @Test
+    @DisplayName("기존 강의의 nullable 키 필드가 비어 있어도 동일 강의로 재사용한다")
+    void getOrCreateOffering_whenExistingKeyFieldsAreNull_reusesExistingOffering() {
+        CreateOfferingCommand cmd = new CreateOfferingCommand(
+                14L,
+                2024,
+                1,
+                " ",
+                24L,
+                null,
+                "수 1-2",
+                "ABSOLUTE",
+                false,
+                20241,
+                " ",
+                null,
+                null,
+                3,
+                " "
+        );
+
+        CourseOffering existing = mock(CourseOffering.class);
+        Course course = mock(Course.class);
+        Professor professor = mock(Professor.class);
+        when(course.getId()).thenReturn(14L);
+        when(professor.getId()).thenReturn(24L);
+        when(existing.getCourse()).thenReturn(course);
+        when(existing.getProfessor()).thenReturn(professor);
+        when(existing.getYear()).thenReturn(2024);
+        when(existing.getSemester()).thenReturn(1);
+        when(existing.getClassSection()).thenReturn(null);
+        when(existing.getFacultyDivisionName()).thenReturn(null);
+        when(existing.getHostDepartment()).thenReturn(null);
+
+        when(courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(
+                Set.of(14L), Set.of(2024), Set.of(1)
+        )).thenReturn(List.of(existing));
+
+        CourseOffering result = courseOfferingService.getOrCreateOffering(cmd);
+
+        assertThat(result).isSameAs(existing);
+        verify(courseOfferingRepository, never()).saveAll(any());
     }
 
     private CreateOfferingCommand command(Long courseId, Long professorId, Long departmentId, Integer areaCode) {

--- a/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/course/service/CourseOfferingServiceUnitTests.java
@@ -22,12 +22,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CourseOfferingServiceUnitTests {
@@ -54,16 +53,27 @@ class CourseOfferingServiceUnitTests {
     @DisplayName("동일 분반 강의가 이미 존재하면 기존 강의를 반환한다")
     void getOrCreateOffering_whenExists_returnsExisting() {
         CreateOfferingCommand cmd = command(10L, 20L, 30L, 101);
-        CourseOffering existing = org.mockito.Mockito.mock(CourseOffering.class);
+        CourseOffering existing = mock(CourseOffering.class);
+        Course course = mock(Course.class);
+        Professor professor = mock(Professor.class);
+        when(course.getId()).thenReturn(10L);
+        when(professor.getId()).thenReturn(20L);
+        when(existing.getCourse()).thenReturn(course);
+        when(existing.getProfessor()).thenReturn(professor);
+        when(existing.getYear()).thenReturn(2024);
+        when(existing.getSemester()).thenReturn(1);
+        when(existing.getClassSection()).thenReturn("01");
+        when(existing.getFacultyDivisionName()).thenReturn(FacultyDivision.전핵);
+        when(existing.getHostDepartment()).thenReturn("컴퓨터학과");
 
-        when(courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
-                10L, 2024, 1, "01", 20L, FacultyDivision.전핵, "컴퓨터학과"
-        )).thenReturn(Optional.of(existing));
+        when(courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(
+                Set.of(10L), Set.of(2024), Set.of(1)
+        )).thenReturn(List.of(existing));
 
         CourseOffering result = courseOfferingService.getOrCreateOffering(cmd);
 
         assertThat(result).isSameAs(existing);
-        verify(courseOfferingRepository, never()).save(any(CourseOffering.class));
+        verify(courseOfferingRepository, never()).saveAll(any());
         verify(courseRepository, never()).getReferenceById(any(Long.class));
     }
 
@@ -76,14 +86,14 @@ class CourseOfferingServiceUnitTests {
         Department department = new Department("CS", "컴퓨터학과");
         LiberalArtsAreaCode areaCode = org.mockito.Mockito.mock(LiberalArtsAreaCode.class);
 
-        when(courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
-                11L, 2024, 1, "01", 21L, FacultyDivision.전핵, "컴퓨터학과"
-        )).thenReturn(Optional.empty());
+        when(courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(
+                Set.of(11L), Set.of(2024), Set.of(1)
+        )).thenReturn(List.of());
         when(courseRepository.getReferenceById(11L)).thenReturn(course);
         when(professorRepository.getReferenceById(21L)).thenReturn(professor);
         when(departmentRepository.getReferenceById(31L)).thenReturn(department);
         when(liberalArtsAreaCodeRepository.getReferenceById(202)).thenReturn(areaCode);
-        when(courseOfferingRepository.save(any(CourseOffering.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(courseOfferingRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         CourseOffering result = courseOfferingService.getOrCreateOffering(cmd);
 
@@ -101,12 +111,12 @@ class CourseOfferingServiceUnitTests {
         Course course = new Course("MAT201", "선형대수");
         Professor professor = new Professor("김교수");
 
-        when(courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
-                12L, 2024, 1, "01", 22L, FacultyDivision.전핵, "컴퓨터학과"
-        )).thenReturn(Optional.empty());
+        when(courseOfferingRepository.findByCourseIdInAndYearInAndSemesterIn(
+                Set.of(12L), Set.of(2024), Set.of(1)
+        )).thenReturn(List.of());
         when(courseRepository.getReferenceById(12L)).thenReturn(course);
         when(professorRepository.getReferenceById(22L)).thenReturn(professor);
-        when(courseOfferingRepository.save(any(CourseOffering.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(courseOfferingRepository.saveAll(any())).thenAnswer(inv -> inv.getArgument(0));
 
         CourseOffering result = courseOfferingService.getOrCreateOffering(cmd);
 


### PR DESCRIPTION
### 참고 사항

- 포털 연동 내부 I/O 병목을 분석할 수 있도록 성능 로그를 추가하고, 교수/과목/개설강좌 생성 경로를 batch 구조로 최적화했습니다.
- StudentCourse 저장을 JDBC batch insert로 전환해 전체 포털 sync 시간을 약 14.9초에서 0.83초 수준으로 단축했습니다.
- 포털 sync 실패 시 polling에서 실패 상태가 남도록 보강했고, 개설강좌 key 정규화 및 병합 기준 복원으로 회귀 위험을 수정했습니다.
- 최근 CloudWatch 측정값 기준으로 total_ms=863, insert_ms=145, course_get_or_create_ms=120이 확인됐습니다.
- 테스트는 ./gradlew test로 검증했습니다.

### 🔗 Related Issue

Closes #192
