### PR TITLE
209 docs: README 서버리스 구조 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@
 **척척학사**는 학생들이 학교 포털과 연동하여 본인의 이수 현황과 졸업 요건을 손쉽게 확인하고 관리할 수 있도록 도와주는 서비스입니다.
 
 > 기존에는 학생들이 졸업 요건을 직접 확인하며 수작업으로 비교해야 했지만,  
-> 척척학사는 이를 **학교 포털과 실시간 연동**, **자동 분석**, **시각적 안내** 기능으로 효율화합니다.
+> 척척학사는 이를 **학교 포털과 비동기 연동**, **자동 분석**, **시각적 안내** 기능으로 효율화합니다.
 
-- ✅ **4,000명 이상** 수원대 재학생 사용 중
-- 🔁 **학교 포털과 실시간 동기화**
+- ✅ **6,000명 이상** 수원대 재학생 사용 중
+- 🔁 **학교 포털과 비동기 연동 + job_id 상태 조회**
 - 🧠 **졸업 요건 자동 분석 및 부족 항목 안내**
 
 ---
@@ -45,6 +45,7 @@
 - 포털 연동을 통한 학점·성적·커리큘럼 실시간 동기화
 - 졸업 요건과 사용자 학사 정보 자동 비교
 - 부족한 학점 및 조건 자동 분석 및 안내
+- job_id 기반 비동기 파이프라인: 요청 수락 -> SQS outbox -> 상태/요약 조회 -> 자동 분석 반영
 
 ---
 
@@ -72,10 +73,13 @@
 - JPA, Hibernate
 
 ### Infra
-- AWS ASG(EC2), ALB, Route53, ACM ...
-- PostgreSQL (Supabase 연동: BaaS 인증/스토리지 활용)
-- Redis, Caffeine 
-- Docker, Nginx
+- AWS API Gateway (HTTP API v2) + AWS Lambda (Spring Boot) + Route53/ACM
+- AWS SQS + HMAC Callback 파이프라인 (스크래핑 워커 연동)
+- PostgreSQL (Supabase 연동) + Caffeine / Redis 캐시
+- Observability: Sentry, Grafana Cloud(OTLP), CloudWatch Logs
+- Docker 기반 Lambda 패키징 및 GitHub Actions 배포
+
+> 장애 롤백 대비를 위해 기존 EC2 ASG 경로는 보조 배포선으로 유지합니다.
 
 ### Tools
 - Git, GitHub
@@ -86,9 +90,32 @@
 
 ## 아키텍처
 
-<p align="center">
-  <img width="1141" height="692" alt="Image" src="https://github.com/user-attachments/assets/192c997a-06ef-4de7-8a64-a32f9c0cea51" />
-</p>
+```mermaid
+flowchart LR
+    Client["Web / Android Client"]
+    APIGW["API Gateway (HTTP API v2)"]
+    Lambda["AWS Lambda (Spring Boot)"]
+    Domain["Domain & Graduation Analysis"]
+    DB[(PostgreSQL)]
+    Cache[(Caffeine / Redis)]
+    Outbox["Scrape Job & Outbox"]
+    SQS["AWS SQS Queue"]
+    Worker["Scraping Worker"]
+    Portal["University Portal"]
+    Callback["Callback API (HMAC)"]
+
+    Client --> APIGW --> Lambda --> Domain
+    Domain --> DB
+    Domain --> Cache
+    Lambda -->|idempotent job_id| Outbox --> SQS --> Worker --> Portal
+    Worker --> Callback --> Lambda
+    Callback --> Domain
+    Callback --> DB
+```
+
+1. 사용자는 `Idempotency-Key`와 함께 비동기 포털 연동을 요청하고, Lambda는 job_id와 polling endpoint를 즉시 반환합니다.
+2. 스크래핑 요청은 Scrape Job Outbox -> AWS SQS -> 전용 워커 -> 학교 포털 순으로 전달되어 병목을 분리합니다.
+3. 워커는 HMAC 서명된 callback으로 결과를 전달하고, Lambda는 졸업 요건 데이터/캐시를 갱신한 뒤 상태/요약 API에 반영합니다.
 
 ---
 
