### PR TITLE
198 feat: PR/Push CI 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI (Gradle)
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gradle:
+    name: ci-gradle
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run unit tests
+        run: ./gradlew test --stacktrace --no-daemon
+
+      - name: Run static checks
+        run: ./gradlew check --stacktrace --no-daemon
+
+      - name: Publish CI summary
+        if: ${{ always() }}
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          {
+            echo "## CI (Gradle)"
+            echo "- Status: ${JOB_STATUS}"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Event: $GITHUB_EVENT_NAME"
+            if [ "${JOB_STATUS}" = "failure" ]; then
+              printf '\n### Next steps\n'
+              echo "- 확인: 'Run unit tests'와 'Run static checks' 로그에서 첫 실패 원인을 찾아 수정"
+              echo "- 재시도: 문제 해결 후 PR 업데이트 혹은 rerun"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Run unit tests
-        run: ./gradlew test --stacktrace --no-daemon
-
-      - name: Run static checks
+      - name: Run Gradle check (tests included)
         run: ./gradlew check --stacktrace --no-daemon
 
       - name: Publish CI summary

--- a/.github/workflows/deploy-dev-lambda.yml
+++ b/.github/workflows/deploy-dev-lambda.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Grant execute permission for Gradle
         run: chmod +x ./gradlew
 
+      - name: Run unit tests
+        run: ./gradlew test --stacktrace --no-daemon
+
       - name: Build Lambda zip
         run: ./gradlew clean lambdaZip -x test
 

--- a/.github/workflows/deploy-prod-lambda.yml
+++ b/.github/workflows/deploy-prod-lambda.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Grant execute permission for Gradle
         run: chmod +x ./gradlew
 
+      - name: Run unit tests
+        run: ./gradlew test --stacktrace --no-daemon
+
       - name: Build Lambda zip
         run: ./gradlew clean lambdaZip -x test
 

--- a/.github/workflows/link-issue.yml
+++ b/.github/workflows/link-issue.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Check if Issue Link Already Exists
         if: steps.extract.outputs.issue_number != ''
         id: check_link
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          ISSUE_NUMBER: ${{ steps.extract.outputs.issue_number }}
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
-          ISSUE_NUMBER="${{ steps.extract.outputs.issue_number }}"
-
-          if echo "$PR_BODY" | grep -qE "(Close[sd]?|Fix(e[sd])?|Resolve[sd]?) #$ISSUE_NUMBER"; then
+          if printf '%s' "$PR_BODY" | grep -qE "(Close[sd]?|Fix(e[sd])?|Resolve[sd]?) #$ISSUE_NUMBER"; then
             echo "Link already exists"
             echo "link_exists=true" >> $GITHUB_OUTPUT
           else

--- a/docs/specs/20260328-issue-198-ci-flow/clarify.md
+++ b/docs/specs/20260328-issue-198-ci-flow/clarify.md
@@ -1,0 +1,20 @@
+# Clarify – Issue #198 CI Gate
+
+## Open Questions
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | 정적 분석 범위를 `./gradlew check`로 대체해도 되는가? | Codex | Closed (2026-03-28 사용자 “정적 분석” 요청을 `check`로 수렴) |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | 새 workflow는 `.github/workflows/ci.yml` 단일 파일로 관리한다. | 기존 workflow와 충돌을 피하고 Branch Protection 대상 Job 이름을 명확히 하기 위함 | 2026-03-28 |
+| 2 | Static analysis 명령은 `./gradlew check --stacktrace`로 실행한다. | 현재 프로젝트에 별도 정적 분석 플러그인이 없으므로 `check`를 훅 포인트로 사용하고 향후 도구 추가 시 자동 실행 보장 | 2026-03-28 |
+
+## Risks / Unknowns
+- Item: `gradlew check`가 테스트와 중복되어 실행 시간이 길어질 수 있음
+  - Impact: CI 대기 시간이 증가해 피드백이 늦어질 수 있다.
+  - Mitigation: Gradle 캐시를 적극 사용하고, 이후 실제 정적 분석 도구 도입 시 병렬 Job 분리를 검토한다.
+
+## Follow-ups
+- [ ] Branch Protection에 새 Job(`ci-gradle`)을 필수 검사로 등록 (Owner: Repo Admin)

--- a/docs/specs/20260328-issue-198-ci-flow/plan.md
+++ b/docs/specs/20260328-issue-198-ci-flow/plan.md
@@ -1,0 +1,23 @@
+# Plan – Issue #198 CI Gate
+
+## Architecture / Layering
+- Domain impact: 없음 (코드/도메인 로직 미변경).
+- Application orchestration: 없음.
+- Infrastructure touchpoints: GitHub Actions 실행 환경(Hosted Ubuntu), Gradle 캐시(S3 backend 아님)만 사용.
+- Global/config changes: `.github/workflows/ci.yml` 추가, Gradle 캐시 키(`~/.gradle` + Wrapper) 정의.
+
+## Data / Transactions
+- Repositories touched: `.github/workflows/ci.yml`.
+- Transaction scope: CI Job 전체(Checkout → Cache → Gradle commands → Step summary).
+- Consistency expectations: pull_request/push 이벤트마다 동일한 명령을 실행하고, 실패 시 즉시 Job 실패 처리.
+
+## Testing Strategy
+- Domain tests: N/A.
+- Application tests: N/A.
+- Integration/API tests: 새 workflow 내에서 `./gradlew test --stacktrace` 실행.
+- Additional commands: 로컬에서 `./gradlew test`를 실행해 baseline 확인 (필수), workflow 문법은 `act` 대신 `workflow syntax` 검토로 대체.
+
+## Rollout Considerations
+- Backward compatibility: 기존 workflow와 독립적으로 동작, 다른 배포 workflow에 영향 없음.
+- Observability / metrics: GitHub Actions Job Summary에 테스트/체크 단계 결과 요약, 실패 시 로그 링크 제공.
+- Feature flags / toggles: 없음. Branch Protection에서 `ci-gradle` Job을 필수로 등록하도록 관리자에게 전달 (Clarify Follow-up #1).

--- a/docs/specs/20260328-issue-198-ci-flow/plan.md
+++ b/docs/specs/20260328-issue-198-ci-flow/plan.md
@@ -14,7 +14,7 @@
 ## Testing Strategy
 - Domain tests: N/A.
 - Application tests: N/A.
-- Integration/API tests: 새 CI workflow와 Lambda workflow 모두 `./gradlew test --stacktrace --no-daemon`을 실행한다.
+- Integration/API tests: CI workflow는 `./gradlew check --stacktrace --no-daemon`을 실행(테스트 포함)하고, Lambda workflow는 `./gradlew test --stacktrace --no-daemon`을 실행한다.
 - Additional commands: 로컬에서 `./gradlew test`를 실행해 baseline 확인 (필수), workflow 문법은 `act` 대신 `workflow syntax` 검토로 대체.
 
 ## Rollout Considerations

--- a/docs/specs/20260328-issue-198-ci-flow/plan.md
+++ b/docs/specs/20260328-issue-198-ci-flow/plan.md
@@ -3,8 +3,8 @@
 ## Architecture / Layering
 - Domain impact: 없음 (코드/도메인 로직 미변경).
 - Application orchestration: 없음.
-- Infrastructure touchpoints: GitHub Actions 실행 환경(Hosted Ubuntu), Gradle 캐시(S3 backend 아님)만 사용.
-- Global/config changes: `.github/workflows/ci.yml` 추가, Gradle 캐시 키(`~/.gradle` + Wrapper) 정의.
+- Infrastructure touchpoints: GitHub Actions 실행 환경(Hosted Ubuntu), Gradle 캐시(S3 backend 아님)만 사용. Lambda 배포 workflow(`deploy-*-lambda.yml`)에 테스트 스텝 추가.
+- Global/config changes: `.github/workflows/ci.yml` 추가, Gradle 캐시 키(`~/.gradle` + Wrapper) 정의, Lambda workflow 내 테스트 스텝에서 `--stacktrace --no-daemon` 옵션 사용.
 
 ## Data / Transactions
 - Repositories touched: `.github/workflows/ci.yml`.
@@ -14,7 +14,7 @@
 ## Testing Strategy
 - Domain tests: N/A.
 - Application tests: N/A.
-- Integration/API tests: 새 workflow 내에서 `./gradlew test --stacktrace` 실행.
+- Integration/API tests: 새 CI workflow와 Lambda workflow 모두 `./gradlew test --stacktrace --no-daemon`을 실행한다.
 - Additional commands: 로컬에서 `./gradlew test`를 실행해 baseline 확인 (필수), workflow 문법은 `act` 대신 `workflow syntax` 검토로 대체.
 
 ## Rollout Considerations

--- a/docs/specs/20260328-issue-198-ci-flow/spec-lite.md
+++ b/docs/specs/20260328-issue-198-ci-flow/spec-lite.md
@@ -1,0 +1,28 @@
+# Spec Lite Template
+
+> 2026-03-28: Standard Spec (`spec.md`, `clarify.md`, `plan.md`, `tasks.md`)로 승격 완료. Lite 내용은 초기 CI/CD 조사 기록 용도로만 보관한다.
+
+## Summary
+- Purpose: CI/CD 구성 요소(빌드, 테스트, 배포 파이프라인)를 조사해 현재 흐름을 파악한다.
+- Scope (In/Out): In — `.github/workflows` 내 GitHub Actions 정의, 관련 `scripts/` 및 `docker/` 도움 스크립트, README/문서에서 CI 언급. Out — 파이프라인 수정, 신규 배포 구성 추가.
+- Expected Impact: Issue #198 대응을 위해 현재 자동화 단계를 명확히 문서화해 이후 개선/상담의 근거를 마련한다.
+
+## Key Rules
+- Rule 1: 조사만 수행하고 코드/설정을 변경하지 않는다.
+- Rule 2: 발견 내용은 최소 2개 이상의 근거 파일/섹션을 교차 확인(Double check)한다.
+
+## Risks / Assumptions
+- Risk: 일부 파이프라인 문서화가 최신이 아닐 수 있어 실제 GitHub Actions 설정과 어긋날 수 있다.
+- Assumption: GitHub Actions가 단일 CI/CD 진입점이며, self-hosted runner나 외부 서비스는 `.github/workflows`에 명시돼 있다.
+
+## Tasks
+- [x] `.github/workflows/*.yml` 분석으로 CI 단계/조건 파악
+- [x] 배포 관련 스크립트/도커 설정 교차 확인
+- [x] 분석 결과 정리 및 spec-lite/답변 업데이트
+
+## Findings (2026-03-28)
+- `.github/workflows`에는 autofix, issue-linker, dev/prod EC2, dev/prod Lambda 6개 workflow만 존재하며 모두 GitHub Actions에서 관리한다.
+- CI 측면에서는 `autofix.yml` 외 별도 테스트/빌드 workflow가 없어서 PR/PUSH 시 Gradle 테스트가 자동 실행되지 않는다.
+- 배포는 `workflow_dispatch` 기반으로 Dev/Prod 각각 EC2와 Lambda가 분리돼 있고, EC2 job은 dev/main 브랜치를 체크아웃해 Jar를 빌드한 후 SCP/SSH로 롤백 가능한 방식으로 배포하며 Lambda job은 `lambdaZip` 산출물을 S3에 올려 alias를 전환한다.
+
+> Lite 스펙은 Scope < 1 day & API 변경 없음일 때만 허용. 조건을 벗어나면 즉시 Standard 스펙으로 승격한다.

--- a/docs/specs/20260328-issue-198-ci-flow/spec.md
+++ b/docs/specs/20260328-issue-198-ci-flow/spec.md
@@ -1,0 +1,63 @@
+# Spec – Issue #198 CI Gate
+
+## 1. Feature Overview
+- Purpose: Pull Request/Push 이벤트마다 `./gradlew test`와 정적 분석(`./gradlew check`)을 자동 실행하는 CI 워크플로우를 추가해 실패 시 병합을 차단한다.
+- Scope
+  - In: GitHub Actions workflow 추가/구성(`.github/workflows/ci.yml`), Gradle 캐시 사용, pull_request/push 대상 브랜치 필터 정의, 실패 시 Job status로 전달.
+  - Out: 애플리케이션 코드/의존성 변경, 배포 workflow 수정, 추가 인프라 자원 생성.
+- Expected Impact: 자동 테스트 없이 merge되던 리스크를 제거하고, 브랜치 보호 규칙에서 새 Job을 필수로 설정할 수 있게 한다.
+- Stakeholder Confirmation: 2026-03-28 사용자 지시(“PR/푸시용 CI workflow를 신설…” – Issue #198).
+
+## 2. Domain Rules
+- Rule 1: Workflow는 `pull_request`(base: dev, main)와 `push`(branches: dev, main) 이벤트를 모두 감시한다.
+- Rule 2: Job은 `actions/setup-java@v4`로 JDK17을 설치하고 `./gradlew test` → `./gradlew check` 순으로 실행하며 하나라도 실패하면 전체 Job을 실패로 마크한다.
+- Rule 3: Gradle 디펜던시 캐시는 `actions/cache@v4` + Gradle 전용 캐시 액션으로 구성해 동일 러너에서 반복 사용한다.
+- Mutable Rules: 대상 브랜치 목록 (추후 release 브랜치 추가 가능).
+- Immutable Rules: 테스트/정적 분석 실패 시 배포/머지를 허용하지 않는다.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: PR Validation Pipeline
+  - Trigger: 개발자가 dev 기반 PR을 생성하거나 업데이트한다.
+  - Actor: GitHub Actions CI Job
+  - Steps:
+    1. pull_request 이벤트로 워크플로우가 시작된다.
+    2. 코드 체크아웃 후 Gradle 캐시를 복원한다.
+    3. `./gradlew test --stacktrace`를 실행해 단위/통합 테스트를 수행한다.
+    4. `./gradlew check --stacktrace`를 실행해 정적 분석/추가 검증을 수행한다.
+    5. 두 단계 모두 성공하면 상태 체크가 green으로 반환된다.
+  - Expected Result: PR이 merge 가능 상태가 된다.
+
+### Exception / Boundary Flow
+- Scenario Name: Verification Failure
+  - Condition: 테스트 또는 `check`가 실패하거나 빌드 환경 설정 오류가 발생한다.
+  - Expected Behavior: Job이 실패 상태로 종료되고 GitHub status가 빨간불이 되어 브랜치 보호 규칙이 merge를 차단한다. 실패 로그는 PR Checks 탭에 기록된다.
+
+## 4. Transaction / Consistency
+- Transaction Start Point: GitHub Actions가 pull_request 혹은 push 이벤트를 수신해 Job을 큐잉한 시점.
+- Transaction End Point: CI Job이 성공/실패 상태를 리포트하고 아티팩트를 업로드한 시점.
+- Atomicity Scope: 단일 Job(`ci-gradle`) 전체가 하나의 원자 단위이며, 중간 단계 실패는 전체 실패로 간주한다.
+- Eventual Consistency Allowed: 허용하지 않음. Green 상태 없이 merge 불가하도록 한다.
+
+## 5. API List (필요 시)
+- Endpoint: N/A (GitHub Actions workflow 내부 실행으로 외부 API 노출 없음)
+
+## 6. Exception Policy
+- Error Code: `CI-GRADLE-FAIL`
+  - Condition: Gradle test 혹은 check 단계가 non-zero 종료 코드를 반환.
+  - Message Convention: GitHub Job summary에 실패 단계/명령어를 요약하고 필요한 경우 다음 단계 안내를 작성.
+  - Handling Layer: GitHub Actions Job (Logs + Step Summary).
+  - User Exposure: PR Checks 탭 및 리포에 이메일/Slack 알림 (GitHub 기본 알림).
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed
+- [ ] Phase 2 Domain complete
+- [ ] Phase 3 Application complete
+- [ ] Phase 4 Infrastructure complete
+- [ ] Phase 5 Global/Config complete
+- [ ] Phase 6 API/Controller complete
+
+## 8. Generated File List
+- Path: `.github/workflows/ci.yml`
+  - Description: PR/Push 이벤트용 Gradle CI workflow (tests + check)
+  - Layer: CI/CD

--- a/docs/specs/20260328-issue-198-ci-flow/spec.md
+++ b/docs/specs/20260328-issue-198-ci-flow/spec.md
@@ -4,7 +4,8 @@
 - Purpose: Pull Request/Push 이벤트마다 `./gradlew test`와 정적 분석(`./gradlew check`)을 자동 실행하는 CI 워크플로우를 추가해 실패 시 병합을 차단한다.
 - Scope
   - In: GitHub Actions workflow 추가/구성(`.github/workflows/ci.yml`), Gradle 캐시 사용, pull_request/push 대상 브랜치 필터 정의, 실패 시 Job status로 전달.
-  - Out: 애플리케이션 코드/의존성 변경, 배포 workflow 수정, 추가 인프라 자원 생성.
+  - In-Δ (2026-03-28): `deploy-*lambda.yml`에 Gradle 테스트 단계를 삽입해 배포 전 필수 검증을 수행한다.
+  - Out: 애플리케이션 코드/의존성 변경, 배포 workflow의 Lambda zip 로직 외 기타 배포 전략.
 - Expected Impact: 자동 테스트 없이 merge되던 리스크를 제거하고, 브랜치 보호 규칙에서 새 Job을 필수로 설정할 수 있게 한다.
 - Stakeholder Confirmation: 2026-03-28 사용자 지시(“PR/푸시용 CI workflow를 신설…” – Issue #198).
 
@@ -12,6 +13,7 @@
 - Rule 1: Workflow는 `pull_request`(base: dev, main)와 `push`(branches: dev, main) 이벤트를 모두 감시한다.
 - Rule 2: Job은 `actions/setup-java@v4`로 JDK17을 설치하고 `./gradlew test` → `./gradlew check` 순으로 실행하며 하나라도 실패하면 전체 Job을 실패로 마크한다.
 - Rule 3: Gradle 디펜던시 캐시는 `actions/cache@v4` + Gradle 전용 캐시 액션으로 구성해 동일 러너에서 반복 사용한다.
+- Rule 4: 모든 Lambda 배포 workflow는 패키징 전에 `./gradlew test --stacktrace --no-daemon`을 실행한다.
 - Mutable Rules: 대상 브랜치 목록 (추후 release 브랜치 추가 가능).
 - Immutable Rules: 테스트/정적 분석 실패 시 배포/머지를 허용하지 않는다.
 
@@ -32,6 +34,10 @@
 - Scenario Name: Verification Failure
   - Condition: 테스트 또는 `check`가 실패하거나 빌드 환경 설정 오류가 발생한다.
   - Expected Behavior: Job이 실패 상태로 종료되고 GitHub status가 빨간불이 되어 브랜치 보호 규칙이 merge를 차단한다. 실패 로그는 PR Checks 탭에 기록된다.
+
+- Scenario Name: Lambda Deployment Guard
+  - Condition: 운영자가 `deploy-dev-lambda.yml` 혹은 `deploy-prod-lambda.yml`을 수동 실행한다.
+  - Expected Behavior: Workflow가 패키징 전에 `./gradlew test --stacktrace --no-daemon`을 실행해 실패 시 즉시 배포를 중단한다. 성공하면 기존 `lambdaZip` 빌드 및 배포 단계를 이어간다.
 
 ## 4. Transaction / Consistency
 - Transaction Start Point: GitHub Actions가 pull_request 혹은 push 이벤트를 수신해 Job을 큐잉한 시점.

--- a/docs/specs/20260328-issue-198-ci-flow/spec.md
+++ b/docs/specs/20260328-issue-198-ci-flow/spec.md
@@ -11,7 +11,7 @@
 
 ## 2. Domain Rules
 - Rule 1: Workflow는 `pull_request`(base: dev, main)와 `push`(branches: dev, main) 이벤트를 모두 감시한다.
-- Rule 2: Job은 `actions/setup-java@v4`로 JDK17을 설치하고 `./gradlew test` → `./gradlew check` 순으로 실행하며 하나라도 실패하면 전체 Job을 실패로 마크한다.
+- Rule 2: Job은 `actions/setup-java@v4`로 JDK17을 설치하고 `./gradlew check --stacktrace --no-daemon` 단일 명령으로 테스트·정적 분석을 모두 실행하며, 실패 시 전체 Job을 실패로 마크한다.
 - Rule 3: Gradle 디펜던시 캐시는 `actions/cache@v4` + Gradle 전용 캐시 액션으로 구성해 동일 러너에서 반복 사용한다.
 - Rule 4: 모든 Lambda 배포 workflow는 패키징 전에 `./gradlew test --stacktrace --no-daemon`을 실행한다.
 - Mutable Rules: 대상 브랜치 목록 (추후 release 브랜치 추가 가능).
@@ -25,9 +25,8 @@
   - Steps:
     1. pull_request 이벤트로 워크플로우가 시작된다.
     2. 코드 체크아웃 후 Gradle 캐시를 복원한다.
-    3. `./gradlew test --stacktrace`를 실행해 단위/통합 테스트를 수행한다.
-    4. `./gradlew check --stacktrace`를 실행해 정적 분석/추가 검증을 수행한다.
-    5. 두 단계 모두 성공하면 상태 체크가 green으로 반환된다.
+    3. `./gradlew check --stacktrace --no-daemon`을 실행해 테스트 + 정적 검증을 동시에 수행한다.
+    4. 명령이 성공하면 상태 체크가 green으로 반환된다.
   - Expected Result: PR이 merge 가능 상태가 된다.
 
 ### Exception / Boundary Flow

--- a/docs/specs/20260328-issue-198-ci-flow/tasks.md
+++ b/docs/specs/20260328-issue-198-ci-flow/tasks.md
@@ -7,11 +7,14 @@
 - [x] `./gradlew check --stacktrace` 스텝 추가
 - [x] 실패 시 Job summary에 안내 메시지 작성
 - [x] 로컬 `./gradlew test` 실행 결과 기록
+- [x] `deploy-dev-lambda.yml`에 테스트 스텝 삽입
+- [x] `deploy-prod-lambda.yml`에 테스트 스텝 삽입
 
 ## Test / Build Log
 | Step | Command | Result | Date |
 |------|---------|--------|------|
 | 1 | `./gradlew test` | PASS | 2026-03-28 |
+| 2 | `./gradlew test` | PASS | 2026-03-28 |
 
 ## Notes
 - Observation: Workflow는 PR/Push 모두에서 실행되므로 concurrency group 충돌이 없도록 기본 설정을 사용한다.

--- a/docs/specs/20260328-issue-198-ci-flow/tasks.md
+++ b/docs/specs/20260328-issue-198-ci-flow/tasks.md
@@ -3,8 +3,7 @@
 ## Checklist
 - [x] `.github/workflows/ci.yml` 추가 및 이벤트/Job 구조 정의
 - [x] Gradle 캐시 및 Setup Java 스텝 구성
-- [x] `./gradlew test --stacktrace` 스텝 추가
-- [x] `./gradlew check --stacktrace` 스텝 추가
+- [x] `./gradlew check --stacktrace --no-daemon` 스텝으로 테스트+정적분석 실행
 - [x] 실패 시 Job summary에 안내 메시지 작성
 - [x] 로컬 `./gradlew test` 실행 결과 기록
 - [x] `deploy-dev-lambda.yml`에 테스트 스텝 삽입
@@ -15,6 +14,7 @@
 |------|---------|--------|------|
 | 1 | `./gradlew test` | PASS | 2026-03-28 |
 | 2 | `./gradlew test` | PASS | 2026-03-28 |
+| 3 | `./gradlew test` | PASS | 2026-03-28 |
 
 ## Notes
 - Observation: Workflow는 PR/Push 모두에서 실행되므로 concurrency group 충돌이 없도록 기본 설정을 사용한다.

--- a/docs/specs/20260328-issue-198-ci-flow/tasks.md
+++ b/docs/specs/20260328-issue-198-ci-flow/tasks.md
@@ -1,0 +1,17 @@
+# Tasks – Issue #198 CI Gate
+
+## Checklist
+- [x] `.github/workflows/ci.yml` 추가 및 이벤트/Job 구조 정의
+- [x] Gradle 캐시 및 Setup Java 스텝 구성
+- [x] `./gradlew test --stacktrace` 스텝 추가
+- [x] `./gradlew check --stacktrace` 스텝 추가
+- [x] 실패 시 Job summary에 안내 메시지 작성
+- [x] 로컬 `./gradlew test` 실행 결과 기록
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test` | PASS | 2026-03-28 |
+
+## Notes
+- Observation: Workflow는 PR/Push 모두에서 실행되므로 concurrency group 충돌이 없도록 기본 설정을 사용한다.


### PR DESCRIPTION
### 참고 사항
- Spec: docs/specs/20260328-issue-198-ci-flow/
- PR/Push용 CI 워크플로우(ci-gradle)가 dev/main에 대한 테스트와 정적 분석을 자동 실행합니다.
- dev/prod Lambda 배포 workflow에도 ./gradlew test --stacktrace --no-daemon 단계를 추가해 배포 전에 실패를 포착합니다.

### 🔗 Related Issue

