### PR TITLE
215 feat: 스크래핑 콜백 트랜잭션 경계 재구성 및 job 상태 전이 정비

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@
 - Move business logic gradually into the domain layer.
 - Gradually reduce transaction scope.
 - Split commits by meaningful units (feature, refactor, test).
+- 커밋은 반드시 작업 최소 단위(기능/버그 수정/테스트 추가 등)별로 분리해라.
 
 ### Git Branch Naming
 - 모든 작업 브랜치는 사용자가 지정한 GitHub Issue 번호와 1:1로 매핑되며, 브랜치명은 항상 `feat/{github-issue-number}` 형식을 따른다. (예: `feat/123`)

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation 'io.opentelemetry:opentelemetry-sdk'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
     implementation 'software.amazon.awssdk:sqs:2.31.72'
+    implementation 'software.amazon.awssdk:s3:2.31.72'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docs/specs/20260410-s3-callback/clarify.md
+++ b/docs/specs/20260410-s3-callback/clarify.md
@@ -12,7 +12,7 @@
 ## Decisions
 | # | Decision | Reason | Date |
 |---|----------|--------|------|
-| 1 | callback 최소 동기 처리는 검증 + 상태 저장까지만 수행, S3 read는 비동기 처리 파이프라인으로 분리 | timeout 리스크 경감 및 스크래핑 서버 SLA 확보 | 2026-04-10 |
+| 1 | 콜백 요청 내에서 검증 → 상태 저장 → S3 read → JSON/schema 검증 → DB 반영까지 모두 동기 처리한다. 별도 비동기 파이프라인은 두지 않는다. | 워커 타임아웃(25초) 내 후처리를 끝내고 duplicate retry 시 멱등성을 보장하기 위함 | 2026-04-10 |
 | 2 | 2026-04-10 사용자 "작업 시작" 지시에 따라 OK to implement 승인 확보 | Phase 2 진행 승인 | 2026-04-10 |
 
 ## Risks / Unknowns
@@ -24,4 +24,4 @@
   - Mitigation: DB 레벨 unique constraint + version check + 멱등 저장 로직
 
 ## Follow-ups
-- [ ] Open 질문 1~5 답변 확보 (Owner: BE 팀)
+- [x] Open 질문 1~5 답변 확보 (Owner: BE 팀)

--- a/docs/specs/20260410-s3-callback/clarify.md
+++ b/docs/specs/20260410-s3-callback/clarify.md
@@ -1,0 +1,27 @@
+# Clarify Template
+
+## Open Questions
+| # | Question | Owner | Status | Decision |
+|---|----------|-------|--------|----------|
+| 1 | S3 key 신뢰 수준: prefix/validation 규칙을 어떻게 제한할지? | BE 팀 | Decided | `s3_key`는 신뢰하지 않는다. 백엔드는 `SCRAPE_RESULT_PREFIX` 하위 key만 허용하고, key 정규화 후 `..`, leading `/`, URL 형태, 다른 prefix를 거부한다. 권장 key 형식은 `develop-shadow/{jobId}/result.json`이며, key 내부 `jobId`와 요청 `jobId`도 매칭한다. |
+| 2 | S3 read 실패 시 job 상태를 즉시 `FAILED`로 전환할지, 재시도 큐를 둘지? | BE 팀 | Decided | 별도 재시도 큐는 두지 않는다. `NoSuchKey`, S3 `5xx`, timeout은 3회 exponential backoff 후 `FAILED_S3_READ`로 전환하고, `AccessDenied` 및 validation 실패는 즉시 실패 처리한다. |
+| 3 | 기존 payload 직접 수신 방식과의 호환이 필요한가? 필요 시 기간/전환 전략? | BE 팀 | Decided | 기존 payload 직접 수신 방식은 완전히 폐기한다. `s3_key` 누락 또는 direct payload 요청은 계약 위반으로 실패 처리하며, 롤백은 워커/IaC 배포 롤백으로 대응한다. |
+| 4 | 결과 JSON schema 버전을 어디에서 관리하고 후방 호환성을 어떻게 보장할지? | BE 팀 | Decided | 결과 JSON에는 필수 `schema_version`을 포함한다. schema 정의/검증은 백엔드 repo에서 관리하며, additive 변경만 허용하고 breaking change는 `v2` 등 새 버전으로 분리한다. |
+| 5 | after-processing 실패 시 상태 반영 정책 (예: `FAILED_POST_PROCESSING`)이 필요한가? | BE 팀 | Decided | after-processing 실패를 구분하기 위해 `FAILED_POST_PROCESSING`을 추가한다. S3 read 실패는 `FAILED_S3_READ`, JSON/schema 실패는 `FAILED_RESULT_SCHEMA`, 후처리 실패는 `FAILED_POST_PROCESSING`으로 기록한다. |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | callback 최소 동기 처리는 검증 + 상태 저장까지만 수행, S3 read는 비동기 처리 파이프라인으로 분리 | timeout 리스크 경감 및 스크래핑 서버 SLA 확보 | 2026-04-10 |
+| 2 | 2026-04-10 사용자 "작업 시작" 지시에 따라 OK to implement 승인 확보 | Phase 2 진행 승인 | 2026-04-10 |
+
+## Risks / Unknowns
+- Item: S3 key에 대한 인증/권한 검증 미흡 시 외부 리소스 접근 가능성
+  - Impact: 악의적 key 주입으로 시스템이 임의 파일을 다운로드할 수 있음
+  - Mitigation: 허용 prefix/bucket allowlist, key validate, signature 검증
+- Item: duplicate callback이 빈번할 경우 상태 전이 race condition
+  - Impact: job 상태가 예기치 않게 덮어써질 수 있음
+  - Mitigation: DB 레벨 unique constraint + version check + 멱등 저장 로직
+
+## Follow-ups
+- [ ] Open 질문 1~5 답변 확보 (Owner: BE 팀)

--- a/docs/specs/20260410-s3-callback/plan.md
+++ b/docs/specs/20260410-s3-callback/plan.md
@@ -1,0 +1,45 @@
+# Plan Template
+
+## Architecture / Layering
+- Domain impact:
+  - Job 엔티티에 `callbackAttempt`, `callbackReceivedAt`, `resultS3Key`를 보관하고 `job_id + attempt` 멱등 판단 메서드 추가
+  - `FAILED_S3_READ`, `FAILED_RESULT_SCHEMA`, `FAILED_POST_PROCESSING` 상태 코드 기록 규칙 정비
+- Application orchestration:
+  - `/internal/scrape-results` 서비스에서 시그니처 검증 → 멱등 체크 → `result_s3_key` 검증 → S3 HEAD/GET → JSON/schema 검증 → PortalCallbackPostProcessor 호출까지 **동기 처리**
+  - duplicate 요청은 `job_id + attempt` 기준으로 즉시 200/202 응답
+- Infrastructure touchpoints:
+  - AWS SDK S3 client에 HEAD/GET + retry 래퍼(`ScrapeResultResultStoreClient`) 구현, prefix allowlist 검증 포함
+  - 비동기 executor/scheduler 제거 (thread/Async 금지)
+- Global/config changes:
+  - `scraping.callback` 하위에 result-store 설정만 유지, post-process executor 설정 제거
+  - 새로운 오류 코드/상태에 대한 로깅 패턴 점검
+
+## Data / Transactions
+- Repositories touched:
+  - ScrapeJobRepository (JPA) → `resultS3Key`, 상태 업데이트 쿼리
+  - 콜백 이벤트 히스토리 테이블 추가 여부 평가
+- Transaction scope:
+  - Controller → Application 서비스 → PortalCallbackPostProcessor 전체를 하나의 요청 흐름에서 실행
+  - PortalCallbackPostProcessor는 REQUIRES_NEW 유지하지만 호출은 동기적이며 응답 전에 완료되어야 함
+- Consistency expectations:
+  - eventual consistency 없음, 콜백 응답 전에 결과 반영이 끝나야 함
+
+## Testing Strategy
+- Domain tests:
+  - 상태 전이/멱등 로직에 대한 단위 테스트 (`job_id`, terminal 상태 보호)
+- Application tests:
+  - 콜백 서비스가 DTO 검증 실패 시 예외 반환, 정상 시 repository 호출 + 멱등 케이스
+- Integration/API tests:
+  - `/internal/scrape-results` 컨트롤러 단위/통합 테스트 (MockMvc)
+  - 콜백 서비스 단위 테스트에서 S3 읽기/검증/에러 코드 시나리오 커버
+- Additional commands:
+  - `./gradlew test`
+  - 필요 시 S3 어댑터용 `./gradlew :module:test` (실제 모듈명 확인 후 기록)
+
+## Rollout Considerations
+- Backward compatibility:
+  - 구 방식 요청 지원 필요 시 기간 동안 request에 payload/s3 key 병행 허용 여부 확정
+- Observability / metrics:
+  - 후처리 실패/재시도 횟수, S3 read latency, duplicate callback 카운터를 메트릭으로 노출
+- Feature flags / toggles:
+  - 비동기 플래그 제거, synchronous 모드가 기본. 롤백은 워커/IaC 배포 롤백으로만 처리.

--- a/docs/specs/20260410-s3-callback/plan.md
+++ b/docs/specs/20260410-s3-callback/plan.md
@@ -11,7 +11,8 @@
   - AWS SDK S3 client에 HEAD/GET + retry 래퍼(`ScrapeResultResultStoreClient`) 구현, prefix allowlist 검증 포함
   - 비동기 executor/scheduler 제거 (thread/Async 금지)
 - Global/config changes:
-  - `scraping.callback` 하위에 result-store 설정만 유지, post-process executor 설정 제거
+  - `scraping.result-store`로 키 경로를 평탄화하고 dev 기본값(`SCRAPING_RESULT_BUCKET`, `SCRAPING_RESULT_PREFIX`, `SCRAPING_RESULT_REGION`, `SCRAPING_RESULT_MAX_PAYLOAD_BYTES`, `SCRAPING_RESULT_API_CALL_TIMEOUT_SECONDS`, `SCRAPING_RESULT_API_CALL_ATTEMPT_TIMEOUT_SECONDS`)을 명시한다.
+  - post-process executor 설정은 제거/비활성화하고 callback 요청 내에서만 처리한다.
   - 새로운 오류 코드/상태에 대한 로깅 패턴 점검
 
 ## Data / Transactions

--- a/docs/specs/20260410-s3-callback/spec.md
+++ b/docs/specs/20260410-s3-callback/spec.md
@@ -1,0 +1,129 @@
+# Spec Template
+
+## 1. Feature Overview
+- Purpose:
+  - 스크래핑 콜백 엔드포인트가 스크래핑 워커가 업로드한 S3 payload를 동기적으로 읽고 검증한 뒤 DB에 반영하도록 한다.
+- Scope
+  - In:
+    - `/internal/scrape-results` 요청 DTO를 `job_id`, `status`, `result_s3_key`, `attempt` 중심으로 재정의
+    - 콜백 수신 시 기본 검증 및 상태 저장 로직을 `job_id + attempt` 기반 멱등 처리로 강화
+    - S3 client 구성 및 HEAD/GET, JSON/schema 검증, 도메인 검증, DB 반영을 **한 요청 안에서 동기 처리**
+    - 예외/로그 정책 정리 및 오류 코드 추가
+  - Out:
+    - 스크래핑 서버 측 변경(별도 시스템)
+    - Frontend UI 변경
+    - 장기 보관/아카이브 파이프라인 설계
+- Expected Impact:
+  - callback 응답을 경량화하여 timeout/중복 콜백 위험 감소
+  - 원본 결과 JSON을 S3에서 재조회 가능해 장애 분석 용이
+  - 멱등성 보장으로 상태 전이 안정성 향상
+- Stakeholder Confirmation:
+  - 요청자(백엔드 팀) 구두 승인, 2026-04-10. Phase 2 진행 전 "OK to implement" 추가 확인 예정.
+
+## 2. Domain Rules
+- Rule 1: `job_id`는 시스템 내에서 유일하며, 상태 전이는 정의된 life-cycle(`PENDING`→`IN_PROGRESS`→`SUCCEEDED|FAILED`)만 허용한다.
+- Rule 2: `result_s3_key`가 없으면 후처리를 진행하지 않으며 요청은 실패로 간주하고 재시도 대상이 된다.
+- Rule 3: terminal 상태(`SUCCEEDED`, `FAILED`, `CANCELLED`) 이후 동일 job에 대한 콜백은 멱등 처리한다.
+- Mutable Rules:
+  - S3 read 실패 시 상태를 `FAILED`로 둘지 재시도 큐로 넘길지 정책 확정 필요.
+  - 결과 JSON schema 버전 관리 전략.
+- Immutable Rules:
+  - callback 엔드포인트는 인증/권한 검증을 유지해야 한다.
+  - 직접 payload 저장 로직은 제거된다.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: 성공 콜백 처리
+  - Trigger: 스크래핑 서버가 `job_id`와 `result_s3_key`를 담아 POST 요청
+  - Actor: 스크래핑 서버
+  - Steps:
+    1. 콜백 요청 도착 → DTO 검증 (`job_id`, `status`, `result_s3_key`, `attempt`)
+    2. 상태 저장/전이 로그 남기기
+    3. S3 HEAD/GET → JSON/schema → 도메인 검증 → DB 반영 → 상태 업데이트
+    4. 성공 응답 200 반환
+  - Expected Result: 콜백 요청 단일 트랜잭션 내에서 모든 후처리가 완료된다.
+
+### Exception / Boundary Flow
+- Scenario Name: duplicate callback
+  - Condition: 동일 `job_id`가 이미 terminal 상태
+  - Expected Behavior: 멱등 로직이 이전 상태를 유지하고 로그에 Duplicate 기록 후 200 응답
+
+- Scenario Name: S3 read 실패
+  - Condition: S3 client 예외, key 존재하지 않음
+  - Expected Behavior: 콜백 응답은 성공(기본 저장 완료)이나 내부 후처리 재시도/실패 상태 기록 및 알람
+
+- Scenario Name: DTO 파싱 실패
+  - Condition: 필수 필드 누락/형식 오류
+  - Expected Behavior: 400 응답, 입력 로그 저장, job 상태 변화 없음
+
+## 4. Transaction / Consistency
+- Transaction Start Point: 콜백 요청에서 시그니처 검증/멱등 체크 후 상태 전이를 시작할 때
+- Transaction End Point: S3 read, JSON/schema 검증, 도메인 검증, DB 반영까지 완료될 때
+- Atomicity Scope: 콜백 요청 전체 (상태 전이 + 결과 반영 + 로그)
+- Eventual Consistency Allowed: 없음. 콜백 응답 전에 모든 후처리를 완료한다.
+
+## 5. API List (필요 시)
+- Endpoint: `/internal/scrape-results`
+  - Method: POST
+  - Request DTO:
+    ```json
+    {
+      "job_id": "string",
+      "status": "SUCCESS|FAIL|CANCELLED",
+      "attempt": 1,
+      "result_s3_key": "s3://bucket/key.json" 또는 key 문자열,
+      "attempt": 1,
+      "metadata": {
+        "duration_ms": 1234,
+        "scraper_version": "v1"
+      }
+    }
+    ```
+  - Response DTO: `{ "accepted": true }`
+  - Authorization: 내부 인증(기존 토큰) 유지
+  - Idempotency: `job_id` + `status` 조합 기준 멱등
+
+## 6. Exception Policy
+- Error Code: `SCRAPE_INVALID_REQUEST`
+  - Condition: DTO 필수값 누락 또는 형식 오류
+  - Message Convention: "Invalid scrape callback payload"
+  - Handling Layer: Controller validation → Global exception handler
+  - User Exposure: 내부 시스템만 사용, 로그에서 추적
+- Error Code: `SCRAPE_INVALID_S3_KEY`
+  - Condition: 허용되지 않은 `result_s3_key` prefix, 형식 위반
+  - Handling Layer: Callback 서비스
+  - User Exposure: 400 응답, 원인 로그
+- Error Code: `SCRAPE_RESULT_S3_FAILED`
+  - Condition: S3 HEAD/GET 실패, 제한 횟수 재시도 후 실패
+  - Handling Layer: Callback 서비스
+  - User Exposure: 5xx 응답
+- Error Code: `SCRAPE_S3_FAILURE`
+  - Condition: S3에서 payload 조회 실패
+  - Message Convention: "Failed to fetch scrape result from S3"
+  - Handling Layer: 후처리 서비스
+  - User Exposure: 내부 로그 + 알람
+- Error Code: `SCRAPE_RESULT_SCHEMA_INVALID`
+  - Condition: JSON / schema 검증 실패
+  - Handling Layer: Callback or PortalCallbackPostProcessor
+  - User Exposure: 4xx 응답, 상태 `FAILED_RESULT_SCHEMA`
+- Error Code: `SCRAPE_RESULT_POST_PROCESSING_FAILED`
+  - Condition: Portal sync / DB 반영 실패
+  - Handling Layer: PortalCallbackPostProcessor
+  - User Exposure: 5xx 응답, 상태 `FAILED_POST_PROCESSING`
+- Error Code: `SCRAPE_STATE_CONFLICT`
+  - Condition: terminal 상태 이후 중복 콜백으로 비정상 상태 전이 시도
+  - Handling Layer: Application 서비스
+  - User Exposure: 내부 로그
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed
+- [ ] Phase 2 Domain complete
+- [ ] Phase 3 Application complete
+- [ ] Phase 4 Infrastructure complete
+- [ ] Phase 5 Global/Config complete
+- [ ] Phase 6 API/Controller complete
+
+## 8. Generated File List
+- Path: docs/specs/20260410-s3-callback/
+  - Description: feat/215 Context Spec Bundle
+  - Layer: Documentation

