### PR TITLE
Hotfix/211 사용자 탈퇴 시 StudentAcademicRecord 삭제 오류 수정 및 학생 정보 삭제 코드 일원화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
@@ -29,4 +29,6 @@ public interface SemesterAcademicRecordRepository extends JpaRepository<Semester
     List<SemesterAcademicRecord> findByStudentId(UUID studentId); //studentID로 data 얻어오기
 
     List<SemesterAcademicRecord> findByStudentIdOrderByYearDescSemesterDesc(UUID studentId);
+
+    void deleteByStudentId(UUID studentId);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
@@ -28,4 +28,6 @@ public interface StudentCourseRepository extends JpaRepository<StudentCourse, Lo
     );
 
     List<StudentCourse> findByStudent(Student student);
+
+    void deleteByStudentId(UUID studentId);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
@@ -76,20 +76,6 @@ public class Student extends BaseEntity {
     @OneToMany(mappedBy = "student", cascade = {CascadeType.PERSIST, REMOVE}, orphanRemoval = true)
     private List<StudentCourse> studentCourses = new ArrayList<>();
 
-    /* Using Method */
-
-    // 회원 정보 초기화
-    public void resetAcademicData() {
-        // 학기별 성적 기록 삭제
-        this.semesterAcademicRecords.clear();
-
-        // 수강 과목 기록 삭제
-        this.studentCourses.clear();
-
-        // 누적 성적 기록 삭제
-//        this.studentAcademicRecord = null;
-    }
-
     @Builder
     public Student(String studentCode, String name, Department department, Department major, Department secondaryMajor,
                    Integer admissionYear, Integer semesterEnrolled, Boolean isTransferStudent, Boolean isGraduated,

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
@@ -1,6 +1,8 @@
 package com.chukchuk.haksa.domain.student.service;
 
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,22 +18,23 @@ import java.util.UUID;
 public class StudentDeletionService {
 
     private final StudentAcademicRecordRepository studentAcademicRecordRepository;
+    private final SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+    private final StudentCourseRepository studentCourseRepository;
     private final StudentRepository studentRepository;
 
     @Transactional
-    public void deleteByStudentId(UUID studentId) {
-        if (studentId == null) {
-            return;
-        }
-
-        Student student = studentRepository.findById(studentId).orElse(null);
+    public void deleteByStudent(Student student) {
         if (student == null) {
-            log.warn("[BIZ] student.deletion.skip studentId={} reason=missing_student", studentId);
+            log.warn("[BIZ] student.deletion.skip, reason=unconnected_user");
             return;
         }
 
-        student.resetAcademicData();
-        studentAcademicRecordRepository.deleteByStudentId(studentId);
+        UUID studentId = student.getId();
+        if (studentId != null) {
+            studentCourseRepository.deleteByStudentId(studentId);
+            semesterAcademicRecordRepository.deleteByStudentId(studentId);
+            studentAcademicRecordRepository.deleteByStudentId(studentId);
+        }
         studentRepository.delete(student);
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
@@ -1,0 +1,37 @@
+package com.chukchuk.haksa.domain.student.service;
+
+import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentDeletionService {
+
+    private final StudentAcademicRecordRepository studentAcademicRecordRepository;
+    private final StudentRepository studentRepository;
+
+    @Transactional
+    public void deleteByStudentId(UUID studentId) {
+        if (studentId == null) {
+            return;
+        }
+
+        Student student = studentRepository.findById(studentId).orElse(null);
+        if (student == null) {
+            log.warn("[BIZ] student.deletion.skip studentId={} reason=missing_student", studentId);
+            return;
+        }
+
+        student.resetAcademicData();
+        studentAcademicRecordRepository.deleteByStudentId(studentId);
+        studentRepository.delete(student);
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentService.java
@@ -1,6 +1,8 @@
 package com.chukchuk.haksa.domain.student.service;
 
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
 import com.chukchuk.haksa.domain.student.dto.StudentDto;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.repository.StudentRepository;
@@ -25,6 +27,8 @@ public class StudentService {
     private final StudentRepository studentRepository;
     private final UserService userService;
     private final StudentAcademicRecordRepository studentAcademicRecordRepository;
+    private final SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+    private final StudentCourseRepository studentCourseRepository;
 
     public Student getStudentById(UUID studentId) {
         return studentRepository.findById(studentId)
@@ -79,8 +83,8 @@ public class StudentService {
 
     @Transactional
     public void resetBy(UUID studentId) {
-        Student student = getStudentById(studentId);
-        student.resetAcademicData();
+        studentCourseRepository.deleteByStudentId(studentId);
+        semesterAcademicRecordRepository.deleteByStudentId(studentId);
         studentAcademicRecordRepository.deleteByStudentId(studentId);
 
         log.info("[BIZ] student.reset.done studentId={}", studentId);

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -69,7 +69,7 @@ public class UserService {
         Student student = user.getStudent();
         UUID studentId = student != null ? student.getId() : null;
 
-        studentDeletionService.deleteByStudentId(studentId);
+        studentDeletionService.deleteByStudent(student);
         if (studentId != null) {
             academicCache.deleteAllByStudentId(studentId);
         }

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.auth.dto.AuthDto;
 import com.chukchuk.haksa.domain.auth.service.RefreshTokenService;
 import com.chukchuk.haksa.domain.cache.AcademicCache;
 import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.service.StudentDeletionService;
 import com.chukchuk.haksa.domain.user.dto.UserDto;
 import com.chukchuk.haksa.domain.user.model.SocialAccount;
 import com.chukchuk.haksa.domain.user.model.User;
@@ -35,6 +36,7 @@ public class UserService {
     private final RefreshTokenService refreshTokenService;
     private final AcademicCache academicCache;
     private final AuthTokenCache authTokenCache;
+    private final StudentDeletionService studentDeletionService;
 
     private final Map<OidcProvider, OidcService> oidcServices;
 
@@ -64,8 +66,13 @@ public class UserService {
     public void deleteUserById(UUID userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
-        UUID studentId = user.getStudent().getId();
-        academicCache.deleteAllByStudentId(studentId);
+        Student student = user.getStudent();
+        UUID studentId = student != null ? student.getId() : null;
+
+        studentDeletionService.deleteByStudentId(studentId);
+        if (studentId != null) {
+            academicCache.deleteAllByStudentId(studentId);
+        }
         authTokenCache.evictByUserId(userId.toString());
         socialAccountRepository.deleteByUser(user);
         userRepository.delete(user);

--- a/src/test/java/com/chukchuk/haksa/domain/student/service/StudentServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/student/service/StudentServiceUnitTests.java
@@ -1,6 +1,8 @@
 package com.chukchuk.haksa.domain.student.service;
 
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
 import com.chukchuk.haksa.domain.department.model.Department;
 import com.chukchuk.haksa.domain.student.dto.StudentDto;
 import com.chukchuk.haksa.domain.student.model.Student;
@@ -39,6 +41,12 @@ class StudentServiceUnitTests {
 
     @Mock
     private StudentAcademicRecordRepository studentAcademicRecordRepository;
+
+    @Mock
+    private SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+
+    @Mock
+    private StudentCourseRepository studentCourseRepository;
 
     @InjectMocks
     private StudentService studentService;
@@ -168,15 +176,16 @@ class StudentServiceUnitTests {
     }
 
     @Test
-    @DisplayName("학생 데이터 초기화 시 학기/과목을 reset하고 학업요약을 삭제한다")
-    void resetBy_resetsAndDeletesAcademicSummary() {
+    @DisplayName("학생 데이터 초기화 시 학기/과목/학업요약을 벌크 삭제한다")
+    void resetBy_deletesAcademicRecordsInBulk() {
         UUID studentId = UUID.randomUUID();
         Student student = org.mockito.Mockito.mock(Student.class);
         when(studentRepository.findById(studentId)).thenReturn(Optional.of(student));
 
         studentService.resetBy(studentId);
 
-        verify(student).resetAcademicData();
+        verify(studentCourseRepository).deleteByStudentId(studentId);
+        verify(semesterAcademicRecordRepository).deleteByStudentId(studentId);
         verify(studentAcademicRecordRepository).deleteByStudentId(studentId);
     }
 

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.chukchuk.haksa.domain.user.service;
+
+import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
+import com.chukchuk.haksa.domain.academic.record.model.StudentAcademicRecord;
+import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.course.model.Course;
+import com.chukchuk.haksa.domain.course.model.CourseOffering;
+import com.chukchuk.haksa.domain.course.model.EvaluationType;
+import com.chukchuk.haksa.domain.course.model.FacultyDivision;
+import com.chukchuk.haksa.domain.course.repository.CourseOfferingRepository;
+import com.chukchuk.haksa.domain.course.repository.CourseRepository;
+import com.chukchuk.haksa.domain.department.model.Department;
+import com.chukchuk.haksa.domain.department.repository.DepartmentRepository;
+import com.chukchuk.haksa.domain.student.model.Grade;
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.model.StudentStatus;
+import com.chukchuk.haksa.domain.student.repository.StudentRepository;
+import com.chukchuk.haksa.domain.user.model.User;
+import com.chukchuk.haksa.domain.user.repository.UserRepository;
+import com.chukchuk.haksa.domain.cache.AcademicCache;
+import com.chukchuk.haksa.global.security.cache.AuthTokenCache;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private UserRepository userRepository;
+    @SpyBean
+    private StudentRepository studentRepository;
+    @SpyBean
+    private StudentAcademicRecordRepository studentAcademicRecordRepository;
+    @Autowired
+    private SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+    @Autowired
+    private StudentCourseRepository studentCourseRepository;
+    @Autowired
+    private DepartmentRepository departmentRepository;
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private CourseOfferingRepository courseOfferingRepository;
+
+    @MockBean
+    private AcademicCache academicCache;
+    @MockBean
+    private AuthTokenCache authTokenCache;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("사용자가 탈퇴하면 관련된 학생 및 학적 정보도 삭제된다")
+    void deleteUser_removesStudentAndAllAssociations() {
+        User user = userRepository.save(User.builder()
+                .email("test@haksa.com")
+                .profileNickname("tester")
+                .build());
+        Student student = createStudent(user);
+
+        persistStudentAssociations(student);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        userService.deleteUserById(user.getId());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        UUID studentId = student.getId();
+        assertThat(userRepository.findById(user.getId())).isEmpty();
+        assertThat(studentRepository.findById(studentId)).isEmpty();
+        assertThat(studentAcademicRecordRepository.findByStudentId(studentId)).isEmpty();
+        assertThat(semesterAcademicRecordRepository.findByStudentId(studentId)).isEmpty();
+        assertThat(studentCourseRepository.findAll()).isEmpty();
+
+        verify(academicCache).deleteAllByStudentId(studentId);
+        verify(authTokenCache).evictByUserId(user.getId().toString());
+    }
+
+    @Test
+    @DisplayName("연동하지 않은 사용자의 탈퇴에서는 학생 관련 정보는 아무 처리 되지 않는다")
+    void deleteUser_withoutStudent_doesNotFail() {
+        User user = userRepository.save(User.builder()
+                .email("orphan@haksa.com")
+                .profileNickname("orphan")
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        userService.deleteUserById(user.getId());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(userRepository.findById(user.getId())).isEmpty();
+        verify(academicCache, never()).deleteAllByStudentId(any());
+        verify(authTokenCache).evictByUserId(user.getId().toString());
+        verify(studentRepository, never()).delete(any());
+        verify(studentAcademicRecordRepository, never()).deleteByStudentId(any());
+    }
+
+    private Student createStudent(User user) {
+        Department department = departmentRepository.save(new Department("2000513", "컴퓨터학과"));
+        Student student = Student.builder()
+                .studentCode("20260001")
+                .name("학생")
+                .department(department)
+                .major(null)
+                .secondaryMajor(null)
+                .admissionYear(2024)
+                .semesterEnrolled(1)
+                .isTransferStudent(false)
+                .isGraduated(false)
+                .status(StudentStatus.재학)
+                .gradeLevel(1)
+                .completedSemesters(0)
+                .admissionType("수시")
+                .user(user)
+                .build();
+        return studentRepository.save(student);
+    }
+
+    private void persistStudentAssociations(Student student) {
+        studentAcademicRecordRepository.save(new StudentAcademicRecord(
+                student,
+                30,
+                24,
+                BigDecimal.valueOf(3.8),
+                BigDecimal.valueOf(85)
+        ));
+
+        SemesterAcademicRecord semesterRecord = new SemesterAcademicRecord(
+                student,
+                2024,
+                1,
+                15,
+                15,
+                BigDecimal.valueOf(3.9),
+                BigDecimal.valueOf(88),
+                BigDecimal.valueOf(3.9),
+                1,
+                30
+        );
+        student.addSemesterRecord(semesterRecord);
+        semesterAcademicRecordRepository.save(semesterRecord);
+
+        Course course = courseRepository.save(new Course("CS101", "자료구조"));
+        CourseOffering offering = courseOfferingRepository.save(new CourseOffering(
+                1,
+                false,
+                2024,
+                1,
+                "공과대학",
+                "A",
+                "월1",
+                null,
+                3,
+                EvaluationType.ABSOLUTE,
+                FacultyDivision.전선,
+                course,
+                null,
+                student.getDepartment(),
+                null
+        ));
+
+        StudentCourse studentCourse = new StudentCourse(
+                student,
+                offering,
+                new Grade(GradeType.A0),
+                3,
+                false,
+                95,
+                false
+        );
+        student.addStudentCourse(studentCourse);
+        studentCourseRepository.save(studentCourse);
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.auth.dto.AuthDto;
 import com.chukchuk.haksa.domain.auth.service.RefreshTokenService;
 import com.chukchuk.haksa.domain.cache.AcademicCache;
 import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.service.StudentDeletionService;
 import com.chukchuk.haksa.domain.user.dto.UserDto;
 import com.chukchuk.haksa.domain.user.model.SocialAccount;
 import com.chukchuk.haksa.domain.user.model.User;
@@ -62,6 +63,9 @@ class UserServiceUnitTests {
 
     @Mock
     private OidcService oidcService;
+
+    @Mock
+    private StudentDeletionService studentDeletionService;
 
     @Test
     @DisplayName("userId로 사용자를 조회할 수 있다")
@@ -329,6 +333,7 @@ class UserServiceUnitTests {
                 refreshTokenService,
                 academicCache,
                 authTokenCache,
+                studentDeletionService,
                 Map.of(OidcProvider.KAKAO, oidcService)
         );
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,59 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:lambda-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;NON_KEYWORDS=YEAR,SEMESTER
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create-drop
+
+security:
+  jwt:
+    secret: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    access-expiration: 3600
+    refresh-expiration: 86400
+  appKey: test-app-key
+  nativeAppKey: test-native-key
+
+crawler:
+  base-url: https://example.com
+
+scraping:
+  mode: async
+  job:
+    queue-url: https://sqs.ap-northeast-2.amazonaws.com/000000000000/test-queue
+  callback:
+    hmac-secret: test-callback-secret
+    allowed-skew-seconds: 300
+  scheduler:
+    enabled: true
+  publisher:
+    enabled: true
+    fixed-delay-ms: 1000
+    batch-size: 10
+    max-attempts: 3
+    initial-backoff-seconds: 1
+    max-backoff-seconds: 10
+    api-call-timeout-seconds: 5
+    api-call-attempt-timeout-seconds: 2
+  stale:
+    enabled: true
+    fixed-delay-ms: 1000
+    timeout-seconds: 60
+    batch-size: 10
+
+sentry:
+  dsn: ""
+  environment: test
+
+swagger:
+  server-url: http://localhost
+
+server:
+  port: 0
+
+LOCAL_DB_URL: jdbc:h2:mem:lambda-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+LOCAL_DB_USERNAME: sa
+LOCAL_DB_PASSWORD:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
기존 사용자 탈퇴 시 StudentAcademicRecord가 외래키 참조 문제로 인해 삭제되지 않음.

삭제를 추가하면서 StudentDeletionService에서 학생 및 학적 삭제 로직을 응집시킴.

### 테스트
테스트는 db 까지 확인하는 통합테스트로 작성.
캐시 관련된 값들은 테스트 하지 않음.

### 🔗 Related Issue
Closes #211 