@@ -171,9 +198,11 @@ fix: 사용자 정보 누락 버그 해결
 👉 [척척학사 블로그 시리즈 전체보기](https://velog.io/@pp8817/series/척척학사)
 
 <details>
-<summary><b>🚀 성능 최적화 & 트러블슈팅</b></summary>
+<summary><b>성능 최적화 & 트러블슈팅</b></summary>
 <div markdown="1">
 
+- [척척학사 포털 연동 과정 16초를 0.8초로 94.8% 개선한 과정](https://velog.io/@pp8817/척척학사-포털-연동-과정-16초를-0.8초로-94.8-개선한-과정)
+- [트래픽 피크형 서비스의 운영 구조를 요청 기반 구조로 바꾼 과정](https://velog.io/@pp8817/트래픽-피크형-서비스의-운영-구조를-요청-기반-구조로-바꾼-과정)
 - [ API 성능 튜닝: P6Spy 쿼리 분석부터 인덱싱 & 캐싱까지](https://velog.io/@pp8817/척척학사-API-성능-튜닝)
 - [크롤링 로직 비동기 처리 대신 Redis 캐싱 도입한 이유](https://velog.io/@pp8817/척척학사-크롤링-로직-비동기-처리-대신-Redis-캐싱을-도입한-이유)
 - [포털 데이터 Redis 캐싱 전략 도입기](https://velog.io/@pp8817/척척학사-포털-데이터-Redis-캐싱-전략-도입기)
@@ -185,9 +214,11 @@ fix: 사용자 정보 누락 버그 해결
 </details>
 
 <details>
-<summary><b>🛠️ 아키텍처 & 인프라</b></summary>
+<summary><b>아키텍처 & 인프라</b></summary>
 <div markdown="1">
 
+- [척척학사 AWS EC2 주기적 사망 원인 분석](https://velog.io/@pp8817/척척학사-AWS-EC2-주기적-사망-원인-분석)
+- [척척학사 Lambda 서버리스 전환 후 처리량 한계 분석](https://velog.io/@pp8817/척척학사-Lambda-서버리스-전환-후-처리량-한계-분석)
 - [Next.js 기반 서버를 Spring으로 갈아엎은 이유](https://velog.io/@pp8817/척척학사-Next.js-Spring-Boot-백엔드-마이그레이션-회고)
 - [ELK의 오버엔지니어링을 걷어내고: Grafana Loki와 Sentry로 로그 스택 재설계하기](https://velog.io/@pp8817/척척학사-로그-시스템-리빌드-ELK-Grafana-Loki)
 - [CI/CD 적용 과정 With GitHub Actions](https://velog.io/@pp8817/척척학사-GitHub-Actions-적용)
@@ -199,7 +230,7 @@ fix: 사용자 정보 누락 버그 해결
 </details>
 
 <details>
-<summary><b>💡 기능 구현 & 설계</b></summary>
+<summary><b>기능 구현 & 설계</b></summary>
 <div markdown="1">
 
 - [Supabase를 알아보자 With Java, Spring](https://velog.io/@pp8817/DB-Supabase를-알아보자-With-Java-Spring)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
   <img src="https://github.com/user-attachments/assets/1f464920-a223-45da-9cf1-4d8c2bd04cd6" width="800" alt="기능 소개2" />
 </p>
 
-- 포털 연동을 통한 학점·성적·커리큘럼 실시간 동기화
+- 포털 연동을 통한 학점·성적·커리큘럼 비동기 동기화
 - 졸업 요건과 사용자 학사 정보 자동 비교
 - 부족한 학점 및 조건 자동 분석 및 안내
-- job_id 기반 비동기 파이프라인: 요청 수락 -> SQS outbox -> 상태/요약 조회 -> 자동 분석 반영
+- job_id 기반 비동기 파이프라인: 요청 접수 -> Outbox 패턴으로 SQS에 발행 -> 비동기 처리 후 결과 반영
 
 ---
 
@@ -102,20 +102,19 @@ flowchart LR
     SQS["AWS SQS Queue"]
     Worker["Scraping Worker"]
     Portal["University Portal"]
-    Callback["Callback API (HMAC)"]
 
-    Client --> APIGW --> Lambda --> Domain
+    Client --> APIGW --> Lambda
+    Lambda --> Domain
     Domain --> DB
     Domain --> Cache
     Lambda -->|idempotent job_id| Outbox --> SQS --> Worker --> Portal
-    Worker --> Callback --> Lambda
-    Callback --> Domain
-    Callback --> DB
+    Worker -- HMAC signed callback --> APIGW
+    APIGW --> Lambda
 ```
 
 1. 사용자는 `Idempotency-Key`와 함께 비동기 포털 연동을 요청하고, Lambda는 job_id와 polling endpoint를 즉시 반환합니다.
 2. 스크래핑 요청은 Scrape Job Outbox -> AWS SQS -> 전용 워커 -> 학교 포털 순으로 전달되어 병목을 분리합니다.
-3. 워커는 HMAC 서명된 callback으로 결과를 전달하고, Lambda는 졸업 요건 데이터/캐시를 갱신한 뒤 상태/요약 API에 반영합니다.
+3. 워커는 HMAC 서명된 callback을 API Gateway로 보내고, Lambda는 이를 처리해 졸업 요건 데이터/캐시를 갱신한 뒤 상태/요약 API에 반영합니다.
 
 ---
 

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/InternalScrapeResultController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/InternalScrapeResultController.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.portal.controller;
 
 import com.chukchuk.haksa.application.portal.ScrapeResultCallbackService;
+import com.chukchuk.haksa.domain.portal.controller.docs.PortalLinkCallbackControllerDocs;
 import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/internal/scrape-results")
 @RequiredArgsConstructor
-public class InternalScrapeResultController {
+public class InternalScrapeResultController implements PortalLinkCallbackControllerDocs {
 
     private final ScrapeResultCallbackService scrapeResultCallbackService;
 

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryController.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.portal.controller;
 
 import com.chukchuk.haksa.application.portal.PortalLinkJobQueryService;
+import com.chukchuk.haksa.domain.portal.controller.docs.PortalLinkQueryControllerDocs;
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/portal/link/jobs")
 @RequiredArgsConstructor
-public class PortalJobQueryController {
+public class PortalJobQueryController implements PortalLinkQueryControllerDocs {
 
     private final PortalLinkJobQueryService portalLinkJobQueryService;
 

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkController.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.portal.controller;
 
 import com.chukchuk.haksa.application.portal.PortalLinkJobService;
+import com.chukchuk.haksa.domain.portal.controller.docs.PortalLinkCommandControllerDocs;
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/portal/link")
 @RequiredArgsConstructor
-public class PortalLinkController {
+public class PortalLinkController implements PortalLinkCommandControllerDocs {
 
     private final PortalLinkJobService portalLinkJobService;
 

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
@@ -1,0 +1,42 @@
+package com.chukchuk.haksa.domain.portal.controller.docs;
+
+import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Portal Link", description = "비동기 포털 연동 job 생성 및 폴링 안내 | [Internal] Callback")
+public interface PortalLinkCallbackControllerDocs {
+
+    @Operation(
+            summary = "[Internal] 스크래핑 결과 콜백 수신",
+            description = "스크래핑 워커가 API Gateway를 통해 전달하는 결과 payload를 검증하고 DB에 반영합니다.\n"
+                    + "HMAC 서명 규칙: signature = HMAC_SHA256(\"{timestamp}.{rawBody}\").",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "콜백 처리 완료",
+                            content = @Content(schema = @Schema(implementation = MessageOnlyResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "서명 검증 실패 (INVALID_CALLBACK_SIGNATURE)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "404", description = "job 미존재 (PORTAL_JOB_NOT_FOUND)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> handleCallback(
+            @RequestBody String rawBody,
+            @RequestHeader("X-Timestamp")
+            @Parameter(name = "X-Timestamp", description = "epoch millis (UTC)", in = ParameterIn.HEADER, required = true)
+            String timestamp,
+            @RequestHeader("X-Signature")
+            @Parameter(name = "X-Signature", description = "HMAC-SHA256 서명 값", in = ParameterIn.HEADER, required = true)
+            String signature
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCommandControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCommandControllerDocs.java
@@ -1,0 +1,46 @@
+package com.chukchuk.haksa.domain.portal.controller.docs;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Portal Link", description = "비동기 포털 연동 job 생성 및 폴링 안내")
+public interface PortalLinkCommandControllerDocs {
+
+    @Operation(
+            summary = "포털 연동 job 생성",
+            description = "포털 자격 증명을 받아 비동기 스크래핑 job을 생성하고 polling endpoint를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "202", description = "요청 수락",
+                            content = @Content(schema = @Schema(implementation = PortalLinkDto.AcceptedResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 입력 (INVALID_ARGUMENT)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "401", description = "자격 증명 오류 (PORTAL_LOGIN_FAILED)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "409", description = "중복 요청 (SCRAPE_JOB_DUPLICATED)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<PortalLinkDto.AcceptedResponse>> createPortalLinkJob(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestHeader("Idempotency-Key")
+            @Parameter(name = "Idempotency-Key", description = "동일 요청 deduplication 용 키", in = ParameterIn.HEADER, required = true)
+            String idempotencyKey,
+            @Valid @RequestBody PortalLinkDto.LinkRequest request
+    );
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
@@ -1,0 +1,51 @@
+package com.chukchuk.haksa.domain.portal.controller.docs;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Portal Link", description = "비동기 포털 연동 job 생성 및 폴링 안내")
+public interface PortalLinkQueryControllerDocs {
+
+    @Operation(
+            summary = "비동기 job 상태 조회",
+            description = "요청된 job_id의 진행 상태, 오류 코드, 완료 시점 등을 제공합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "상태 조회 성공",
+                            content = @Content(schema = @Schema(implementation = PortalLinkDto.JobStatusResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "job 미존재 또는 권한 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<PortalLinkDto.JobStatusResponse>> getJobStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String jobId
+    );
+
+    @Operation(
+            summary = "비동기 job 요약 조회",
+            description = "job이 성공적으로 완료된 경우 최신 학생 요약 데이터를 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "요약 조회 성공",
+                            content = @Content(schema = @Schema(implementation = PortalLinkDto.JobSummaryResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "job 미존재 또는 권한 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<PortalLinkDto.JobSummaryResponse>> getJobSummary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String jobId
+    );
+}


### PR DESCRIPTION
### 참고 사항
- README 소개/주요 기능/기술 스택 문구를 비동기 job 파이프라인 기준으로 정리했습니다.
- 기존 스크린샷 이미지를 제거하고 Mermaid 다이어그램으로 Lambda+SQS+callback 구조를 설명했습니다.
- 요청받은 4개의 블로그 글을 섹션별로 추가하고, 섹션 제목의 이모지를 제거했습니다.

### 🔗 Related Issue
- Closes #209