--- a/docs/specs/20260410-s3-callback/spec.md
+++ b/docs/specs/20260410-s3-callback/spec.md
@@ -84,10 +84,10 @@
   - Idempotency: `job_id` + `status` 조합 기준 멱등
 
 ## 6. Exception Policy
-- Error Code: `SCRAPE_INVALID_REQUEST`
-  - Condition: DTO 필수값 누락 또는 형식 오류
+- Error Code: `SCRAPE_INVALID_CALLBACK_REQUEST`
+  - Condition: DTO 필수값 누락, attempt 불일치, 서명은 통과했으나 payload 형식이 계약을 위반한 경우
   - Message Convention: "Invalid scrape callback payload"
-  - Handling Layer: Controller validation → Global exception handler
+  - Handling Layer: Controller validation → Callback 서비스
   - User Exposure: 내부 시스템만 사용, 로그에서 추적
 - Error Code: `SCRAPE_INVALID_S3_KEY`
   - Condition: 허용되지 않은 `result_s3_key` prefix, 형식 위반

--- a/docs/specs/20260410-s3-callback/tasks.md
+++ b/docs/specs/20260410-s3-callback/tasks.md
@@ -15,6 +15,8 @@
 | 2 | `./gradlew test` | Success | 2026-04-10 |
 | 3 | `./gradlew test --tests com.chukchuk.haksa.application.portal.ScrapeResultCallbackServiceUnitTests` | Success | 2026-04-10 |
 | 4 | `./gradlew test` | Success | 2026-04-10 |
+| 5 | `./gradlew test --tests com.chukchuk.haksa.application.portal.ScrapeResultCallbackServiceUnitTests --tests com.chukchuk.haksa.application.portal.PortalCallbackPostProcessorTests --tests com.chukchuk.haksa.application.portal.ScrapeJobOutboxDispatcherUnitTests --tests com.chukchuk.haksa.application.portal.ScrapeJobStaleReconcilerUnitTests` | Success | 2026-04-11 |
+| 6 | `./gradlew test` | Success | 2026-04-11 |
 
 ## Notes
 - Observation: Phase 1 완료, clarify 답변(동기 처리/상태 코드) 반영됨. Phase 2에서 S3 검증~DB 반영을 단일 요청 안에서 구현해야 함.

--- a/docs/specs/20260410-s3-callback/tasks.md
+++ b/docs/specs/20260410-s3-callback/tasks.md
@@ -1,0 +1,17 @@
+# Tasks Template
+
+## Checklist
+- [ ] Domain tests: job 상태 전이/멱등 로직 추가
+- [ ] Application layer: 콜백 서비스 DTO/상태 저장/후처리 트리거 구현
+- [ ] Infrastructure layer: S3 client + 어댑터 + 설정 추가
+- [ ] Global/config: S3 자격증명, 로깅 key
+- [ ] API/controller: `/internal/scrape-results` 요청/응답 갱신 및 검증
+- [ ] Documentation: API 명세, 운영 가이드 업데이트
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test` | Success | 2026-04-10 |
+
+## Notes
+- Observation: Phase 1 완료, clarify 답변(동기 처리/상태 코드) 반영됨. Phase 2에서 S3 검증~DB 반영을 단일 요청 안에서 구현해야 함.

--- a/docs/specs/20260410-s3-callback/tasks.md
+++ b/docs/specs/20260410-s3-callback/tasks.md
@@ -13,6 +13,8 @@
 |------|---------|--------|------|
 | 1 | `./gradlew test` | Success | 2026-04-10 |
 | 2 | `./gradlew test` | Success | 2026-04-10 |
+| 3 | `./gradlew test --tests com.chukchuk.haksa.application.portal.ScrapeResultCallbackServiceUnitTests` | Success | 2026-04-10 |
+| 4 | `./gradlew test` | Success | 2026-04-10 |
 
 ## Notes
 - Observation: Phase 1 완료, clarify 답변(동기 처리/상태 코드) 반영됨. Phase 2에서 S3 검증~DB 반영을 단일 요청 안에서 구현해야 함.

--- a/docs/specs/20260410-s3-callback/tasks.md
+++ b/docs/specs/20260410-s3-callback/tasks.md
@@ -12,6 +12,7 @@
 | Step | Command | Result | Date |
 |------|---------|--------|------|
 | 1 | `./gradlew test` | Success | 2026-04-10 |
+| 2 | `./gradlew test` | Success | 2026-04-10 |
 
 ## Notes
 - Observation: Phase 1 완료, clarify 답변(동기 처리/상태 코드) 반영됨. Phase 2에서 S3 검증~DB 반영을 단일 요청 안에서 구현해야 함.

--- a/docs/sql/20260411-scrape-job-callback-columns-ddl.sql
+++ b/docs/sql/20260411-scrape-job-callback-columns-ddl.sql
@@ -1,0 +1,5 @@
+ALTER TABLE scrape_jobs
+    ADD COLUMN result_checksum VARCHAR(255) NULL;
+
+ALTER TABLE scrape_jobs
+    ADD COLUMN callback_metadata_json TEXT NULL;

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -27,6 +27,9 @@ import java.util.UUID;
 @Component
 public class PortalCallbackPostProcessor {
 
+    private static final String FAILED_POST_PROCESSING = "FAILED_POST_PROCESSING";
+    private static final String FAILED_RESULT_SCHEMA = "FAILED_RESULT_SCHEMA";
+
     private final PortalSyncService portalSyncService;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
@@ -108,7 +111,7 @@ public class PortalCallbackPostProcessor {
             JsonProcessingException exception
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").increment();
-        markJobFailed(jobId, finishedAt, queuedAgeSeconds, "INVALID_PORTAL_PAYLOAD", exception.getOriginalMessage());
+        markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_RESULT_SCHEMA, exception.getOriginalMessage());
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
                 jobId, userId, operationType, exception.getOriginalMessage(), exception);
     }
@@ -122,9 +125,10 @@ public class PortalCallbackPostProcessor {
             Exception exception
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", reason).increment();
-        markJobFailed(jobId, finishedAt, queuedAgeSeconds, failureCode(reason, exception, operationType), exception.getMessage());
-        log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} message={}",
-                jobId, operationType, reason, exception.getMessage(), exception);
+        String failureDetail = failureCode(reason, exception, operationType);
+        markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_POST_PROCESSING, failureDetail + ":" + exception.getMessage());
+        log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} detail={}",
+                jobId, operationType, reason, failureDetail, exception);
     }
 
     private void markJobFailed(String jobId, Instant finishedAt, Double queuedAgeSeconds, String errorCode, String message) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.infrastructure.portal.dto.raw.RawPortalData;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
@@ -114,6 +115,7 @@ public class PortalCallbackPostProcessor {
         markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_RESULT_SCHEMA, exception.getOriginalMessage());
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
                 jobId, userId, operationType, exception.getOriginalMessage(), exception);
+        throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
     }
 
     private void recordFailure(
@@ -129,6 +131,7 @@ public class PortalCallbackPostProcessor {
         markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_POST_PROCESSING, failureDetail + ":" + exception.getMessage());
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} detail={}",
                 jobId, operationType, reason, failureDetail, exception);
+        throw new CommonException(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED, exception);
     }
 
     private void markJobFailed(String jobId, Instant finishedAt, Double queuedAgeSeconds, String errorCode, String message) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -1,8 +1,6 @@
 package com.chukchuk.haksa.application.portal;
 
-import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
-import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
@@ -16,9 +14,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -31,24 +26,18 @@ public class PortalCallbackPostProcessor {
     private static final String FAILED_POST_PROCESSING = "FAILED_POST_PROCESSING";
     private static final String FAILED_RESULT_SCHEMA = "FAILED_RESULT_SCHEMA";
 
-    private final PortalSyncService portalSyncService;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
-    private final ScrapeJobRepository scrapeJobRepository;
-    private final TransactionTemplate successTemplate;
+    private final ScrapeResultCallbackTxService scrapeResultCallbackTxService;
 
     public PortalCallbackPostProcessor(
-            PortalSyncService portalSyncService,
             ObjectMapper objectMapper,
             MeterRegistry meterRegistry,
-            ScrapeJobRepository scrapeJobRepository,
-            PlatformTransactionManager transactionManager
+            ScrapeResultCallbackTxService scrapeResultCallbackTxService
     ) {
-        this.portalSyncService = portalSyncService;
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
-        this.scrapeJobRepository = scrapeJobRepository;
-        this.successTemplate = buildRequiresNewTemplate(transactionManager);
+        this.scrapeResultCallbackTxService = scrapeResultCallbackTxService;
     }
 
     public void process(
@@ -62,6 +51,7 @@ public class PortalCallbackPostProcessor {
             String workerRequestId,
             String payloadHash
     ) {
+        long startedAt = System.nanoTime();
         PortalData portalData;
         try {
             portalData = toPortalData(payloadJson);
@@ -74,24 +64,22 @@ public class PortalCallbackPostProcessor {
         log.info("[BIZ] scrape.job.callback.postprocess.start jobId={} userId={} operationType={} studentCode={} attempt={} requestId={} payloadHash={}",
                 jobId, userId, operationType, studentCode, attempt, workerRequestId, payloadHash);
         try {
-            successTemplate.executeWithoutResult(status -> {
-                ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(jobId)
-                        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND));
-                log.info("[BIZ] scrape.job.callback.postprocess.execute jobId={} currentStatus={}", job.getJobId(), job.getStatus());
-                if (operationType == ScrapeJobOperationType.LINK) {
-                    portalSyncService.syncWithPortal(userId, portalData);
-                } else {
-                    portalSyncService.refreshFromPortal(userId, portalData);
-                }
-                Instant resolvedFinishedAt = resolveFinishedAt(finishedAt);
-                job.markSucceeded(payloadJson, resolvedFinishedAt);
-                recordQueuedAge(job, finishedAt, queuedAgeSeconds);
-                log.info("[BIZ] scrape.job.succeeded jobId={} operationType={} payloadHash={} finishedAt={}",
-                        job.getJobId(), job.getOperationType(), payloadHash, resolvedFinishedAt);
-            });
+            scrapeResultCallbackTxService.completeSuccess(
+                    jobId,
+                    userId,
+                    operationType,
+                    portalData,
+                    payloadJson,
+                    finishedAt,
+                    queuedAgeSeconds,
+                    payloadHash
+            );
             meterRegistry.counter("scrape.job.callback.postprocess.success").increment();
-            log.info("[BIZ] scrape.job.callback.postprocess.success jobId={} userId={} operationType={} studentCode={}",
-                    jobId, userId, operationType, studentCode);
+            long elapsedMs = Duration.ofNanos(System.nanoTime() - startedAt).toMillis();
+            meterRegistry.timer("scrape.job.callback.stage", "stage", "postprocess_tx")
+                    .record(Duration.ofMillis(elapsedMs));
+            log.info("[BIZ] scrape.job.callback.postprocess.success jobId={} userId={} operationType={} studentCode={} elapsed_ms={}",
+                    jobId, userId, operationType, studentCode, elapsedMs);
         } catch (EntityNotFoundException exception) {
             recordFailure(jobId, finishedAt, queuedAgeSeconds, "user_missing", operationType, exception);
         } catch (PortalScrapeException exception) {
@@ -112,7 +100,14 @@ public class PortalCallbackPostProcessor {
             JsonProcessingException exception
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").increment();
-        markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_RESULT_SCHEMA, exception.getOriginalMessage());
+        scrapeResultCallbackTxService.markFailed(
+                jobId,
+                finishedAt,
+                queuedAgeSeconds,
+                FAILED_RESULT_SCHEMA,
+                exception.getOriginalMessage(),
+                false
+        );
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
                 jobId, userId, operationType, exception.getOriginalMessage(), exception);
         throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
@@ -128,40 +123,22 @@ public class PortalCallbackPostProcessor {
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", reason).increment();
         String failureDetail = failureCode(reason, exception, operationType);
-        markJobFailed(jobId, finishedAt, queuedAgeSeconds, FAILED_POST_PROCESSING, failureDetail + ":" + exception.getMessage());
+        scrapeResultCallbackTxService.markFailed(
+                jobId,
+                finishedAt,
+                queuedAgeSeconds,
+                FAILED_POST_PROCESSING,
+                failureDetail + ":" + exception.getMessage(),
+                false
+        );
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} detail={}",
                 jobId, operationType, reason, failureDetail, exception);
         throw new CommonException(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED, exception);
     }
 
-    private void markJobFailed(String jobId, Instant finishedAt, Double queuedAgeSeconds, String errorCode, String message) {
-        successTemplate.executeWithoutResult(status -> {
-            ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(jobId)
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND));
-            job.markFailed(errorCode, message, false, resolveFinishedAt(finishedAt));
-            recordQueuedAge(job, finishedAt, queuedAgeSeconds);
-        });
-    }
-
-    private void recordQueuedAge(ScrapeJob job, Instant finishedAt, Double queuedAgeSeconds) {
-        double value;
-        if (queuedAgeSeconds != null) {
-            value = queuedAgeSeconds;
-        } else if (job.getCreatedAt() != null && finishedAt != null) {
-            value = Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
-        } else {
-            return;
-        }
-        meterRegistry.summary("scrape.job.queued.age.seconds").record(value);
-    }
-
     private PortalData toPortalData(String payloadJson) throws JsonProcessingException {
         RawPortalData rawPortalData = objectMapper.readValue(payloadJson, RawPortalData.class);
         return PortalDataMapper.toPortalData(rawPortalData);
-    }
-
-    private static Instant resolveFinishedAt(Instant finishedAt) {
-        return finishedAt != null ? finishedAt : Instant.now();
     }
 
     private String failureCode(String reason, Exception exception, ScrapeJobOperationType operationType) {
@@ -186,11 +163,5 @@ public class PortalCallbackPostProcessor {
                     : ErrorCode.REFRESH_FAILED.code();
         }
         return "PORTAL_CALLBACK_POSTPROCESS_ERROR";
-    }
-
-    private static TransactionTemplate buildRequiresNewTemplate(PlatformTransactionManager transactionManager) {
-        TransactionTemplate template = new TransactionTemplate(transactionManager);
-        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-        return template;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalSyncService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalSyncService.java
@@ -19,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.UUID;
 
-import static com.chukchuk.haksa.global.logging.config.LoggingThresholds.SLOW_MS;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -59,9 +57,7 @@ public class PortalSyncService {
         studentService.markReconnectedByUser(user);
 
         long tookMs = LogTime.elapsedMs(t0);
-        if (tookMs >= SLOW_MS) {
-            log.info("[BIZ] portal.sync.done userId={} took_ms={}", userId, tookMs);
-        }
+        log.info("[BIZ] portal.sync.done userId={} activeUserId={} took_ms={}", userId, activeUserId, tookMs);
 
         // 4. 응답 생성
         return ScrapingResponse.success(UUID.randomUUID().toString(), conn.studentInfo());
@@ -94,9 +90,7 @@ public class PortalSyncService {
         studentService.markReconnectedByUser(user);
 
         long tookMs = LogTime.elapsedMs(t0);
-        if (tookMs >= SLOW_MS) {
-            log.info("[BIZ] portal.refresh.done userId={} took_ms={}", userId, tookMs);
-        }
+        log.info("[BIZ] portal.refresh.done userId={} activeUserId={} took_ms={}", userId, activeUserId, tookMs);
 
         // 4. 응답 생성
         return ScrapingResponse.success(UUID.randomUUID().toString(), conn.studentInfo());

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
@@ -147,6 +147,7 @@ public class ScrapeJobOutboxDispatcher {
                     trigger, outbox.getOutboxId(), outbox.getJobId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
             String queueMessageId = scrapeJobPublisher.publish(outbox.getPayloadJson());
             outbox.markSent(queueMessageId, attemptedAt);
+            job.markRunning();
             meterRegistry.counter("scrape.outbox.publish.success").increment();
             log.info("[BIZ] scrape.outbox.sent trigger={} outboxId={} jobId={} attempt={} outboxStatus={} queueMessageId={}",
                     trigger, outbox.getOutboxId(), outbox.getJobId(), outbox.getAttemptCount(), outbox.getStatus(), queueMessageId);

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -42,7 +42,7 @@ public class ScrapeJobStaleReconciler {
         List<ScrapeJobOutbox> staleOutboxes = scrapeJobOutboxRepository.findStaleSentTargetsForUpdate(
                 ScrapeJobOutboxStatus.SENT,
                 threshold,
-                ScrapeJobStatus.QUEUED,
+                ScrapeJobStatus.RUNNING,
                 PageRequest.of(0, scrapingProperties.getStale().getBatchSize())
         );
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -103,7 +103,7 @@ public class ScrapeResultCallbackService {
             return;
         }
 
-        throw new CommonException(ErrorCode.INVALID_ARGUMENT);
+        throw new CommonException(ErrorCode.SCRAPE_INVALID_CALLBACK_REQUEST);
     }
 
     private PortalLinkDto.ScrapeResultCallbackRequest parseRequest(String rawBody, String bodyHash) {
@@ -112,7 +112,7 @@ public class ScrapeResultCallbackService {
         } catch (JsonProcessingException e) {
             log.warn("[BIZ] scrape.job.callback.invalid_payload stage=request_parse rawBodyHash={} message={}",
                     bodyHash, e.getOriginalMessage());
-            throw new CommonException(ErrorCode.INVALID_ARGUMENT, e);
+            throw new CommonException(ErrorCode.SCRAPE_INVALID_CALLBACK_REQUEST, e);
         }
     }
 
@@ -237,7 +237,15 @@ public class ScrapeResultCallbackService {
         if (resultS3Key == null || resultS3Key.isBlank()) {
             throw new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY);
         }
-        if (!resultS3Key.contains(jobId)) {
+        ScrapeResultResultStoreClient.S3Location location;
+        try {
+            location = resultStoreClient.validateLocation(resultS3Key);
+        } catch (ScrapeResultPayloadAccessException exception) {
+            log.warn("[BIZ] scrape.job.callback.invalid_s3_key jobId={} resultS3Key={} reason={}",
+                    jobId, resultS3Key, exception.getMessage());
+            throw new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY, exception);
+        }
+        if (!location.key().contains(jobId)) {
             log.warn("[BIZ] scrape.job.callback.s3_key_without_job jobId={} resultS3Key={}", jobId, resultS3Key);
             throw new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY);
         }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -4,11 +4,10 @@ import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
-import com.chukchuk.haksa.global.exception.type.BaseException;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
-import com.chukchuk.haksa.infrastructure.portal.dto.raw.RawPortalData;
-import com.chukchuk.haksa.infrastructure.portal.mapper.PortalDataMapper;
+import com.chukchuk.haksa.infrastructure.portal.client.ScrapeResultResultStoreClient;
+import com.chukchuk.haksa.infrastructure.portal.exception.ScrapeResultPayloadAccessException;
 import com.chukchuk.haksa.infrastructure.security.HmacSignatureVerifier;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,15 +27,18 @@ import java.time.Instant;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ScrapeResultCallbackService {
 
+    private static final String FAILED_S3_READ = "FAILED_S3_READ";
+    private static final String FAILED_RESULT_SCHEMA = "FAILED_RESULT_SCHEMA";
+
     private final ScrapeJobRepository scrapeJobRepository;
     private final PortalCallbackPostProcessor portalCallbackPostProcessor;
+    private final ScrapeResultResultStoreClient resultStoreClient;
     private final HmacSignatureVerifier hmacSignatureVerifier;
     private final MeterRegistry meterRegistry;
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
@@ -45,13 +47,15 @@ public class ScrapeResultCallbackService {
     public void handleCallback(String rawBody, String timestamp, String signature, String attemptHeader, String workerRequestId) {
         String bodyHash = hashRawBody(rawBody);
         String hintedJobId = extractJobId(rawBody);
-        int attempt = parseAttempt(attemptHeader);
+        PortalLinkDto.ScrapeResultCallbackRequest request = parseRequest(rawBody, bodyHash);
+        int attempt = resolveAttempt(attemptHeader, request.attempt());
         String normalizedWorkerRequestId = normalizeWorkerRequestId(workerRequestId);
 
         try {
             hmacSignatureVerifier.verify(timestamp, rawBody, signature);
         } catch (CommonException exception) {
-            HmacSignatureVerifier.VerificationDiagnostics diagnostics = hmacSignatureVerifier.diagnostics(timestamp, rawBody, signature);
+            HmacSignatureVerifier.VerificationDiagnostics diagnostics =
+                    hmacSignatureVerifier.diagnostics(timestamp, rawBody, signature);
             log.warn("[BIZ] scrape.job.callback.invalid_signature jobId={} signatureValid=false reason={} timestamp={} parsedTimestamp={} timestampDeltaSeconds={} rawBodyHash={} actualSignatureEncoding={} actualSignatureLength={} actualSignatureHash={} expectedUtf8SignatureHash={} expectedHexSignatureHash={}",
                     hintedJobId,
                     diagnostics.reason(),
@@ -67,7 +71,6 @@ public class ScrapeResultCallbackService {
             throw exception;
         }
 
-        PortalLinkDto.ScrapeResultCallbackRequest request = parseRequest(rawBody, bodyHash);
         ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(request.job_id())
                 .orElseThrow(() -> {
                     log.warn("[BIZ] scrape.job.callback.job_not_found jobId={} signatureValid=true rawBodyHash={}",
@@ -75,19 +78,20 @@ public class ScrapeResultCallbackService {
                     return new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND);
                 });
 
-        log.info("[BIZ] scrape.job.callback.received jobId={} status={} attempt={} requestId={} rawBodyHash={}",
-                job.getJobId(), job.getStatus(), attempt, normalizedWorkerRequestId, bodyHash);
+        log.info("[BIZ] scrape.job.callback.received jobId={} status={} attempt={} requestId={} resultS3Key={} rawBodyHash={}",
+                job.getJobId(), request.status(), attempt, normalizedWorkerRequestId, request.result_s3_key(), bodyHash);
 
-        if (job.isCompleted() || job.hasWorkerResult()) {
-            handleDuplicate(job, attempt, normalizedWorkerRequestId);
+        if (job.hasProcessedAttempt(attempt) || job.isCompleted()) {
+            handleDuplicate(job, attempt, normalizedWorkerRequestId, request.result_s3_key());
             return;
         }
+        job.recordCallbackAttempt(attempt, Instant.now());
 
         Instant finishedAt = request.finished_at() == null ? Instant.now() : request.finished_at();
         String normalizedStatus = normalize(request.status());
 
         if ("succeeded".equals(normalizedStatus)) {
-            handleSucceeded(job, request, finishedAt, bodyHash, attempt, normalizedWorkerRequestId);
+            handleSucceeded(job, request, finishedAt, attempt, normalizedWorkerRequestId);
             return;
         }
 
@@ -116,61 +120,61 @@ public class ScrapeResultCallbackService {
             ScrapeJob job,
             PortalLinkDto.ScrapeResultCallbackRequest request,
             Instant finishedAt,
-            String bodyHash,
             int attempt,
             String workerRequestId
     ) {
-        try {
-            if (request.result_payload() == null || request.result_payload().isNull()) {
-                log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_missing jobId={} rawBodyHash={}",
-                        job.getJobId(), bodyHash);
-                throw new CommonException(ErrorCode.INVALID_ARGUMENT);
-            }
-            JsonNode normalizedPayload = normalizeNodeKeys(request.result_payload());
-            RawPortalData rawPortalData = objectMapper.treeToValue(normalizedPayload, RawPortalData.class);
-            PortalDataMapper.toPortalData(rawPortalData); // validate payload before persisting
+        validateResultKey(job.getJobId(), request.result_s3_key());
+        job.recordResultLocation(request.result_s3_key(), attempt, Instant.now());
 
-            String payloadJson = writeJson(normalizedPayload);
-            String payloadHash = hashRawBody(payloadJson);
-            job.recordWorkerResult(payloadJson, finishedAt);
+        try {
+            String normalizedPayloadJson = fetchAndNormalizePayload(request.result_s3_key());
+
+            job.recordWorkerResult(normalizedPayloadJson, finishedAt);
             Double queuedAgeSeconds = calculateQueuedAgeSeconds(job, finishedAt);
             recordQueuedAge(job, finishedAt);
             meterRegistry.counter("scrape.job.callback.persisted").increment();
-            log.info("[BIZ] scrape.job.callback.persisted jobId={} attempt={} requestId={} payloadHash={} queuedAgeSeconds={}",
-                    job.getJobId(), attempt, workerRequestId, payloadHash, queuedAgeSeconds);
+            String payloadHash = hashRawBody(normalizedPayloadJson);
+            log.info("[BIZ] scrape.job.callback.persisted jobId={} attempt={} requestId={} payloadHash={}",
+                    job.getJobId(), attempt, workerRequestId, payloadHash);
+
             portalCallbackPostProcessor.process(
                     job.getJobId(),
                     job.getUserId(),
                     job.getOperationType(),
-                    payloadJson,
+                    normalizedPayloadJson,
                     finishedAt,
                     queuedAgeSeconds,
                     attempt,
                     workerRequestId,
                     payloadHash
             );
-        } catch (BaseException | IllegalArgumentException e) {
-            job.markFailed("BUSINESS_RULE_VIOLATION", e.getMessage(), false, finishedAt);
+        } catch (ScrapeResultPayloadAccessException exception) {
+            job.markFailed(FAILED_S3_READ, exception.getMessage(), exception.isRetryable(), finishedAt);
             recordQueuedAge(job, finishedAt);
-            log.warn("[BIZ] scrape.job.business_fail jobId={} operationType={} message={}",
-                    job.getJobId(), job.getOperationType(), e.getMessage());
-        } catch (JsonProcessingException e) {
-            log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_mapping jobId={} rawBodyHash={} resultPayloadKeys={} message={}",
-                    job.getJobId(), bodyHash, topLevelFieldNames(request.result_payload()), e.getOriginalMessage());
-            throw new CommonException(ErrorCode.INVALID_ARGUMENT, e);
-        } catch (RuntimeException e) {
-            job.markFailed("INTERNAL_ERROR", e.getMessage(), false, finishedAt);
+            log.error("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
+                    job.getJobId(), request.result_s3_key(), attempt, exception.getMessage());
+            throw new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED, exception);
+        } catch (JsonProcessingException exception) {
+            job.markFailed(FAILED_RESULT_SCHEMA, exception.getOriginalMessage(), false, finishedAt);
             recordQueuedAge(job, finishedAt);
-            log.error("[BIZ] scrape.job.callback.unexpected_fail jobId={} operationType={} ex={}",
-                    job.getJobId(), job.getOperationType(), e.getClass().getSimpleName(), e);
+            log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_parse jobId={} resultS3Key={} message={}",
+                    job.getJobId(), request.result_s3_key(), exception.getOriginalMessage());
+            throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
         }
     }
 
-    private void handleDuplicate(ScrapeJob job, int attempt, String workerRequestId) {
+    private String fetchAndNormalizePayload(String resultS3Key) throws JsonProcessingException {
+        String payload = resultStoreClient.fetch(resultS3Key);
+        JsonNode original = objectMapper.readTree(payload);
+        JsonNode normalized = normalizeNodeKeys(original);
+        return writeJson(normalized);
+    }
+
+    private void handleDuplicate(ScrapeJob job, int attempt, String workerRequestId, String resultS3Key) {
         meterRegistry.counter("scrape.job.callback.duplicate", "status", job.getStatus().name().toLowerCase(Locale.ROOT))
                 .increment();
-        log.info("[BIZ] scrape.job.callback.duplicate jobId={} status={} attempt={} requestId={}",
-                job.getJobId(), job.getStatus(), attempt, workerRequestId);
+        log.info("[BIZ] scrape.job.callback.duplicate jobId={} status={} attempt={} requestId={} resultS3Key={}",
+                job.getJobId(), job.getStatus(), attempt, workerRequestId, resultS3Key);
     }
 
     private Double calculateQueuedAgeSeconds(ScrapeJob job, Instant finishedAt) {
@@ -180,20 +184,12 @@ public class ScrapeResultCallbackService {
         return Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
     }
 
-    private String writeJson(Object value) {
-        try {
-            return objectMapper.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
-            throw new CommonException(ErrorCode.INVALID_ARGUMENT, e);
-        }
-    }
-
     private String normalize(String status) {
         return status == null ? "" : status.trim().toLowerCase(Locale.ROOT);
     }
 
     private void recordQueuedAge(ScrapeJob job, Instant finishedAt) {
-        if (job.getCreatedAt() == null) {
+        if (job.getCreatedAt() == null || finishedAt == null) {
             return;
         }
         double queuedAgeSeconds = Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
@@ -217,7 +213,10 @@ public class ScrapeResultCallbackService {
         }
     }
 
-    private int parseAttempt(String attemptHeader) {
+    private int resolveAttempt(String attemptHeader, Integer attemptFromPayload) {
+        if (attemptFromPayload != null && attemptFromPayload > 0) {
+            return attemptFromPayload;
+        }
         if (attemptHeader == null || attemptHeader.isBlank()) {
             return 1;
         }
@@ -232,6 +231,16 @@ public class ScrapeResultCallbackService {
 
     private String normalizeWorkerRequestId(String workerRequestId) {
         return workerRequestId == null ? "" : workerRequestId;
+    }
+
+    private void validateResultKey(String jobId, String resultS3Key) {
+        if (resultS3Key == null || resultS3Key.isBlank()) {
+            throw new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY);
+        }
+        if (!resultS3Key.contains(jobId)) {
+            log.warn("[BIZ] scrape.job.callback.s3_key_without_job jobId={} resultS3Key={}", jobId, resultS3Key);
+            throw new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY);
+        }
     }
 
     private JsonNode normalizeNodeKeys(JsonNode node) {
@@ -276,19 +285,11 @@ public class ScrapeResultCallbackService {
         return builder.toString();
     }
 
-    private String topLevelFieldNames(JsonNode node) {
-        if (node == null || !node.isObject()) {
-            return "";
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT, e);
         }
-
-        StringBuilder builder = new StringBuilder();
-        Iterator<String> fieldNames = node.fieldNames();
-        while (fieldNames.hasNext()) {
-            if (builder.length() > 0) {
-                builder.append(',');
-            }
-            builder.append(fieldNames.next());
-        }
-        return builder.toString();
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -1,8 +1,6 @@
 package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
-import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
-import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
@@ -18,7 +16,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -36,20 +33,23 @@ public class ScrapeResultCallbackService {
     private static final String FAILED_S3_READ = "FAILED_S3_READ";
     private static final String FAILED_RESULT_SCHEMA = "FAILED_RESULT_SCHEMA";
 
-    private final ScrapeJobRepository scrapeJobRepository;
     private final PortalCallbackPostProcessor portalCallbackPostProcessor;
+    private final ScrapeResultCallbackTxService scrapeResultCallbackTxService;
     private final ScrapeResultResultStoreClient resultStoreClient;
     private final HmacSignatureVerifier hmacSignatureVerifier;
     private final MeterRegistry meterRegistry;
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
-    @Transactional
     public void handleCallback(String rawBody, String timestamp, String signature, String attemptHeader, String workerRequestId) {
+        long startedAt = System.nanoTime();
         String bodyHash = hashRawBody(rawBody);
         String hintedJobId = extractJobId(rawBody);
         PortalLinkDto.ScrapeResultCallbackRequest request = parseRequest(rawBody, bodyHash);
         int attempt = resolveAttempt(attemptHeader, request.attempt());
         String normalizedWorkerRequestId = normalizeWorkerRequestId(workerRequestId);
+        String callbackMetadataJson = writeJson(request.metadata());
+        String normalizedStatus = normalize(request.status());
+        Instant callbackReceivedAt = Instant.now();
 
         try {
             hmacSignatureVerifier.verify(timestamp, rawBody, signature);
@@ -71,35 +71,24 @@ public class ScrapeResultCallbackService {
             throw exception;
         }
 
-        ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(request.job_id())
-                .orElseThrow(() -> {
-                    log.warn("[BIZ] scrape.job.callback.job_not_found jobId={} signatureValid=true rawBodyHash={}",
-                            request.job_id(), bodyHash);
-                    return new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND);
-                });
-
-        log.info("[BIZ] scrape.job.callback.received jobId={} status={} attempt={} requestId={} resultS3Key={} rawBodyHash={}",
-                job.getJobId(), request.status(), attempt, normalizedWorkerRequestId, request.result_s3_key(), bodyHash);
-
-        if (job.hasProcessedAttempt(attempt) || job.isCompleted()) {
-            handleDuplicate(job, attempt, normalizedWorkerRequestId, request.result_s3_key());
-            return;
-        }
-        job.recordCallbackAttempt(attempt, Instant.now());
-
         Instant finishedAt = request.finished_at() == null ? Instant.now() : request.finished_at();
-        String normalizedStatus = normalize(request.status());
+        logStage(
+                "validated",
+                request.job_id(),
+                attempt,
+                normalizedStatus,
+                request.result_s3_key(),
+                normalizedWorkerRequestId,
+                elapsedMillis(startedAt)
+        );
 
         if ("succeeded".equals(normalizedStatus)) {
-            handleSucceeded(job, request, finishedAt, attempt, normalizedWorkerRequestId);
+            handleSucceeded(request, callbackMetadataJson, callbackReceivedAt, finishedAt, attempt, normalizedWorkerRequestId, bodyHash, startedAt);
             return;
         }
 
         if ("failed".equals(normalizedStatus)) {
-            job.markFailed(request.error_code(), request.error_message(), request.retryable(), finishedAt);
-            recordQueuedAge(job, finishedAt);
-            log.info("[BIZ] scrape.job.failed jobId={} errorCode={} retryable={} attempt={} requestId={}",
-                    job.getJobId(), request.error_code(), request.retryable(), attempt, normalizedWorkerRequestId);
+            handleFailed(request, callbackMetadataJson, callbackReceivedAt, finishedAt, attempt, normalizedWorkerRequestId, bodyHash, startedAt);
             return;
         }
 
@@ -117,50 +106,160 @@ public class ScrapeResultCallbackService {
     }
 
     private void handleSucceeded(
-            ScrapeJob job,
             PortalLinkDto.ScrapeResultCallbackRequest request,
+            String callbackMetadataJson,
+            Instant callbackReceivedAt,
             Instant finishedAt,
             int attempt,
-            String workerRequestId
+            String workerRequestId,
+            String bodyHash,
+            long startedAt
     ) {
-        validateResultKey(job.getJobId(), request.result_s3_key());
-        job.recordResultLocation(request.result_s3_key(), attempt, Instant.now());
+        validateResultKey(request.job_id(), request.result_s3_key());
+        long receiptStartedAt = System.nanoTime();
+        ScrapeResultCallbackTxService.CallbackReceipt receipt = receiveSuccessCallback(
+                request,
+                callbackMetadataJson,
+                callbackReceivedAt,
+                attempt,
+                bodyHash
+        );
+        logStage(
+                "receipt_committed",
+                receipt.jobId(),
+                attempt,
+                receipt.status(),
+                request.result_s3_key(),
+                workerRequestId,
+                elapsedMillis(receiptStartedAt)
+        );
+        if (receipt.duplicate()) {
+            handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
+            return;
+        }
 
         try {
+            long s3StartedAt = System.nanoTime();
             String normalizedPayloadJson = fetchAndNormalizePayload(request.result_s3_key());
+            verifyChecksum(request.resultChecksum(), normalizedPayloadJson);
+            logStage(
+                    "payload_ready",
+                    receipt.jobId(),
+                    attempt,
+                    receipt.status(),
+                    request.result_s3_key(),
+                    workerRequestId,
+                    elapsedMillis(s3StartedAt)
+            );
 
-            job.recordWorkerResult(normalizedPayloadJson, finishedAt);
-            Double queuedAgeSeconds = calculateQueuedAgeSeconds(job, finishedAt);
-            recordQueuedAge(job, finishedAt);
             meterRegistry.counter("scrape.job.callback.persisted").increment();
             String payloadHash = hashRawBody(normalizedPayloadJson);
             log.info("[BIZ] scrape.job.callback.persisted jobId={} attempt={} requestId={} payloadHash={}",
-                    job.getJobId(), attempt, workerRequestId, payloadHash);
+                    receipt.jobId(), attempt, workerRequestId, payloadHash);
 
+            long postProcessStartedAt = System.nanoTime();
             portalCallbackPostProcessor.process(
-                    job.getJobId(),
-                    job.getUserId(),
-                    job.getOperationType(),
+                    receipt.jobId(),
+                    receipt.userId(),
+                    receipt.operationType(),
                     normalizedPayloadJson,
                     finishedAt,
-                    queuedAgeSeconds,
+                    receipt.queuedAgeSeconds(),
                     attempt,
                     workerRequestId,
                     payloadHash
             );
+            logStage(
+                    "postprocess_committed",
+                    receipt.jobId(),
+                    attempt,
+                    "succeeded",
+                    request.result_s3_key(),
+                    workerRequestId,
+                    elapsedMillis(postProcessStartedAt)
+            );
+        } catch (CommonException exception) {
+            if (ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code().equals(exception.getCode())) {
+                scrapeResultCallbackTxService.markFailed(
+                        receipt.jobId(),
+                        finishedAt,
+                        receipt.queuedAgeSeconds(),
+                        FAILED_RESULT_SCHEMA,
+                        exception.getMessage(),
+                        false
+                );
+            }
+            throw exception;
         } catch (ScrapeResultPayloadAccessException exception) {
-            job.markFailed(FAILED_S3_READ, exception.getMessage(), exception.isRetryable(), finishedAt);
-            recordQueuedAge(job, finishedAt);
+            scrapeResultCallbackTxService.markFailed(
+                    receipt.jobId(),
+                    finishedAt,
+                    receipt.queuedAgeSeconds(),
+                    FAILED_S3_READ,
+                    exception.getMessage(),
+                    exception.isRetryable()
+            );
             log.error("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
-                    job.getJobId(), request.result_s3_key(), attempt, exception.getMessage());
+                    receipt.jobId(), request.result_s3_key(), attempt, exception.getMessage());
             throw new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED, exception);
         } catch (JsonProcessingException exception) {
-            job.markFailed(FAILED_RESULT_SCHEMA, exception.getOriginalMessage(), false, finishedAt);
-            recordQueuedAge(job, finishedAt);
+            scrapeResultCallbackTxService.markFailed(
+                    receipt.jobId(),
+                    finishedAt,
+                    receipt.queuedAgeSeconds(),
+                    FAILED_RESULT_SCHEMA,
+                    exception.getOriginalMessage(),
+                    false
+            );
             log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_parse jobId={} resultS3Key={} message={}",
-                    job.getJobId(), request.result_s3_key(), exception.getOriginalMessage());
+                    receipt.jobId(), request.result_s3_key(), exception.getOriginalMessage());
             throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
+        } finally {
+            logStage(
+                    "completed",
+                    receipt.jobId(),
+                    attempt,
+                    normalizedStatus(request.status()),
+                    request.result_s3_key(),
+                    workerRequestId,
+                    elapsedMillis(startedAt)
+            );
         }
+    }
+
+    private void handleFailed(
+            PortalLinkDto.ScrapeResultCallbackRequest request,
+            String callbackMetadataJson,
+            Instant callbackReceivedAt,
+            Instant finishedAt,
+            int attempt,
+            String workerRequestId,
+            String bodyHash,
+            long startedAt
+    ) {
+        ScrapeResultCallbackTxService.CallbackReceipt receipt = receiveFailedCallback(
+                request,
+                callbackMetadataJson,
+                callbackReceivedAt,
+                finishedAt,
+                attempt,
+                bodyHash
+        );
+        if (receipt.duplicate()) {
+            handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
+            return;
+        }
+        log.info("[BIZ] scrape.job.failed jobId={} errorCode={} retryable={} attempt={} requestId={}",
+                receipt.jobId(), request.error_code(), request.retryable(), attempt, workerRequestId);
+        logStage(
+                "completed",
+                receipt.jobId(),
+                attempt,
+                receipt.status(),
+                request.result_s3_key(),
+                workerRequestId,
+                elapsedMillis(startedAt)
+        );
     }
 
     private String fetchAndNormalizePayload(String resultS3Key) throws JsonProcessingException {
@@ -170,30 +269,20 @@ public class ScrapeResultCallbackService {
         return writeJson(normalized);
     }
 
-    private void handleDuplicate(ScrapeJob job, int attempt, String workerRequestId, String resultS3Key) {
-        meterRegistry.counter("scrape.job.callback.duplicate", "status", job.getStatus().name().toLowerCase(Locale.ROOT))
+    private void handleDuplicate(
+            ScrapeResultCallbackTxService.CallbackReceipt receipt,
+            int attempt,
+            String workerRequestId,
+            String resultS3Key
+    ) {
+        meterRegistry.counter("scrape.job.callback.duplicate", "status", receipt.status())
                 .increment();
         log.info("[BIZ] scrape.job.callback.duplicate jobId={} status={} attempt={} requestId={} resultS3Key={}",
-                job.getJobId(), job.getStatus(), attempt, workerRequestId, resultS3Key);
-    }
-
-    private Double calculateQueuedAgeSeconds(ScrapeJob job, Instant finishedAt) {
-        if (job.getCreatedAt() == null || finishedAt == null) {
-            return null;
-        }
-        return Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
+                receipt.jobId(), receipt.status(), attempt, workerRequestId, resultS3Key);
     }
 
     private String normalize(String status) {
         return status == null ? "" : status.trim().toLowerCase(Locale.ROOT);
-    }
-
-    private void recordQueuedAge(ScrapeJob job, Instant finishedAt) {
-        if (job.getCreatedAt() == null || finishedAt == null) {
-            return;
-        }
-        double queuedAgeSeconds = Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
-        meterRegistry.summary("scrape.job.queued.age.seconds").record(queuedAgeSeconds);
     }
 
     private String extractJobId(String rawBody) {
@@ -251,6 +340,92 @@ public class ScrapeResultCallbackService {
         }
     }
 
+    private void verifyChecksum(String expectedChecksum, String payloadJson) {
+        if (expectedChecksum == null || expectedChecksum.isBlank()) {
+            return;
+        }
+
+        String normalizedExpected = expectedChecksum.trim().toLowerCase(Locale.ROOT);
+        String actualHash = hashRawBody(payloadJson);
+        String expectedHash = normalizedExpected.startsWith("sha256:")
+                ? normalizedExpected.substring("sha256:".length())
+                : normalizedExpected;
+        if (!actualHash.equals(expectedHash)) {
+            throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID);
+        }
+    }
+
+    private ScrapeResultCallbackTxService.CallbackReceipt receiveSuccessCallback(
+            PortalLinkDto.ScrapeResultCallbackRequest request,
+            String callbackMetadataJson,
+            Instant callbackReceivedAt,
+            int attempt,
+            String bodyHash
+    ) {
+        try {
+            return scrapeResultCallbackTxService.receiveSuccessCallback(
+                    request.job_id(),
+                    attempt,
+                    request.result_s3_key(),
+                    request.resultChecksum(),
+                    callbackMetadataJson,
+                    callbackReceivedAt
+            );
+        } catch (EntityNotFoundException exception) {
+            log.warn("[BIZ] scrape.job.callback.job_not_found jobId={} signatureValid=true rawBodyHash={}",
+                    request.job_id(), bodyHash);
+            throw exception;
+        }
+    }
+
+    private ScrapeResultCallbackTxService.CallbackReceipt receiveFailedCallback(
+            PortalLinkDto.ScrapeResultCallbackRequest request,
+            String callbackMetadataJson,
+            Instant callbackReceivedAt,
+            Instant finishedAt,
+            int attempt,
+            String bodyHash
+    ) {
+        try {
+            return scrapeResultCallbackTxService.receiveFailedCallback(
+                    request.job_id(),
+                    attempt,
+                    callbackMetadataJson,
+                    request.error_code(),
+                    request.error_message(),
+                    request.retryable(),
+                    callbackReceivedAt,
+                    finishedAt
+            );
+        } catch (EntityNotFoundException exception) {
+            log.warn("[BIZ] scrape.job.callback.job_not_found jobId={} signatureValid=true rawBodyHash={}",
+                    request.job_id(), bodyHash);
+            throw exception;
+        }
+    }
+
+    private void logStage(
+            String stage,
+            String jobId,
+            int attempt,
+            String status,
+            String resultS3Key,
+            String workerRequestId,
+            long elapsedMs
+    ) {
+        meterRegistry.timer("scrape.job.callback.stage", "stage", stage).record(Duration.ofMillis(elapsedMs));
+        log.info("[BIZ] scrape.job.callback.stage stage={} jobId={} attempt={} status={} resultS3Key={} requestId={} elapsed_ms={}",
+                stage, jobId, attempt, status, resultS3Key, workerRequestId, elapsedMs);
+    }
+
+    private long elapsedMillis(long startedAt) {
+        return Duration.ofNanos(System.nanoTime() - startedAt).toMillis();
+    }
+
+    private String normalizedStatus(String status) {
+        return normalize(status);
+    }
+
     private JsonNode normalizeNodeKeys(JsonNode node) {
         if (node == null || node.isNull()) {
             return node;
@@ -294,6 +469,9 @@ public class ScrapeResultCallbackService {
     }
 
     private String writeJson(Object value) {
+        if (value == null) {
+            return null;
+        }
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackTxService.java
@@ -1,0 +1,190 @@
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
+import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
+import com.chukchuk.haksa.infrastructure.portal.model.PortalData;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScrapeResultCallbackTxService {
+
+    private final ScrapeJobRepository scrapeJobRepository;
+    private final PortalSyncService portalSyncService;
+    private final MeterRegistry meterRegistry;
+
+    @Transactional
+    public CallbackReceipt receiveSuccessCallback(
+            String jobId,
+            int attempt,
+            String resultS3Key,
+            String resultChecksum,
+            String callbackMetadataJson,
+            Instant receivedAt
+    ) {
+        ScrapeJob job = findJobForUpdate(jobId);
+        if (job.hasProcessedAttempt(attempt) || job.isCompleted()) {
+            return CallbackReceipt.duplicate(job);
+        }
+
+        job.markPostProcessing(resultS3Key, resultChecksum, callbackMetadataJson, attempt, receivedAt);
+        return CallbackReceipt.accepted(job);
+    }
+
+    @Transactional
+    public CallbackReceipt receiveFailedCallback(
+            String jobId,
+            int attempt,
+            String callbackMetadataJson,
+            String errorCode,
+            String errorMessage,
+            Boolean retryable,
+            Instant receivedAt,
+            Instant finishedAt
+    ) {
+        ScrapeJob job = findJobForUpdate(jobId);
+        if (job.hasProcessedAttempt(attempt) || job.isCompleted()) {
+            return CallbackReceipt.duplicate(job);
+        }
+
+        job.recordFailedCallback(
+                attempt,
+                receivedAt,
+                callbackMetadataJson,
+                errorCode,
+                errorMessage,
+                retryable,
+                finishedAt
+        );
+        recordQueuedAge(job, finishedAt);
+        return CallbackReceipt.accepted(job);
+    }
+
+    @Transactional
+    public void completeSuccess(
+            String jobId,
+            UUID userId,
+            ScrapeJobOperationType operationType,
+            PortalData portalData,
+            String payloadJson,
+            Instant finishedAt,
+            Double queuedAgeSeconds,
+            String payloadHash
+    ) {
+        ScrapeJob job = findJobForUpdate(jobId);
+        log.info("[BIZ] scrape.job.callback.postprocess.execute jobId={} currentStatus={}",
+                job.getJobId(), job.getStatus());
+
+        if (operationType == ScrapeJobOperationType.LINK) {
+            portalSyncService.syncWithPortal(userId, portalData);
+        } else {
+            portalSyncService.refreshFromPortal(userId, portalData);
+        }
+
+        Instant resolvedFinishedAt = resolveFinishedAt(finishedAt);
+        job.markSucceeded(payloadJson, resolvedFinishedAt);
+        recordQueuedAge(job, finishedAt, queuedAgeSeconds);
+        log.info("[BIZ] scrape.job.succeeded jobId={} operationType={} payloadHash={} finishedAt={}",
+                job.getJobId(), job.getOperationType(), payloadHash, resolvedFinishedAt);
+    }
+
+    @Transactional
+    public void markFailed(
+            String jobId,
+            Instant finishedAt,
+            Double queuedAgeSeconds,
+            String errorCode,
+            String message,
+            Boolean retryable
+    ) {
+        ScrapeJob job = findJobForUpdate(jobId);
+        if (job.isCompleted() || job.getStatus() == ScrapeJobStatus.SUCCEEDED) {
+            log.info("[BIZ] scrape.job.callback.fail.skip jobId={} status={} errorCode={}",
+                    job.getJobId(), job.getStatus(), errorCode);
+            return;
+        }
+        job.markFailed(errorCode, message, retryable, resolveFinishedAt(finishedAt));
+        recordQueuedAge(job, finishedAt, queuedAgeSeconds);
+    }
+
+    private ScrapeJob findJobForUpdate(String jobId) {
+        return scrapeJobRepository.findForUpdateByJobId(jobId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND));
+    }
+
+    private void recordQueuedAge(ScrapeJob job, Instant finishedAt) {
+        if (job.getCreatedAt() == null || finishedAt == null) {
+            return;
+        }
+        double queuedAgeSeconds = Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
+        meterRegistry.summary("scrape.job.queued.age.seconds").record(queuedAgeSeconds);
+    }
+
+    private void recordQueuedAge(ScrapeJob job, Instant finishedAt, Double queuedAgeSeconds) {
+        double value;
+        if (queuedAgeSeconds != null) {
+            value = queuedAgeSeconds;
+        } else if (job.getCreatedAt() != null && finishedAt != null) {
+            value = Duration.between(job.getCreatedAt(), finishedAt).toMillis() / 1000.0;
+        } else {
+            return;
+        }
+        meterRegistry.summary("scrape.job.queued.age.seconds").record(value);
+    }
+
+    private static Instant resolveFinishedAt(Instant finishedAt) {
+        return finishedAt != null ? finishedAt : Instant.now();
+    }
+
+    public record CallbackReceipt(
+            boolean duplicate,
+            String jobId,
+            UUID userId,
+            ScrapeJobOperationType operationType,
+            String status,
+            Double queuedAgeSeconds
+    ) {
+        public static CallbackReceipt accepted(ScrapeJob job) {
+            return new CallbackReceipt(
+                    false,
+                    job.getJobId(),
+                    job.getUserId(),
+                    job.getOperationType(),
+                    job.getStatus().name().toLowerCase(Locale.ROOT),
+                    calculateQueuedAgeSeconds(job)
+            );
+        }
+
+        public static CallbackReceipt duplicate(ScrapeJob job) {
+            return new CallbackReceipt(
+                    true,
+                    job.getJobId(),
+                    job.getUserId(),
+                    job.getOperationType(),
+                    job.getStatus().name().toLowerCase(Locale.ROOT),
+                    calculateQueuedAgeSeconds(job)
+            );
+        }
+
+        private static Double calculateQueuedAgeSeconds(ScrapeJob job) {
+            if (job.getCreatedAt() == null) {
+                return null;
+            }
+            return Duration.between(job.getCreatedAt(), Instant.now()).toMillis() / 1000.0;
+        }
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
@@ -19,7 +19,8 @@ public interface PortalLinkCallbackControllerDocs {
 
     @Operation(
             summary = "[Internal] 스크래핑 결과 콜백 수신",
-            description = "스크래핑 워커가 API Gateway를 통해 전달하는 결과 payload를 검증하고 DB에 반영합니다.\n"
+            description = "스크래핑 워커가 API Gateway를 통해 전달하는 job 상태와 result_s3_key를 검증하고 DB에 반영합니다.\n"
+                    + "실제 결과 payload는 result_s3_key 기반으로 백엔드가 S3에서 조회합니다.\n"
                     + "HMAC 서명 규칙: signature = HMAC_SHA256(\"{timestamp}.{rawBody}\").",
             responses = {
                     @ApiResponse(responseCode = "200", description = "콜백 처리 완료",

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCallbackControllerDocs.java
@@ -27,6 +27,8 @@ public interface PortalLinkCallbackControllerDocs {
                             content = @Content(schema = @Schema(implementation = MessageOnlyResponse.class))),
                     @ApiResponse(responseCode = "400", description = "서명 검증 실패 (INVALID_CALLBACK_SIGNATURE)",
                             content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 콜백 요청 (SCRAPE_INVALID_CALLBACK_REQUEST)",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
                     @ApiResponse(responseCode = "404", description = "job 미존재 (PORTAL_JOB_NOT_FOUND)",
                             content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
             }

--- a/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
@@ -84,6 +84,8 @@ public class PortalLinkDto {
             Integer attempt,
             @JsonProperty("result_s3_key")
             String result_s3_key,
+            @JsonProperty("result_checksum")
+            String resultChecksum,
             @JsonProperty("error_code")
             String error_code,
             @JsonProperty("error_message")

--- a/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
@@ -81,14 +81,17 @@ public class PortalLinkDto {
             @JsonProperty("job_id")
             String job_id,
             String status,
-            @JsonProperty("result_payload")
-            JsonNode result_payload,
+            Integer attempt,
+            @JsonProperty("result_s3_key")
+            String result_s3_key,
             @JsonProperty("error_code")
             String error_code,
             @JsonProperty("error_message")
             String error_message,
             Boolean retryable,
             @JsonProperty("finished_at")
-            Instant finished_at
+            Instant finished_at,
+            @JsonProperty("metadata")
+            JsonNode metadata
     ) {}
 }

--- a/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
+++ b/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
@@ -59,6 +59,15 @@ public class ScrapeJob extends BaseEntity {
     @Column(name = "result_payload_json", columnDefinition = "TEXT")
     private String resultPayloadJson;
 
+    @Column(name = "result_s3_key")
+    private String resultS3Key;
+
+    @Column(name = "callback_attempt")
+    private Integer callbackAttempt;
+
+    @Column(name = "callback_received_at")
+    private Instant callbackReceivedAt;
+
     @Column(name = "error_code")
     private String errorCode;
 
@@ -123,6 +132,10 @@ public class ScrapeJob extends BaseEntity {
         return resultPayloadJson != null;
     }
 
+    public boolean hasProcessedAttempt(int attempt) {
+        return callbackAttempt != null && attempt <= callbackAttempt;
+    }
+
     public void markSucceeded(String resultPayloadJson, Instant finishedAt) {
         recordWorkerResult(resultPayloadJson, finishedAt);
         this.status = ScrapeJobStatus.SUCCEEDED;
@@ -134,6 +147,16 @@ public class ScrapeJob extends BaseEntity {
         this.errorMessage = null;
         this.retryable = null;
         this.finishedAt = finishedAt;
+    }
+
+    public void recordCallbackAttempt(int attempt, Instant receivedAt) {
+        this.callbackAttempt = attempt;
+        this.callbackReceivedAt = receivedAt;
+    }
+
+    public void recordResultLocation(String resultS3Key, int attempt, Instant receivedAt) {
+        recordCallbackAttempt(attempt, receivedAt);
+        this.resultS3Key = resultS3Key;
     }
 
     public void markFailed(String errorCode, String errorMessage, Boolean retryable, Instant finishedAt) {

--- a/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
+++ b/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
@@ -62,11 +62,18 @@ public class ScrapeJob extends BaseEntity {
     @Column(name = "result_s3_key")
     private String resultS3Key;
 
+    @Column(name = "result_checksum")
+    private String resultChecksum;
+
     @Column(name = "callback_attempt")
     private Integer callbackAttempt;
 
     @Column(name = "callback_received_at")
     private Instant callbackReceivedAt;
+
+    @Lob
+    @Column(name = "callback_metadata_json", columnDefinition = "TEXT")
+    private String callbackMetadataJson;
 
     @Column(name = "error_code")
     private String errorCode;
@@ -136,6 +143,29 @@ public class ScrapeJob extends BaseEntity {
         return callbackAttempt != null && attempt <= callbackAttempt;
     }
 
+    public void markRunning() {
+        if (!isCompleted()) {
+            this.status = ScrapeJobStatus.RUNNING;
+        }
+    }
+
+    public void markPostProcessing(
+            String resultS3Key,
+            String resultChecksum,
+            String callbackMetadataJson,
+            int attempt,
+            Instant receivedAt
+    ) {
+        this.status = ScrapeJobStatus.POST_PROCESSING;
+        this.resultS3Key = resultS3Key;
+        this.resultChecksum = resultChecksum;
+        this.callbackMetadataJson = callbackMetadataJson;
+        this.errorCode = null;
+        this.errorMessage = null;
+        this.retryable = null;
+        recordCallbackAttempt(attempt, receivedAt);
+    }
+
     public void markSucceeded(String resultPayloadJson, Instant finishedAt) {
         recordWorkerResult(resultPayloadJson, finishedAt);
         this.status = ScrapeJobStatus.SUCCEEDED;
@@ -157,6 +187,20 @@ public class ScrapeJob extends BaseEntity {
     public void recordResultLocation(String resultS3Key, int attempt, Instant receivedAt) {
         recordCallbackAttempt(attempt, receivedAt);
         this.resultS3Key = resultS3Key;
+    }
+
+    public void recordFailedCallback(
+            int attempt,
+            Instant receivedAt,
+            String callbackMetadataJson,
+            String errorCode,
+            String errorMessage,
+            Boolean retryable,
+            Instant finishedAt
+    ) {
+        recordCallbackAttempt(attempt, receivedAt);
+        this.callbackMetadataJson = callbackMetadataJson;
+        markFailed(errorCode, errorMessage, retryable, finishedAt);
     }
 
     public void markFailed(String errorCode, String errorMessage, Boolean retryable, Instant finishedAt) {

--- a/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJobStatus.java
+++ b/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJobStatus.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.scrapejob.model;
 public enum ScrapeJobStatus {
     QUEUED,
     RUNNING,
+    POST_PROCESSING,
     SUCCEEDED,
     FAILED
 }

--- a/src/main/java/com/chukchuk/haksa/global/config/ScrapeJobDispatchConfig.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/ScrapeJobDispatchConfig.java
@@ -7,6 +7,9 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @RequiredArgsConstructor
@@ -37,5 +40,17 @@ public class ScrapeJobDispatchConfig {
         scheduler.setRemoveOnCancelPolicy(true);
         scheduler.initialize();
         return scheduler;
+    }
+
+    @Bean
+    public S3Client scrapeResultS3Client() {
+        ScrapingProperties.Callback.ResultStore store = scrapingProperties.getCallback().getResultStore();
+        return S3Client.builder()
+                .region(Region.of(store.getRegion()))
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .apiCallTimeout(java.time.Duration.ofSeconds(store.getApiCallTimeoutSeconds()))
+                        .apiCallAttemptTimeout(java.time.Duration.ofSeconds(store.getApiCallAttemptTimeoutSeconds()))
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/com/chukchuk/haksa/global/config/ScrapeJobDispatchConfig.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/ScrapeJobDispatchConfig.java
@@ -44,7 +44,7 @@ public class ScrapeJobDispatchConfig {
 
     @Bean
     public S3Client scrapeResultS3Client() {
-        ScrapingProperties.Callback.ResultStore store = scrapingProperties.getCallback().getResultStore();
+        ScrapingProperties.ResultStore store = scrapingProperties.getResultStore();
         return S3Client.builder()
                 .region(Region.of(store.getRegion()))
                 .overrideConfiguration(ClientOverrideConfiguration.builder()

--- a/src/main/java/com/chukchuk/haksa/global/config/ScrapingProperties.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/ScrapingProperties.java
@@ -14,6 +14,7 @@ public class ScrapingProperties {
     private String mode = "sync";
     private final Job job = new Job();
     private final Callback callback = new Callback();
+    private final ResultStore resultStore = new ResultStore();
     private final Scheduler scheduler = new Scheduler();
     private final Publisher publisher = new Publisher();
     private final Stale stale = new Stale();
@@ -29,19 +30,17 @@ public class ScrapingProperties {
     public static class Callback {
         private String hmacSecret = "";
         private long allowedSkewSeconds = 300;
-        private final ResultStore resultStore = new ResultStore();
+    }
 
-        @Getter
-        @Setter
-        public static class ResultStore {
-            private String bucket = "";
-            private String prefix = "";
-            private String region = "ap-northeast-2";
-            private long maxPayloadBytes = 2_097_152;
-            private long apiCallTimeoutSeconds = 10;
-            private long apiCallAttemptTimeoutSeconds = 5;
-        }
-
+    @Getter
+    @Setter
+    public static class ResultStore {
+        private String bucket = "";
+        private String prefix = "";
+        private String region = "ap-northeast-2";
+        private long maxPayloadBytes = 2_097_152;
+        private long apiCallTimeoutSeconds = 30;
+        private long apiCallAttemptTimeoutSeconds = 3;
     }
 
     @Getter

--- a/src/main/java/com/chukchuk/haksa/global/config/ScrapingProperties.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/ScrapingProperties.java
@@ -29,6 +29,19 @@ public class ScrapingProperties {
     public static class Callback {
         private String hmacSecret = "";
         private long allowedSkewSeconds = 300;
+        private final ResultStore resultStore = new ResultStore();
+
+        @Getter
+        @Setter
+        public static class ResultStore {
+            private String bucket = "";
+            private String prefix = "";
+            private String region = "ap-northeast-2";
+            private long maxPayloadBytes = 2_097_152;
+            private long apiCallTimeoutSeconds = 10;
+            private long apiCallAttemptTimeoutSeconds = 5;
+        }
+
     }
 
     @Getter

--- a/src/main/java/com/chukchuk/haksa/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/code/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
     SCRAPE_JOB_OUTBOX_DEAD("C12", "스크래핑 작업 전송이 중단되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     SCRAPE_JOB_NOT_COMPLETED("C13", "스크래핑 작업이 아직 완료되지 않았습니다.", HttpStatus.CONFLICT),
     SCRAPE_JOB_FAILED_RESULT("C14", "스크래핑 작업이 실패 상태입니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+    SCRAPE_INVALID_S3_KEY("C15", "허용되지 않은 S3 key 입니다.", HttpStatus.BAD_REQUEST),
+    SCRAPE_RESULT_S3_FAILED("C16", "S3에서 스크래핑 결과를 읽어오지 못했습니다.", HttpStatus.BAD_GATEWAY),
+    SCRAPE_RESULT_SCHEMA_INVALID("C17", "스크래핑 결과 스키마가 유효하지 않습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
+    SCRAPE_RESULT_POST_PROCESSING_FAILED("C18", "스크래핑 결과 후처리에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 인증 및 세션 관련
     SESSION_EXPIRED("A04", "로그인 세션이 만료되었습니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/chukchuk/haksa/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/code/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     SCRAPE_RESULT_S3_FAILED("C16", "S3에서 스크래핑 결과를 읽어오지 못했습니다.", HttpStatus.BAD_GATEWAY),
     SCRAPE_RESULT_SCHEMA_INVALID("C17", "스크래핑 결과 스키마가 유효하지 않습니다.", HttpStatus.UNPROCESSABLE_ENTITY),
     SCRAPE_RESULT_POST_PROCESSING_FAILED("C18", "스크래핑 결과 후처리에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    SCRAPE_INVALID_CALLBACK_REQUEST("C19", "스크래핑 콜백 요청이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 인증 및 세션 관련
     SESSION_EXPIRED("A04", "로그인 세션이 만료되었습니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/ScrapeResultResultStoreClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/ScrapeResultResultStoreClient.java
@@ -1,0 +1,171 @@
+package com.chukchuk.haksa.infrastructure.portal.client;
+
+import com.chukchuk.haksa.global.config.ScrapingProperties;
+import com.chukchuk.haksa.infrastructure.portal.exception.ScrapeResultPayloadAccessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScrapeResultResultStoreClient {
+
+    private static final String ERROR_CODE = "SCRAPE_S3_FAILURE";
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long INITIAL_BACKOFF_MS = 200L;
+
+    private final S3Client s3Client;
+    private final ScrapingProperties scrapingProperties;
+
+    public String fetch(String requestedLocation) {
+        ScrapingProperties.Callback.ResultStore store = scrapingProperties.getCallback().getResultStore();
+        S3Location location = resolveLocation(requestedLocation, store);
+        return fetchWithRetry(store, location);
+    }
+
+    private String fetchWithRetry(ScrapingProperties.Callback.ResultStore store, S3Location location) {
+        long backoffMs = INITIAL_BACKOFF_MS;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                HeadObjectResponse head = s3Client.headObject(HeadObjectRequest.builder()
+                        .bucket(location.bucket())
+                        .key(location.key())
+                        .build());
+                long contentLength = head.contentLength() == null ? -1L : head.contentLength();
+                validateContentLength(store, contentLength);
+
+                ResponseBytes<GetObjectResponse> responseBytes = s3Client.getObjectAsBytes(GetObjectRequest.builder()
+                        .bucket(location.bucket())
+                        .key(location.key())
+                        .build());
+                byte[] payload = responseBytes.asByteArray();
+                if (payload.length > store.getMaxPayloadBytes()) {
+                    throw new ScrapeResultPayloadAccessException(
+                            ERROR_CODE,
+                            "S3 payload exceeds max bytes: " + payload.length,
+                            false
+                    );
+                }
+                return new String(payload, StandardCharsets.UTF_8);
+            } catch (NoSuchKeyException exception) {
+                if (attempt == MAX_ATTEMPTS) {
+                    throw new ScrapeResultPayloadAccessException(
+                            ERROR_CODE,
+                            "S3 key not found: " + location.key(),
+                            true,
+                            exception
+                    );
+                }
+                sleep(backoffMs);
+                backoffMs *= 2;
+            } catch (SdkClientException | S3Exception exception) {
+                boolean retryable = isRetryable(exception);
+                if (!retryable || attempt == MAX_ATTEMPTS) {
+                    throw new ScrapeResultPayloadAccessException(
+                            ERROR_CODE,
+                            "Failed to fetch result from S3: " + exception.getMessage(),
+                            retryable,
+                            exception
+                    );
+                }
+                sleep(backoffMs);
+                backoffMs *= 2;
+            }
+        }
+        try {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "S3 fetch attempts exhausted", true);
+        } catch (ScrapeResultPayloadAccessException exception) {
+            throw exception;
+        }
+    }
+
+    private void validateContentLength(ScrapingProperties.Callback.ResultStore store, long contentLength) {
+        if (contentLength < 0) {
+            return;
+        }
+        if (contentLength > store.getMaxPayloadBytes()) {
+            throw new ScrapeResultPayloadAccessException(
+                    ERROR_CODE,
+                    "S3 payload exceeds max bytes: " + contentLength,
+                    false
+            );
+        }
+    }
+
+    private boolean isRetryable(Exception exception) {
+        if (exception instanceof S3Exception s3Exception) {
+            int status = s3Exception.statusCode();
+            if (status == 403) {
+                return false;
+            }
+            return status >= 500 || status == 404;
+        }
+        return true;
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private S3Location resolveLocation(String requestedLocation, ScrapingProperties.Callback.ResultStore store) {
+        if (requestedLocation == null || requestedLocation.isBlank()) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "result_s3_key is missing", true);
+        }
+        String location = requestedLocation.trim();
+        String bucket = store.getBucket();
+        String key = location;
+
+        if (location.startsWith("http://") || location.startsWith("https://")) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "S3 key must not be a URL", false);
+        }
+        if (location.startsWith("s3://")) {
+            String withoutScheme = location.substring("s3://".length());
+            int slashIndex = withoutScheme.indexOf('/');
+            if (slashIndex <= 0 || slashIndex == withoutScheme.length() - 1) {
+                throw new ScrapeResultPayloadAccessException(ERROR_CODE, "Invalid s3 uri: " + location, false);
+            }
+            bucket = withoutScheme.substring(0, slashIndex);
+            key = withoutScheme.substring(slashIndex + 1);
+        } else if (location.startsWith("/")) {
+            key = location.substring(1);
+        }
+
+        if (bucket == null || bucket.isBlank()) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "Result store bucket is not configured", false);
+        }
+        if (!bucket.equals(store.getBucket())) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "Bucket not allowed: " + bucket, false);
+        }
+
+        String prefix = store.getPrefix();
+        if (key.isBlank()) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "S3 key is blank", false);
+        }
+        if (key.contains("..") || key.contains("//")) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "S3 key contains invalid path traversal", false);
+        }
+        if (prefix != null && !prefix.isBlank() && !key.startsWith(prefix)) {
+            throw new ScrapeResultPayloadAccessException(ERROR_CODE, "S3 key outside allowed prefix", false);
+        }
+
+        return new S3Location(bucket, key);
+    }
+
+    private record S3Location(String bucket, String key) {}
+}

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/ScrapeResultResultStoreClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/ScrapeResultResultStoreClient.java
@@ -30,12 +30,16 @@ public class ScrapeResultResultStoreClient {
     private final ScrapingProperties scrapingProperties;
 
     public String fetch(String requestedLocation) {
-        ScrapingProperties.Callback.ResultStore store = scrapingProperties.getCallback().getResultStore();
-        S3Location location = resolveLocation(requestedLocation, store);
-        return fetchWithRetry(store, location);
+        S3Location location = validateLocation(requestedLocation);
+        return fetchWithRetry(location);
     }
 
-    private String fetchWithRetry(ScrapingProperties.Callback.ResultStore store, S3Location location) {
+    public S3Location validateLocation(String requestedLocation) {
+        return resolveLocation(requestedLocation, scrapingProperties.getResultStore());
+    }
+
+    private String fetchWithRetry(S3Location location) {
+        ScrapingProperties.ResultStore store = scrapingProperties.getResultStore();
         long backoffMs = INITIAL_BACKOFF_MS;
         for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
             try {
@@ -91,7 +95,7 @@ public class ScrapeResultResultStoreClient {
         }
     }
 
-    private void validateContentLength(ScrapingProperties.Callback.ResultStore store, long contentLength) {
+    private void validateContentLength(ScrapingProperties.ResultStore store, long contentLength) {
         if (contentLength < 0) {
             return;
         }
@@ -123,7 +127,7 @@ public class ScrapeResultResultStoreClient {
         }
     }
 
-    private S3Location resolveLocation(String requestedLocation, ScrapingProperties.Callback.ResultStore store) {
+    private S3Location resolveLocation(String requestedLocation, ScrapingProperties.ResultStore store) {
         if (requestedLocation == null || requestedLocation.isBlank()) {
             throw new ScrapeResultPayloadAccessException(ERROR_CODE, "result_s3_key is missing", true);
         }
@@ -167,5 +171,5 @@ public class ScrapeResultResultStoreClient {
         return new S3Location(bucket, key);
     }
 
-    private record S3Location(String bucket, String key) {}
+    public record S3Location(String bucket, String key) {}
 }

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/exception/ScrapeResultPayloadAccessException.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/exception/ScrapeResultPayloadAccessException.java
@@ -1,0 +1,22 @@
+package com.chukchuk.haksa.infrastructure.portal.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ScrapeResultPayloadAccessException extends RuntimeException {
+
+    private final String errorCode;
+    private final boolean retryable;
+
+    public ScrapeResultPayloadAccessException(String errorCode, String message, boolean retryable) {
+        super(message);
+        this.errorCode = errorCode;
+        this.retryable = retryable;
+    }
+
+    public ScrapeResultPayloadAccessException(String errorCode, String message, boolean retryable, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+        this.retryable = retryable;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,13 @@ scraping:
   callback:
     hmac-secret: ${SCRAPING_CALLBACK_HMAC_SECRET:}
     allowed-skew-seconds: ${SCRAPING_CALLBACK_ALLOWED_SKEW_SECONDS:300}
+    result-store:
+      bucket: ${SCRAPING_RESULT_BUCKET:}
+      prefix: ${SCRAPING_RESULT_PREFIX:}
+      region: ${SCRAPING_RESULT_REGION:ap-northeast-2}
+      max-payload-bytes: ${SCRAPING_RESULT_MAX_PAYLOAD_BYTES:2097152}
+      api-call-timeout-seconds: ${SCRAPING_RESULT_API_CALL_TIMEOUT_SECONDS:10}
+      api-call-attempt-timeout-seconds: ${SCRAPING_RESULT_API_CALL_ATTEMPT_TIMEOUT_SECONDS:5}
   scheduler:
     enabled: ${SCRAPING_SCHEDULER_ENABLED:true}
   publisher:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,13 +58,13 @@ scraping:
   callback:
     hmac-secret: ${SCRAPING_CALLBACK_HMAC_SECRET:}
     allowed-skew-seconds: ${SCRAPING_CALLBACK_ALLOWED_SKEW_SECONDS:300}
-    result-store:
-      bucket: ${SCRAPING_RESULT_BUCKET:}
-      prefix: ${SCRAPING_RESULT_PREFIX:}
-      region: ${SCRAPING_RESULT_REGION:ap-northeast-2}
-      max-payload-bytes: ${SCRAPING_RESULT_MAX_PAYLOAD_BYTES:2097152}
-      api-call-timeout-seconds: ${SCRAPING_RESULT_API_CALL_TIMEOUT_SECONDS:10}
-      api-call-attempt-timeout-seconds: ${SCRAPING_RESULT_API_CALL_ATTEMPT_TIMEOUT_SECONDS:5}
+  result-store:
+    bucket: ${SCRAPING_RESULT_BUCKET:cck-develop-shadow-scrape-results-984762359128}
+    prefix: ${SCRAPING_RESULT_PREFIX:develop-shadow/}
+    region: ${SCRAPING_RESULT_REGION:ap-northeast-2}
+    max-payload-bytes: ${SCRAPING_RESULT_MAX_PAYLOAD_BYTES:2097152}
+    api-call-timeout-seconds: ${SCRAPING_RESULT_API_CALL_TIMEOUT_SECONDS:30}
+    api-call-attempt-timeout-seconds: ${SCRAPING_RESULT_API_CALL_ATTEMPT_TIMEOUT_SECONDS:3}
   scheduler:
     enabled: ${SCRAPING_SCHEDULER_ENABLED:true}
   publisher:

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
@@ -5,6 +5,7 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -123,7 +125,7 @@ class PortalCallbackPostProcessorTests {
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         doThrow(new PortalScrapeException(ErrorCode.SCRAPING_FAILED)).when(portalSyncService).refreshFromPortal(eq(job.getUserId()), any());
 
-        processor.process(
+        assertThatThrownBy(() -> processor.process(
                 job.getJobId(),
                 job.getUserId(),
                 ScrapeJobOperationType.REFRESH,
@@ -133,7 +135,8 @@ class PortalCallbackPostProcessorTests {
                 1,
                 "",
                 "payload-hash"
-        );
+        )).isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED.code()));
 
         assertThat(meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "portal_conn_fail").count()).isEqualTo(1.0);
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);
@@ -147,7 +150,7 @@ class PortalCallbackPostProcessorTests {
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         doThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND)).when(portalSyncService).syncWithPortal(eq(job.getUserId()), any());
 
-        processor.process(
+        assertThatThrownBy(() -> processor.process(
                 job.getJobId(),
                 job.getUserId(),
                 ScrapeJobOperationType.LINK,
@@ -157,7 +160,8 @@ class PortalCallbackPostProcessorTests {
                 1,
                 "",
                 "payload-hash"
-        );
+        )).isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED.code()));
 
         assertThat(meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "user_missing").count()).isEqualTo(1.0);
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);
@@ -170,7 +174,7 @@ class PortalCallbackPostProcessorTests {
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
-        processor.process(
+        assertThatThrownBy(() -> processor.process(
             job.getJobId(),
             job.getUserId(),
             ScrapeJobOperationType.LINK,
@@ -180,7 +184,8 @@ class PortalCallbackPostProcessorTests {
             1,
             "",
             "invalid"
-        );
+        )).isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code()));
 
         assertThat(meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").count()).isEqualTo(1.0);
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
@@ -17,11 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.AbstractPlatformTransactionManager;
-import org.springframework.transaction.support.DefaultTransactionStatus;
-
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -56,42 +51,17 @@ class PortalCallbackPostProcessorTests {
 
     private SimpleMeterRegistry meterRegistry;
     private PortalCallbackPostProcessor processor;
-    private PlatformTransactionManager transactionManager;
+    private ScrapeResultCallbackTxService txService;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        transactionManager = new TestTransactionManager();
+        txService = new ScrapeResultCallbackTxService(scrapeJobRepository, portalSyncService, meterRegistry);
         processor = new PortalCallbackPostProcessor(
-                portalSyncService,
                 new ObjectMapper().findAndRegisterModules(),
                 meterRegistry,
-                scrapeJobRepository,
-                transactionManager
+                txService
         );
-    }
-
-    private static class TestTransactionManager extends AbstractPlatformTransactionManager {
-
-        @Override
-        protected Object doGetTransaction() {
-            return new Object();
-        }
-
-        @Override
-        protected void doBegin(Object transaction, TransactionDefinition definition) {
-            // no-op
-        }
-
-        @Override
-        protected void doCommit(DefaultTransactionStatus status) {
-            // no-op
-        }
-
-        @Override
-        protected void doRollback(DefaultTransactionStatus status) {
-            // no-op
-        }
     }
 
     @Test
@@ -121,6 +91,7 @@ class PortalCallbackPostProcessorTests {
     @DisplayName("PORTAL refresh 실패는 실패 메트릭에 reason=portal_conn_fail로 기록된다")
     void handle_portalFailure_recordsPortalReason() {
         ScrapeJob job = newJob(ScrapeJobOperationType.REFRESH);
+        job.markPostProcessing("callbacks/" + job.getJobId() + "/result.json", null, null, 1, Instant.now());
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         doThrow(new PortalScrapeException(ErrorCode.SCRAPING_FAILED)).when(portalSyncService).refreshFromPortal(eq(job.getUserId()), any());
@@ -146,6 +117,7 @@ class PortalCallbackPostProcessorTests {
     @DisplayName("EntityNotFoundException은 reason=user_missing으로 기록된다")
     void handle_userMissing_recordsReason() {
         ScrapeJob job = newJob(ScrapeJobOperationType.LINK);
+        job.markPostProcessing("callbacks/" + job.getJobId() + "/result.json", null, null, 1, Instant.now());
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         doThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND)).when(portalSyncService).syncWithPortal(eq(job.getUserId()), any());
@@ -171,6 +143,7 @@ class PortalCallbackPostProcessorTests {
     @DisplayName("Json 파싱 실패는 portal sync를 호출하지 않고 invalid_payload 메트릭을 증가시킨다")
     void handle_invalidPayload_recordsFailure() {
         ScrapeJob job = newJob(ScrapeJobOperationType.LINK);
+        job.markPostProcessing("callbacks/" + job.getJobId() + "/result.json", null, null, 1, Instant.now());
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
@@ -192,7 +165,7 @@ class PortalCallbackPostProcessorTests {
     }
 
     private static ScrapeJob newJob(ScrapeJobOperationType operationType) {
-        ScrapeJob job = ScrapeJob.createQueued(
+        return ScrapeJob.createQueued(
                 UUID.randomUUID(),
                 "suwon",
                 operationType,
@@ -200,7 +173,5 @@ class PortalCallbackPostProcessorTests {
                 "fingerprint",
                 "{}"
         );
-        job.recordWorkerResult(PAYLOAD_JSON, Instant.parse("2026-04-08T00:00:00Z"));
-        return job;
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcherUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcherUnitTests.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.application.portal;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutbox;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutboxStatus;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobOutboxRepository;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.config.ScrapingProperties;
@@ -66,6 +67,7 @@ class ScrapeJobOutboxDispatcherUnitTests {
 
         assertThat(outbox.getStatus()).isEqualTo(ScrapeJobOutboxStatus.SENT);
         assertThat(outbox.getQueueMessageId()).isEqualTo("msg-1");
+        assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.RUNNING);
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutbox;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutboxStatus;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobOutboxRepository;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.config.ScrapingProperties;
@@ -58,9 +59,10 @@ class ScrapeJobStaleReconcilerUnitTests {
                 "{\"username\":\"17019013\",\"password\":\"pw\"}"
         );
         ScrapeJobOutbox outbox = ScrapeJobOutbox.createPending(job.getJobId(), "{\"job_id\":\"" + job.getJobId() + "\"}", Instant.now());
+        job.markRunning();
         outbox.markSent("msg-1", Instant.now().minusSeconds(120));
 
-        when(scrapeJobOutboxRepository.findStaleSentTargetsForUpdate(eq(ScrapeJobOutboxStatus.SENT), any(), any(), any(Pageable.class)))
+        when(scrapeJobOutboxRepository.findStaleSentTargetsForUpdate(eq(ScrapeJobOutboxStatus.SENT), any(), eq(ScrapeJobStatus.RUNNING), any(Pageable.class)))
                 .thenReturn(List.of(outbox));
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +48,11 @@ class ScrapeResultCallbackServiceUnitTests {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
+        lenient().when(resultStoreClient.validateLocation(any()))
+                .thenAnswer(invocation -> new ScrapeResultResultStoreClient.S3Location(
+                        "bucket",
+                        invocation.getArgument(0, String.class)
+                ));
     }
 
     @Test
@@ -183,6 +190,30 @@ class ScrapeResultCallbackServiceUnitTests {
     }
 
     @Test
+    @DisplayName("S3 key 형식 검증이 실패하면 SCRAPE_INVALID_S3_KEY를 반환한다")
+    void handleCallback_rejectsInvalidS3KeyFormat() {
+        ScrapeResultCallbackService service = createService();
+        String timestamp = Instant.now().toString();
+        ScrapeJob job = createJob(UUID.randomUUID());
+        String rawBody = """
+                {
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\",
+                  \"result_s3_key\":\"invalid/key.json\"
+                }
+                """.formatted(job.getJobId());
+
+        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.validateLocation("invalid/key.json")).thenThrow(
+                new ScrapeResultPayloadAccessException("SCRAPE_S3_FAILURE", "prefix mismatch", false)
+        );
+
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_INVALID_S3_KEY.code()));
+    }
+
+    @Test
     @DisplayName("S3 읽기 실패 시 FAILED_S3_READ로 저장하고 SCRAPE_RESULT_S3_FAILED 반환")
     void handleCallback_marksS3Failure() {
         ScrapeResultCallbackService service = createService();
@@ -205,6 +236,32 @@ class ScrapeResultCallbackServiceUnitTests {
                 .isInstanceOf(CommonException.class)
                 .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_S3_FAILED.code()));
         assertThat(job.getErrorCode()).isEqualTo("FAILED_S3_READ");
+    }
+
+    @Test
+    @DisplayName("후처리 실패는 SCRAPE_RESULT_POST_PROCESSING_FAILED로 전달된다")
+    void handleCallback_propagatesPostProcessingFailure() {
+        ScrapeResultCallbackService service = createService();
+        ScrapeJob job = createJob(UUID.randomUUID());
+        String timestamp = Instant.now().toString();
+        String rawBody = """
+                {
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\",
+                  \"result_s3_key\":\"callbacks/%s/result.json\"
+                }
+                """.formatted(job.getJobId(), job.getJobId());
+
+        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.fetch("callbacks/%s/result.json".formatted(job.getJobId())))
+                .thenReturn("{\"schema_version\":\"v1\"}");
+        doThrow(new CommonException(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED))
+                .when(portalCallbackPostProcessor)
+                .process(any(), any(), any(), any(), any(), any(), anyInt(), any(), any());
+
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, "req-1"))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED.code()));
     }
 
     private ScrapeResultCallbackService createService() {

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -5,6 +5,8 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
+import com.chukchuk.haksa.infrastructure.portal.client.ScrapeResultResultStoreClient;
+import com.chukchuk.haksa.infrastructure.portal.exception.ScrapeResultPayloadAccessException;
 import com.chukchuk.haksa.infrastructure.security.HmacSignatureVerifier;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,6 +37,9 @@ class ScrapeResultCallbackServiceUnitTests {
 
     @Mock
     private PortalCallbackPostProcessor portalCallbackPostProcessor;
+
+    @Mock
+    private ScrapeResultResultStoreClient resultStoreClient;
 
     private SimpleMeterRegistry meterRegistry;
 
@@ -51,7 +55,7 @@ class ScrapeResultCallbackServiceUnitTests {
         String timestamp = Instant.now().toString();
 
         assertThatThrownBy(() -> service.handleCallback(
-                "{\"job_id\":\"job-1\",\"status\":\"failed\",\"error_code\":\"INVALID_PAYLOAD\",\"error_message\":\"bad\",\"retryable\":false,\"finished_at\":\"2026-03-14T10:01:00Z\"}",
+                "{\"job_id\":\"job-1\",\"status\":\"failed\",\"error_code\":\"INVALID\"}",
                 timestamp,
                 "invalid-signature",
                 null,
@@ -61,80 +65,72 @@ class ScrapeResultCallbackServiceUnitTests {
     }
 
     @Test
-    @DisplayName("성공 callback이면 LINK job을 성공 처리한다")
-    void handleCallback_marksLinkJobSucceeded() {
+    @DisplayName("성공 callback은 S3를 읽어 후처리를 동기 실행한다")
+    void handleCallback_fetchesS3Synchronously() {
         ScrapeResultCallbackService service = createService();
         UUID userId = UUID.randomUUID();
         String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                userId,
-                "suwon",
-                ScrapeJobOperationType.LINK,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
+        ScrapeJob job = createJob(userId);
+
         String rawBody = """
                 {
-                  "job_id":"%s",
-                  "status":"succeeded",
-                  "result_payload":{
-                    "student":{"sno":"17019013","studNm":"홍길동","univCd":"01","univNm":"수원대학교","dpmjCd":"D1","dpmjNm":"컴퓨터학부","mjorCd":"M1","mjorNm":"컴퓨터학과","the2MjorCd":null,"the2MjorNm":null,"scrgStatNm":"재학","enscYear":"2021","enscSmrCd":"10","enscDvcd":"신입","studGrde":4,"facSmrCnt":8},
-                    "semesters":[{"semester":"2024-10","courses":[{"subjtCd":"C101","subjtNm":"자료구조","ltrPrfsNm":"김교수","estbDpmjNm":"컴퓨터학부","point":3,"cretGrdCd":"A+","refacYearSmr":"-","timtSmryCn":"월1-2","facDvnm":"전공","cltTerrNm":"0영역","cltTerrCd":"0","subjtEstbSmrCd":"10","subjtEstbYearSmr":"2024-10","diclNo":"01","gainPont":"95","cretDelCd":null,"cretDelNm":null}]}],
-                    "academicRecords":{"listSmrCretSumTabYearSmr":[{"cretGainYear":"2024","cretSmrCd":"10","gainPoint":"18","applPoint":"18","gainAvmk":"4.2","gainTavgPont":"95","dpmjOrdp":"1/100"}],"selectSmrCretSumTabSjTotal":{"gainPoint":"120","applPoint":"130","gainAvmk":"3.8","gainTavgPont":"90"}}
-                  },
-                  "finished_at":"2026-03-14T10:01:00Z"
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\",
+                  \"result_s3_key\":\"callbacks/%s/result.json\",
+                  \"finished_at\":\"2026-03-14T10:01:00Z\"
                 }
-                """.formatted(job.getJobId());
+                """.formatted(job.getJobId(), job.getJobId());
 
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.fetch("callbacks/%s/result.json".formatted(job.getJobId())))
+                .thenReturn("""
+                        {
+                          \"schema_version\":\"v1\",
+                          \"student\":{\"sno\":\"17019013\",\"stud_nm\":\"홍길동\",\"univ_cd\":\"01\",\"univ_nm\":\"수원대학교\",\"stud_grde\":4},
+                          \"semesters\":[{\"semester\":\"2024-10\",\"courses\":[{\"subjt_cd\":\"C101\",\"subjt_nm\":\"자료구조\"}]}],
+                          \"academic_records\":{\"listSmrCretSumTabYearSmr\":[{\"cretGainYear\":\"2024\",\"gainPoint\":\"18\"}]}
+                        }
+                        """);
 
-        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
+        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), "2", "req-1");
 
-        assertThat(job.getResultPayloadJson()).isNotBlank();
+        verify(resultStoreClient).fetch("callbacks/%s/result.json".formatted(job.getJobId()));
         verify(portalCallbackPostProcessor).process(
-                eq(job.getJobId()),
-                eq(userId),
-                eq(ScrapeJobOperationType.LINK),
                 any(),
-                eq(Instant.parse("2026-03-14T10:01:00Z")),
                 any(),
-                eq(1),
-                eq(""),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyInt(),
+                any(),
                 any()
         );
+        assertThat(job.getResultPayloadJson()).isNotBlank();
     }
 
     @Test
-    @DisplayName("완료된 job의 중복 callback은 무시한다")
-    void handleCallback_ignoresDuplicateCallback() {
+    @DisplayName("이미 처리된 attempt면 중복으로 간주한다")
+    void handleCallback_ignoresDuplicateAttempt() {
         ScrapeResultCallbackService service = createService();
-        String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                UUID.randomUUID(),
-                "suwon",
-                ScrapeJobOperationType.REFRESH,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
-        job.markFailed("INVALID_PAYLOAD", "bad", false, Instant.parse("2026-03-14T10:01:00Z"));
+        ScrapeJob job = createJob(UUID.randomUUID());
+        job.recordCallbackAttempt(1, Instant.now());
+        job.markFailed("FAILED_S3_READ", "fail", true, Instant.now());
 
+        String timestamp = Instant.now().toString();
         String rawBody = """
                 {
-                  "job_id":"%s",
-                  "status":"failed",
-                  "error_code":"INVALID_PAYLOAD",
-                  "error_message":"bad",
-                  "retryable":false,
-                  "finished_at":"2026-03-14T10:01:00Z"
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\",
+                  \"result_s3_key\":\"callbacks/%s/result.json\"
                 }
-                """.formatted(job.getJobId());
+                """.formatted(job.getJobId(), job.getJobId());
 
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
-        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
+        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), "1", "req-1");
 
+        verify(resultStoreClient, never()).fetch(any());
         verify(portalCallbackPostProcessor, never()).process(any(), any(), any(), any(), any(), any(), anyInt(), any(), any());
     }
 
@@ -143,22 +139,15 @@ class ScrapeResultCallbackServiceUnitTests {
     void handleCallback_marksJobFailed() {
         ScrapeResultCallbackService service = createService();
         String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                UUID.randomUUID(),
-                "suwon",
-                ScrapeJobOperationType.REFRESH,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
+        ScrapeJob job = createJob(UUID.randomUUID());
         String rawBody = """
                 {
-                  "job_id":"%s",
-                  "status":"failed",
-                  "error_code":"PORTAL_AUTH_FAILED",
-                  "error_message":"invalid credential",
-                  "retryable":false,
-                  "finished_at":"2026-03-14T10:01:00Z"
+                  \"job_id\":\"%s\",
+                  \"status\":\"failed\",
+                  \"error_code\":\"PORTAL_AUTH_FAILED\",
+                  \"error_message\":\"invalid credential\",
+                  \"retryable\":false,
+                  \"finished_at\":\"2026-03-14T10:01:00Z\"
                 }
                 """.formatted(job.getJobId());
 
@@ -169,153 +158,80 @@ class ScrapeResultCallbackServiceUnitTests {
         assertThat(job.getStatus().name()).isEqualTo("FAILED");
         assertThat(job.getErrorCode()).isEqualTo("PORTAL_AUTH_FAILED");
         assertThat(job.getRetryable()).isFalse();
-        verify(portalCallbackPostProcessor, never()).process(any(), any(), any(), any(), any(), any(), anyInt(), any(), any());
+        verify(resultStoreClient, never()).fetch(any());
     }
 
     @Test
-    @DisplayName("성공 callback이면 REFRESH job을 재연동 흐름으로 처리한다")
-    void handleCallback_marksRefreshJobSucceeded() {
+    @DisplayName("result_s3_key 없이 성공 콜백이 오면 SCRAPE_INVALID_S3_KEY")
+    void handleCallback_requiresS3Key() {
         ScrapeResultCallbackService service = createService();
-        UUID userId = UUID.randomUUID();
         String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                userId,
-                "suwon",
-                ScrapeJobOperationType.REFRESH,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
+        ScrapeJob job = createJob(UUID.randomUUID());
+
         String rawBody = """
                 {
-                  "job_id":"%s",
-                  "status":"succeeded",
-                  "result_payload":{
-                    "student":{"sno":"17019013","studNm":"홍길동","univCd":"01","univNm":"수원대학교","dpmjCd":"D1","dpmjNm":"컴퓨터학부","mjorCd":"M1","mjorNm":"컴퓨터학과","the2MjorCd":null,"the2MjorNm":null,"scrgStatNm":"재학","enscYear":"2021","enscSmrCd":"10","enscDvcd":"신입","studGrde":4,"facSmrCnt":8},
-                    "semesters":[{"semester":"2024-10","courses":[{"subjtCd":"C101","subjtNm":"자료구조","ltrPrfsNm":"김교수","estbDpmjNm":"컴퓨터학부","point":3,"cretGrdCd":"A+","refacYearSmr":"-","timtSmryCn":"월1-2","facDvnm":"전공","cltTerrNm":"0영역","cltTerrCd":"0","subjtEstbSmrCd":"10","subjtEstbYearSmr":"2024-10","diclNo":"01","gainPont":"95","cretDelCd":null,"cretDelNm":null}]}],
-                    "academicRecords":{"listSmrCretSumTabYearSmr":[{"cretGainYear":"2024","cretSmrCd":"10","gainPoint":"18","applPoint":"18","gainAvmk":"4.2","gainTavgPont":"95","dpmjOrdp":"1/100"}],"selectSmrCretSumTabSjTotal":{"gainPoint":"120","applPoint":"130","gainAvmk":"3.8","gainTavgPont":"90"}}
-                  },
-                  "finished_at":"2026-03-14T10:01:00Z"
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\"
                 }
                 """.formatted(job.getJobId());
 
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
-        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
-
-        verify(portalCallbackPostProcessor).process(
-                eq(job.getJobId()),
-                eq(userId),
-                eq(ScrapeJobOperationType.REFRESH),
-                any(),
-                eq(Instant.parse("2026-03-14T10:01:00Z")),
-                any(),
-                eq(1),
-                eq(""),
-                any()
-        );
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_INVALID_S3_KEY.code()));
     }
 
     @Test
-    @DisplayName("성공 callback의 result_payload가 snake_case여도 성공 처리한다")
-    void handleCallback_acceptsSnakeCaseResultPayload() {
+    @DisplayName("S3 읽기 실패 시 FAILED_S3_READ로 저장하고 SCRAPE_RESULT_S3_FAILED 반환")
+    void handleCallback_marksS3Failure() {
         ScrapeResultCallbackService service = createService();
-        UUID userId = UUID.randomUUID();
+        ScrapeJob job = createJob(UUID.randomUUID());
         String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                userId,
-                "suwon",
-                ScrapeJobOperationType.LINK,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
+
         String rawBody = """
                 {
-                  "job_id":"%s",
-                  "status":"succeeded",
-                  "result_payload":{
-                    "student":{"sno":"17019013","stud_nm":"홍길동","univ_cd":"01","univ_nm":"수원대학교","dpmj_cd":"D1","dpmj_nm":"컴퓨터학부","mjor_cd":"M1","mjor_nm":"컴퓨터학과","the2_mjor_cd":null,"the2_mjor_nm":null,"scrg_stat_nm":"재학","ensc_year":"2021","ensc_smr_cd":"10","ensc_dvcd":"신입","stud_grde":4,"fac_smr_cnt":8},
-                    "semesters":[{"semester":"2024-10","courses":[{"subjt_cd":"C101","subjt_nm":"자료구조","ltr_prfs_nm":"김교수","estb_dpmj_nm":"컴퓨터학부","point":3,"cret_grd_cd":"A+","refac_year_smr":"-","timt_smry_cn":"월1-2","fac_dvnm":"전공","clt_terr_nm":"0영역","clt_terr_cd":"0","subjt_estb_smr_cd":"10","subjt_estb_year_smr":"2024-10","dicl_no":"01","gain_pont":"95","cret_del_cd":null,"cret_del_nm":null}]}],
-                    "academic_records":{"list_smr_cret_sum_tab_year_smr":[{"cret_gain_year":"2024","cret_smr_cd":"10","gain_point":"18","appl_point":"18","gain_avmk":"4.2","gain_tavg_pont":"95","dpmj_ordp":"1/100"}],"select_smr_cret_sum_tab_sj_total":{"gain_point":"120","appl_point":"130","gain_avmk":"3.8","gain_tavg_pont":"90"}}
-                  },
-                  "finished_at":"2026-03-14T10:01:00Z"
+                  \"job_id\":\"%s\",
+                  \"status\":\"succeeded\",
+                  \"result_s3_key\":\"callbacks/%s/result.json\"
                 }
-                """.formatted(job.getJobId());
+                """.formatted(job.getJobId(), job.getJobId());
 
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.fetch("callbacks/%s/result.json".formatted(job.getJobId())))
+                .thenThrow(new ScrapeResultPayloadAccessException("SCRAPE_S3_FAILURE", "missing", true));
 
-        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
-
-        verify(portalCallbackPostProcessor).process(
-                eq(job.getJobId()),
-                eq(userId),
-                eq(ScrapeJobOperationType.LINK),
-                any(),
-                eq(Instant.parse("2026-03-14T10:01:00Z")),
-                any(),
-                eq(1),
-                eq(""),
-                any()
-        );
-    }
-
-    @Test
-    @DisplayName("성공 callback의 course에 extra field가 있어도 성공 처리한다")
-    void handleCallback_ignoresUnknownCourseField() {
-        ScrapeResultCallbackService service = createService();
-        UUID userId = UUID.randomUUID();
-        String timestamp = Instant.now().toString();
-        ScrapeJob job = ScrapeJob.createQueued(
-                userId,
-                "suwon",
-                ScrapeJobOperationType.LINK,
-                "idem-1",
-                "fingerprint",
-                "{\"username\":\"17019013\",\"password\":\"pw\"}"
-        );
-        String rawBody = """
-                {
-                  "job_id":"%s",
-                  "status":"succeeded",
-                  "result_payload":{
-                    "student":{"sno":"17019013","studNm":"홍길동","univCd":"01","univNm":"수원대학교","dpmjCd":"D1","dpmjNm":"컴퓨터학부","mjorCd":"M1","mjorNm":"컴퓨터학과","the2MjorCd":null,"the2MjorNm":null,"scrgStatNm":"재학","enscYear":"2021","enscSmrCd":"10","enscDvcd":"신입","studGrde":4,"facSmrCnt":8},
-                    "semesters":[{"semester":"2024-10","courses":[{"subjtCd":"C101","subjtNm":"자료구조","ltrPrfsNm":"김교수","estbDpmjNm":"컴퓨터학부","point":3,"cretGrdCd":"A+","refacYearSmr":"-","timtSmryCn":"월1-2","facDvnm":"전공","cltTerrNm":"0영역","cltTerrCd":"0","subjtEstbYear":"2024","subjtEstbSmrCd":"10","subjtEstbYearSmr":"2024-10","diclNo":"01","gainPont":"95","cretDelCd":null,"cretDelNm":null}]}],
-                    "academicRecords":{"listSmrCretSumTabYearSmr":[{"cretGainYear":"2024","cretSmrCd":"10","gainPoint":"18","applPoint":"18","gainAvmk":"4.2","gainTavgPont":"95","dpmjOrdp":"1/100"}],"selectSmrCretSumTabSjTotal":{"gainPoint":"120","applPoint":"130","gainAvmk":"3.8","gainTavgPont":"90"}}
-                  },
-                  "finished_at":"2026-03-14T10:01:00Z"
-                }
-                """.formatted(job.getJobId());
-
-        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
-
-        service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
-
-        verify(portalCallbackPostProcessor).process(
-                eq(job.getJobId()),
-                eq(userId),
-                eq(ScrapeJobOperationType.LINK),
-                any(),
-                eq(Instant.parse("2026-03-14T10:01:00Z")),
-                any(),
-                eq(1),
-                eq(""),
-                any()
-        );
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, "req-1"))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_S3_FAILED.code()));
+        assertThat(job.getErrorCode()).isEqualTo("FAILED_S3_READ");
     }
 
     private ScrapeResultCallbackService createService() {
+        HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
         return new ScrapeResultCallbackService(
                 scrapeJobRepository,
                 portalCallbackPostProcessor,
-                new HmacSignatureVerifier("test-callback-secret", 300),
+                resultStoreClient,
+                verifier,
                 meterRegistry
         );
     }
 
-    private static String sign(String timestamp, String rawBody) {
-        HmacSignatureVerifier verifier = new HmacSignatureVerifier("test-callback-secret", 300);
-        byte[] signatureBytes = verifier.hmac(timestamp + "." + rawBody);
-        return Base64.getEncoder().encodeToString(signatureBytes);
+    private ScrapeJob createJob(UUID userId) {
+        return ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "fingerprint",
+                "{\"username\":\"170\",\"password\":\"pw\"}"
+        );
+    }
+
+    private String sign(String timestamp, String rawBody) {
+        String data = timestamp + "." + rawBody;
+        HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
+        return Base64.getEncoder().encodeToString(verifier.hmac(data));
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -84,6 +84,7 @@ class ScrapeResultCallbackServiceUnitTests {
                   \"job_id\":\"%s\",
                   \"status\":\"succeeded\",
                   \"result_s3_key\":\"callbacks/%s/result.json\",
+                  \"result_checksum\":\"sha256:abc123\",
                   \"finished_at\":\"2026-03-14T10:01:00Z\"
                 }
                 """.formatted(job.getJobId(), job.getJobId());

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -2,6 +2,7 @@ package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
@@ -42,6 +43,9 @@ class ScrapeResultCallbackServiceUnitTests {
 
     @Mock
     private ScrapeResultResultStoreClient resultStoreClient;
+
+    @Mock
+    private PortalSyncService portalSyncService;
 
     private SimpleMeterRegistry meterRegistry;
 
@@ -84,7 +88,6 @@ class ScrapeResultCallbackServiceUnitTests {
                   \"job_id\":\"%s\",
                   \"status\":\"succeeded\",
                   \"result_s3_key\":\"callbacks/%s/result.json\",
-                  \"result_checksum\":\"sha256:abc123\",
                   \"finished_at\":\"2026-03-14T10:01:00Z\"
                 }
                 """.formatted(job.getJobId(), job.getJobId());
@@ -114,7 +117,8 @@ class ScrapeResultCallbackServiceUnitTests {
                 any(),
                 any()
         );
-        assertThat(job.getResultPayloadJson()).isNotBlank();
+        assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.POST_PROCESSING);
+        assertThat(job.getResultS3Key()).isEqualTo("callbacks/%s/result.json".formatted(job.getJobId()));
     }
 
     @Test
@@ -183,8 +187,6 @@ class ScrapeResultCallbackServiceUnitTests {
                 }
                 """.formatted(job.getJobId());
 
-        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
-
         assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null))
                 .isInstanceOf(CommonException.class)
                 .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_INVALID_S3_KEY.code()));
@@ -204,7 +206,6 @@ class ScrapeResultCallbackServiceUnitTests {
                 }
                 """.formatted(job.getJobId());
 
-        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
         when(resultStoreClient.validateLocation("invalid/key.json")).thenThrow(
                 new ScrapeResultPayloadAccessException("SCRAPE_S3_FAILURE", "prefix mismatch", false)
         );
@@ -267,9 +268,14 @@ class ScrapeResultCallbackServiceUnitTests {
 
     private ScrapeResultCallbackService createService() {
         HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
-        return new ScrapeResultCallbackService(
+        ScrapeResultCallbackTxService txService = new ScrapeResultCallbackTxService(
                 scrapeJobRepository,
+                portalSyncService,
+                meterRegistry
+        );
+        return new ScrapeResultCallbackService(
                 portalCallbackPostProcessor,
+                txService,
                 resultStoreClient,
                 verifier,
                 meterRegistry

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/InternalScrapeResultControllerApiIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/InternalScrapeResultControllerApiIntegrationTest.java
@@ -33,10 +33,8 @@ class InternalScrapeResultControllerApiIntegrationTest extends ApiControllerWebM
         String body = """
                 {
                   "job_id":"job-1",
-                  "status":"failed",
-                  "error_code":"INVALID_PAYLOAD",
-                  "error_message":"bad",
-                  "retryable":false,
+                  "status":"succeeded",
+                  "result_s3_key":"callbacks/job-1/result.json",
                   "finished_at":"2026-03-14T10:01:00Z"
                 }
                 """;


### PR DESCRIPTION
### 변경 사항
- `/internal/scrape-results`의 긴 단일 트랜잭션 구조를 분리했습니다.
- callback 접수, S3 조회, 후처리, 상태 반영 경계를 정리했습니다.
- `scrape_jobs` 상태에 `POST_PROCESSING`을 추가해 worker 실행과 backend 후처리를 구분했습니다.
- callback 단계별 로그/메트릭을 추가해 병목 구간을 추적할 수 있게 했습니다.
- outbox publish 후 `RUNNING` 전이, stale timeout 판정 기준도 함께 정리했습니다.


### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue

Closes #215

