### PR TITLE
221 feat: EventBridge maintenance direct invoke 전환

### DIFF
--- a/docs/specs/20260426-issue-221-eventbridge-maintenance/clarify.md
+++ b/docs/specs/20260426-issue-221-eventbridge-maintenance/clarify.md
@@ -1,0 +1,28 @@
+# Clarify
+
+## Open Questions
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | EventBridge Scheduler는 HTTP endpoint를 호출할지 Lambda를 직접 invoke할지? | BE 팀 | Decided |
+| 2 | Lambda direct invoke 인증은 어떻게 처리할지? | BE 팀 | Decided |
+| 3 | 기존 내부 `@Scheduled` 유지 여부는? | BE 팀 | Decided |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | EventBridge Scheduler -> Backend Lambda direct invoke를 사용한다. | Lambda 환경에서 HTTP/HMAC endpoint보다 IAM invoke permission이 단순하고 안전하다. | 2026-04-26 |
+| 2 | 인증은 HMAC이 아니라 scheduler role의 Lambda invoke IAM 권한으로 처리한다. | direct invoke는 API Gateway를 거치지 않으므로 IAM 경계가 자연스럽다. | 2026-04-26 |
+| 3 | stale job reconcile과 refresh token cleanup은 내부 `@Scheduled`를 제거하고 maintenance event에서 직접 호출한다. | Lambda 내부 scheduler/thread 생명주기에 의존하지 않기 위함이다. | 2026-04-26 |
+| 4 | HTTP internal endpoint는 추가하지 않는다. | 공격면과 인증 구현을 늘리지 않기 위함이다. | 2026-04-26 |
+| 5 | 사용자 "feat/218을 기준으로 feat/221을 생성하고 아까 계획한 작업을 시작" 지시로 OK to implement 승인 확보. | Phase 2 진행 승인. | 2026-04-26 |
+
+## Risks / Unknowns
+- Item: Lambda handler에서 HTTP event와 maintenance event를 잘못 구분할 가능성
+  - Impact: HTTP 요청이 maintenance 경로로 라우팅되거나 반대로 maintenance event가 HTTP proxy로 넘어갈 수 있음
+  - Mitigation: `source=eventbridge.scheduler`와 `task` 존재 여부를 모두 확인하고, HTTP event 회귀 테스트 추가
+- Item: EventBridge Scheduler 재시도에 따른 중복 실행
+  - Impact: 동일 cleanup/reconcile이 반복 실행될 수 있음
+  - Mitigation: 기존 cleanup/reconcile 로직을 idempotent하게 유지하고 affected count만 반환
+
+## Follow-ups
+- [ ] Terraform/EventBridge Scheduler rule, target, IAM invoke permission은 인프라 작업에서 반영한다.

--- a/docs/specs/20260426-issue-221-eventbridge-maintenance/plan.md
+++ b/docs/specs/20260426-issue-221-eventbridge-maintenance/plan.md
@@ -1,0 +1,44 @@
+# Plan
+
+## Architecture / Layering
+- Domain impact: 없음. 기존 scrape job 상태 전이 규칙과 refresh token 만료 규칙을 유지한다.
+- Application orchestration:
+  - maintenance task enum과 handler를 추가한다.
+  - handler는 task별로 `ScrapeJobStaleReconciler`와 `RefreshTokenService`를 호출하고 affected count를 반환한다.
+- Infrastructure touchpoints: 신규 외부 client나 DB schema 없음.
+- Global/config changes:
+  - `StreamLambdaHandler`가 raw input을 읽어 EventBridge Scheduler maintenance event면 Spring bean으로 라우팅한다.
+  - maintenance event가 아니면 기존 HTTP proxy stream 경로로 넘긴다.
+
+## Data / Transactions
+- Repositories touched:
+  - 기존 stale job reconcile repository 접근.
+  - 기존 refresh token repository 삭제 메서드.
+- Transaction scope:
+  - 각 maintenance task service 내부의 기존 짧은 트랜잭션을 유지한다.
+  - Lambda handler 자체에는 트랜잭션을 두지 않는다.
+- Consistency expectations:
+  - EventBridge 재시도/중복 실행에도 결과가 깨지지 않아야 한다.
+
+## Testing Strategy
+- Application tests:
+  - known task가 올바른 service를 호출하고 affected count를 반환하는지 검증.
+  - unknown task는 실패하는지 검증.
+  - refresh token cleanup이 삭제 count를 반환하는지 검증.
+- Global/Lambda tests:
+  - EventBridge Scheduler event가 maintenance handler로 라우팅되는지 검증.
+  - 일반 HTTP API event는 기존 proxy handler로 전달되는지 회귀 검증.
+- Additional commands:
+  - `./gradlew test --tests "com.chukchuk.haksa.application.maintenance.*"`
+  - `./gradlew test --tests "com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest"`
+  - `./gradlew test`
+
+## Rollout Considerations
+- Backward compatibility:
+  - HTTP API event 처리 경로는 유지한다.
+  - 기존 scheduler bean은 코드에서 사용하지 않도록 정리한다.
+- Observability / metrics:
+  - task, scheduled_at, affected_count, elapsed_ms를 maintenance 로그에 남긴다.
+- Feature flags / toggles:
+  - 별도 feature flag 없음.
+  - Lambda 환경에서는 `SCRAPING_SCHEDULER_ENABLED=false`를 인프라에서 설정하는 것을 권장한다.

--- a/docs/specs/20260426-issue-221-eventbridge-maintenance/spec.md
+++ b/docs/specs/20260426-issue-221-eventbridge-maintenance/spec.md
@@ -1,0 +1,106 @@
+# 221 EventBridge Maintenance Direct Invoke
+
+## 1. Feature Overview
+- Purpose: Lambda 내부 `@Scheduled` 실행에 의존하던 유지보수 작업을 EventBridge Scheduler가 백엔드 Lambda를 직접 invoke하는 방식으로 전환한다.
+- Scope
+  - In:
+    - EventBridge Scheduler payload를 Lambda handler에서 감지하고 HTTP proxy 처리와 분기한다.
+    - `SCRAPE_JOB_RECONCILE_STALE`, `REFRESH_TOKEN_CLEANUP` maintenance task를 처리한다.
+    - 기존 stale scrape job 정리와 refresh token 정리 로직은 재사용하되 `@Scheduled` 의존을 제거한다.
+  - Out:
+    - HTTP internal endpoint 추가.
+    - HMAC 인증 추가.
+    - Terraform/EventBridge 리소스 생성.
+    - 신규 DB DDL.
+- Expected Impact:
+  - Lambda 런타임 내부 scheduler/thread 생명주기에 의존하지 않고 외부 durable trigger로 유지보수 작업을 실행할 수 있다.
+  - 기존 HTTP API Lambda handler는 HTTP 요청을 계속 처리한다.
+- Stakeholder Confirmation:
+  - 2026-04-26 사용자 요청: `feat/218` 기준 `feat/221` 생성 후 EventBridge Scheduler 직접 invoke 방식 적용.
+
+## 2. Domain Rules
+- Rule 1: stale scrape job 정리는 기존 정책을 유지한다. 오래 `RUNNING`에 머문 job은 `FAILED`와 callback timeout 계열 오류로 전이한다.
+- Rule 2: 만료된 refresh token 삭제는 기존 삭제 기준을 유지한다.
+- Rule 3: maintenance task는 허용된 task enum만 실행하며, 알 수 없는 task는 실패로 처리한다.
+- Mutable Rules:
+  - EventBridge payload의 `scheduled_at`은 로깅/추적용이며 비즈니스 기준 시간으로 사용하지 않는다.
+- Immutable Rules:
+  - EventBridge Scheduler 인증은 HTTP/HMAC이 아니라 Lambda invoke IAM 권한으로 처리한다.
+  - Lambda handler는 HTTP API event를 기존 proxy 경로로 계속 전달해야 한다.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: stale scrape job reconcile
+  - Trigger: EventBridge Scheduler 직접 Lambda invoke
+  - Actor: EventBridge Scheduler role
+  - Steps:
+    1. Lambda handler가 payload `source=eventbridge.scheduler`, `task=SCRAPE_JOB_RECONCILE_STALE`를 감지한다.
+    2. Spring bean maintenance handler로 라우팅한다.
+    3. stale job reconciler가 기존 정책대로 오래된 job을 실패 처리한다.
+  - Expected Result: 성공 응답 JSON에 task, success, affected count가 기록된다.
+
+- Scenario Name: refresh token cleanup
+  - Trigger: EventBridge Scheduler 직접 Lambda invoke
+  - Actor: EventBridge Scheduler role
+  - Steps:
+    1. Lambda handler가 payload `task=REFRESH_TOKEN_CLEANUP`를 감지한다.
+    2. refresh token cleanup service를 호출한다.
+  - Expected Result: 성공 응답 JSON에 task, success, deleted count가 기록된다.
+
+### Exception / Boundary Flow
+- Scenario Name: unknown maintenance task
+  - Condition: `source=eventbridge.scheduler`이지만 task가 허용 목록에 없음
+  - Expected Behavior: Lambda invocation이 실패하고 error log를 남긴다.
+
+- Scenario Name: HTTP request
+  - Condition: HTTP API v2 payload가 들어옴
+  - Expected Behavior: 기존 `SpringBootLambdaContainerHandler.proxyStream` 경로로 처리한다.
+
+## 4. Transaction / Consistency
+- Transaction Start Point:
+  - stale job reconcile: 기존 reconciler 트랜잭션 경계.
+  - refresh token cleanup: refresh token 삭제 메서드 트랜잭션 경계.
+- Transaction End Point: 각 maintenance task 메서드 종료 시점.
+- Atomicity Scope: task 1회 실행 단위.
+- Eventual Consistency Allowed: EventBridge Scheduler 재시도에 의해 동일 작업이 다시 실행될 수 있으므로 cleanup/reconcile은 idempotent해야 한다.
+
+## 5. API List
+- Public HTTP Endpoint: 없음.
+- Lambda Event Contract:
+  - Request:
+    - `source`: `eventbridge.scheduler`
+    - `task`: `SCRAPE_JOB_RECONCILE_STALE` 또는 `REFRESH_TOKEN_CLEANUP`
+    - `scheduled_at`: ISO-8601 문자열, optional
+  - Response:
+    - `success`: boolean
+    - `task`: string
+    - `affected_count`: number
+    - `scheduled_at`: string/null
+
+## 6. Exception Policy
+- Error Code: `UNKNOWN_MAINTENANCE_TASK`
+  - Condition: task 값이 없거나 허용 목록에 없음
+  - Message Convention: task/source 값을 포함해 운영 로그로 추적 가능하게 작성
+  - Handling Layer: global lambda maintenance handler
+  - User Exposure: EventBridge invocation failure
+- Error Code: `MAINTENANCE_TASK_FAILED`
+  - Condition: task 실행 중 예외 발생
+  - Message Convention: task, scheduled_at, exception class를 로그에 남김
+  - Handling Layer: application/global
+  - User Exposure: EventBridge invocation failure
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed
+- [x] Phase 2 Domain complete
+- [x] Phase 3 Application complete
+- [x] Phase 4 Infrastructure complete
+- [x] Phase 5 Global/Config complete
+- [x] Phase 6 API/Controller complete
+
+## 8. Generated File List
+- Path: `src/main/java/com/chukchuk/haksa/application/maintenance`
+  - Description: maintenance task routing and service orchestration
+  - Layer: Application
+- Path: `src/main/java/com/chukchuk/haksa/global/lambda`
+  - Description: EventBridge direct invoke detection and routing
+  - Layer: Global

--- a/docs/specs/20260426-issue-221-eventbridge-maintenance/tasks.md
+++ b/docs/specs/20260426-issue-221-eventbridge-maintenance/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## Checklist
+- [x] Spec bundle 작성
+- [x] Maintenance application tests 작성
+- [x] Lambda routing tests 작성
+- [x] Maintenance application handler 구현
+- [x] Lambda handler direct invoke 분기 구현
+- [x] 내부 `@Scheduled` 의존 제거
+- [x] Documentation updated
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test --tests "com.chukchuk.haksa.application.maintenance.*" --tests "com.chukchuk.haksa.application.portal.ScrapeJobStaleReconcilerUnitTests" --tests "com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests" --tests "com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest"` | Pass | 2026-04-26 |
+| 2 | `./gradlew test --tests "com.chukchuk.haksa.global.config.SchedulingConfigTests" --tests "com.chukchuk.haksa.application.maintenance.*" --tests "com.chukchuk.haksa.application.portal.ScrapeJobStaleReconcilerUnitTests" --tests "com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests" --tests "com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest"` | Pass | 2026-04-26 |
+| 3 | `./gradlew test` | Pass | 2026-04-26 |
+| 4 | `./gradlew build` | Pass | 2026-04-26 |
+
+## Notes
+- Observation: 이번 작업은 HTTP endpoint 추가 없이 EventBridge Scheduler direct Lambda invoke만 지원한다.

--- a/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskHandler.java
+++ b/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskHandler.java
@@ -1,0 +1,30 @@
+package com.chukchuk.haksa.application.maintenance;
+
+import com.chukchuk.haksa.application.portal.ScrapeJobStaleReconciler;
+import com.chukchuk.haksa.domain.auth.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MaintenanceTaskHandler {
+
+    private final ScrapeJobStaleReconciler scrapeJobStaleReconciler;
+    private final RefreshTokenService refreshTokenService;
+
+    public MaintenanceTaskResult handle(MaintenanceTaskRequest request) {
+        long startedAt = System.nanoTime();
+        MaintenanceTaskType taskType = MaintenanceTaskType.from(request.task());
+        int affectedCount = switch (taskType) {
+            case SCRAPE_JOB_RECONCILE_STALE -> scrapeJobStaleReconciler.reconcileStaleQueuedJobs();
+            case REFRESH_TOKEN_CLEANUP -> refreshTokenService.deletedExpiredTokens();
+        };
+
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+        log.info("[BIZ] maintenance.task.completed task={} scheduledAt={} affectedCount={} elapsed_ms={}",
+                taskType.name(), request.scheduledAt(), affectedCount, elapsedMs);
+        return MaintenanceTaskResult.success(taskType.name(), affectedCount, request.scheduledAt());
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskRequest.java
+++ b/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskRequest.java
@@ -1,0 +1,8 @@
+package com.chukchuk.haksa.application.maintenance;
+
+public record MaintenanceTaskRequest(
+        String source,
+        String task,
+        String scheduledAt
+) {
+}

--- a/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskResult.java
+++ b/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskResult.java
@@ -1,0 +1,17 @@
+package com.chukchuk.haksa.application.maintenance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MaintenanceTaskResult(
+        boolean success,
+        String task,
+        @JsonProperty("affected_count")
+        int affectedCount,
+        @JsonProperty("scheduled_at")
+        String scheduledAt
+) {
+
+    public static MaintenanceTaskResult success(String task, int affectedCount, String scheduledAt) {
+        return new MaintenanceTaskResult(true, task, affectedCount, scheduledAt);
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskType.java
+++ b/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskType.java
@@ -1,0 +1,15 @@
+package com.chukchuk.haksa.application.maintenance;
+
+import java.util.Arrays;
+
+public enum MaintenanceTaskType {
+    SCRAPE_JOB_RECONCILE_STALE,
+    REFRESH_TOKEN_CLEANUP;
+
+    public static MaintenanceTaskType from(String value) {
+        return Arrays.stream(values())
+                .filter(taskType -> taskType.name().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown maintenance task: " + value));
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskType.java
+++ b/src/main/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskType.java
@@ -1,15 +1,21 @@
 package com.chukchuk.haksa.application.maintenance;
 
 import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public enum MaintenanceTaskType {
     SCRAPE_JOB_RECONCILE_STALE,
     REFRESH_TOKEN_CLEANUP;
 
+    private static final Map<String, MaintenanceTaskType> LOOKUP = Arrays.stream(values())
+            .collect(Collectors.toUnmodifiableMap(Enum::name, taskType -> taskType));
+
     public static MaintenanceTaskType from(String value) {
-        return Arrays.stream(values())
-                .filter(taskType -> taskType.name().equals(value))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Unknown maintenance task: " + value));
+        MaintenanceTaskType taskType = LOOKUP.get(value);
+        if (taskType == null) {
+            throw new IllegalArgumentException("Unknown maintenance task: " + value);
+        }
+        return taskType;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -12,7 +12,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,11 +29,10 @@ public class ScrapeJobStaleReconciler {
     private final ScrapingProperties scrapingProperties;
     private final MeterRegistry meterRegistry;
 
-    @Scheduled(fixedDelayString = "${scraping.stale.fixed-delay-ms:60000}")
     @Transactional
-    public void reconcileStaleQueuedJobs() {
+    public int reconcileStaleQueuedJobs() {
         if (!scrapingProperties.getStale().isEnabled()) {
-            return;
+            return 0;
         }
 
         Instant now = Instant.now();
@@ -46,6 +44,7 @@ public class ScrapeJobStaleReconciler {
                 PageRequest.of(0, scrapingProperties.getStale().getBatchSize())
         );
 
+        int affectedCount = 0;
         for (ScrapeJobOutbox outbox : staleOutboxes) {
             ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(outbox.getJobId()).orElse(null);
             if (job == null || job.isCompleted()) {
@@ -60,9 +59,11 @@ public class ScrapeJobStaleReconciler {
             );
             meterRegistry.counter("scrape.job.callback.timeout").increment();
             recordQueuedAge(job, now);
+            affectedCount++;
             log.warn("[BIZ] scrape.job.callback.timeout jobId={} outboxId={} attempt={} outboxStatus={} queueMessageId={}",
                     job.getJobId(), outbox.getOutboxId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
         }
+        return affectedCount;
     }
 
     private void recordQueuedAge(ScrapeJob job, Instant finishedAt) {

--- a/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
@@ -13,7 +13,6 @@ import com.chukchuk.haksa.global.security.service.JwtProvider;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -80,16 +79,12 @@ public class RefreshTokenService {
                 .orElseThrow(() -> new TokenException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
     }
 
-    /* 일정 시간마다 유효기간이 지난 RefreshToken 정보 삭제 */
+    /* 유효기간이 지난 RefreshToken 정보 삭제 */
     @Transactional
-    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 정각 실행
-    public void deletedExpiredTokens() {
-        try {
-            Date now = new Date();
-            int deleted = refreshTokenRepository.deleteByExpiryBefore(now);
-            log.info("[BIZ] auth.refresh.cleanup.deleted count={}", deleted);
-        } catch (Exception e) {
-            log.error("[BIZ] auth.refresh.cleanup.error", e);
-        }
+    public int deletedExpiredTokens() {
+        Date now = new Date();
+        int deleted = refreshTokenRepository.deleteByExpiryBefore(now);
+        log.info("[BIZ] auth.refresh.cleanup.deleted count={}", deleted);
+        return deleted;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/global/config/SchedulingConfig.java
+++ b/src/main/java/com/chukchuk/haksa/global/config/SchedulingConfig.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
-@ConditionalOnProperty(prefix = "scraping.scheduler", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "scraping.scheduler", name = "enabled", havingValue = "true")
 public class SchedulingConfig {
 
     @Bean

--- a/src/main/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandler.java
@@ -55,30 +55,33 @@ public class StreamLambdaHandler implements RequestStreamHandler {
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
         byte[] payload = input.readAllBytes();
-        if (isMaintenanceEvent(payload)) {
-            handleMaintenanceEvent(payload, output);
+        JsonNode jsonNode = readJsonNode(payload);
+        if (jsonNode != null && isMaintenanceEvent(jsonNode)) {
+            handleMaintenanceEvent(jsonNode, output);
             return;
         }
 
         HANDLER.proxyStream(new ByteArrayInputStream(payload), output, context);
     }
 
-    private boolean isMaintenanceEvent(byte[] payload) {
+    private JsonNode readJsonNode(byte[] payload) {
         try {
-            JsonNode jsonNode = OBJECT_MAPPER.readTree(payload);
-            return EVENTBRIDGE_SCHEDULER_SOURCE.equals(jsonNode.path("source").asText())
-                    && jsonNode.hasNonNull("task");
+            return OBJECT_MAPPER.readTree(payload);
         } catch (IOException e) {
-            return false;
+            return null;
         }
     }
 
-    private void handleMaintenanceEvent(byte[] payload, OutputStream output) throws IOException {
-        JsonNode jsonNode = OBJECT_MAPPER.readTree(payload);
+    private boolean isMaintenanceEvent(JsonNode jsonNode) {
+        return EVENTBRIDGE_SCHEDULER_SOURCE.equals(jsonNode.path("source").asText())
+                && jsonNode.hasNonNull("task");
+    }
+
+    private void handleMaintenanceEvent(JsonNode jsonNode, OutputStream output) throws IOException {
         MaintenanceTaskRequest request = new MaintenanceTaskRequest(
                 jsonNode.path("source").asText(),
                 jsonNode.path("task").asText(),
-                jsonNode.path("scheduled_at").isMissingNode() ? null : jsonNode.path("scheduled_at").asText(null)
+                jsonNode.path("scheduled_at").textValue()
         );
 
         try {

--- a/src/main/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandler.java
@@ -9,13 +9,24 @@ import com.amazonaws.serverless.proxy.spring.SpringBootProxyHandlerBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.chukchuk.haksa.ChukchukHaksaApplication;
+import com.chukchuk.haksa.application.maintenance.MaintenanceTaskHandler;
+import com.chukchuk.haksa.application.maintenance.MaintenanceTaskRequest;
+import com.chukchuk.haksa.application.maintenance.MaintenanceTaskResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+@Slf4j
 public class StreamLambdaHandler implements RequestStreamHandler {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String EVENTBRIDGE_SCHEDULER_SOURCE = "eventbridge.scheduler";
     private static final SpringBootLambdaContainerHandler<HttpApiV2ProxyRequest, AwsProxyResponse> HANDLER;
 
     static {
@@ -43,6 +54,45 @@ public class StreamLambdaHandler implements RequestStreamHandler {
 
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
-        HANDLER.proxyStream(input, output, context);
+        byte[] payload = input.readAllBytes();
+        if (isMaintenanceEvent(payload)) {
+            handleMaintenanceEvent(payload, output);
+            return;
+        }
+
+        HANDLER.proxyStream(new ByteArrayInputStream(payload), output, context);
+    }
+
+    private boolean isMaintenanceEvent(byte[] payload) {
+        try {
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(payload);
+            return EVENTBRIDGE_SCHEDULER_SOURCE.equals(jsonNode.path("source").asText())
+                    && jsonNode.hasNonNull("task");
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private void handleMaintenanceEvent(byte[] payload, OutputStream output) throws IOException {
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(payload);
+        MaintenanceTaskRequest request = new MaintenanceTaskRequest(
+                jsonNode.path("source").asText(),
+                jsonNode.path("task").asText(),
+                jsonNode.path("scheduled_at").isMissingNode() ? null : jsonNode.path("scheduled_at").asText(null)
+        );
+
+        try {
+            MaintenanceTaskResult result = maintenanceTaskHandler().handle(request);
+            OBJECT_MAPPER.writeValue(output, result);
+        } catch (RuntimeException e) {
+            log.error("[BIZ] maintenance.task.failed task={} scheduledAt={} exceptionClass={} message={}",
+                    request.task(), request.scheduledAt(), e.getClass().getSimpleName(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private MaintenanceTaskHandler maintenanceTaskHandler() {
+        return WebApplicationContextUtils.getRequiredWebApplicationContext(HANDLER.getServletContext())
+                .getBean(MaintenanceTaskHandler.class);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,7 +66,7 @@ scraping:
     api-call-timeout-seconds: ${SCRAPING_RESULT_API_CALL_TIMEOUT_SECONDS:30}
     api-call-attempt-timeout-seconds: ${SCRAPING_RESULT_API_CALL_ATTEMPT_TIMEOUT_SECONDS:3}
   scheduler:
-    enabled: ${SCRAPING_SCHEDULER_ENABLED:true}
+    enabled: ${SCRAPING_SCHEDULER_ENABLED:false}
   publisher:
     enabled: ${SCRAPING_PUBLISHER_ENABLED:true}
     fixed-delay-ms: ${SCRAPING_PUBLISHER_FIXED_DELAY_MS:10000}

--- a/src/test/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskHandlerUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/maintenance/MaintenanceTaskHandlerUnitTests.java
@@ -1,0 +1,75 @@
+package com.chukchuk.haksa.application.maintenance;
+
+import com.chukchuk.haksa.application.portal.ScrapeJobStaleReconciler;
+import com.chukchuk.haksa.domain.auth.service.RefreshTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MaintenanceTaskHandlerUnitTests {
+
+    @Mock
+    private ScrapeJobStaleReconciler scrapeJobStaleReconciler;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("SCRAPE_JOB_RECONCILE_STALE 작업은 stale reconciler를 실행하고 처리 건수를 반환한다")
+    void handle_reconcileStale_returnsAffectedCount() {
+        MaintenanceTaskHandler handler = new MaintenanceTaskHandler(scrapeJobStaleReconciler, refreshTokenService);
+        when(scrapeJobStaleReconciler.reconcileStaleQueuedJobs()).thenReturn(2);
+
+        MaintenanceTaskResult result = handler.handle(new MaintenanceTaskRequest(
+                "eventbridge.scheduler",
+                "SCRAPE_JOB_RECONCILE_STALE",
+                "2026-04-26T00:00:00Z"
+        ));
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.task()).isEqualTo("SCRAPE_JOB_RECONCILE_STALE");
+        assertThat(result.affectedCount()).isEqualTo(2);
+        assertThat(result.scheduledAt()).isEqualTo("2026-04-26T00:00:00Z");
+        verify(scrapeJobStaleReconciler).reconcileStaleQueuedJobs();
+    }
+
+    @Test
+    @DisplayName("REFRESH_TOKEN_CLEANUP 작업은 만료 토큰 정리를 실행하고 삭제 건수를 반환한다")
+    void handle_refreshTokenCleanup_returnsDeletedCount() {
+        MaintenanceTaskHandler handler = new MaintenanceTaskHandler(scrapeJobStaleReconciler, refreshTokenService);
+        when(refreshTokenService.deletedExpiredTokens()).thenReturn(3);
+
+        MaintenanceTaskResult result = handler.handle(new MaintenanceTaskRequest(
+                "eventbridge.scheduler",
+                "REFRESH_TOKEN_CLEANUP",
+                "2026-04-26T00:00:00Z"
+        ));
+
+        assertThat(result.success()).isTrue();
+        assertThat(result.task()).isEqualTo("REFRESH_TOKEN_CLEANUP");
+        assertThat(result.affectedCount()).isEqualTo(3);
+        assertThat(result.scheduledAt()).isEqualTo("2026-04-26T00:00:00Z");
+        verify(refreshTokenService).deletedExpiredTokens();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 maintenance task는 실패한다")
+    void handle_unknownTask_throws() {
+        MaintenanceTaskHandler handler = new MaintenanceTaskHandler(scrapeJobStaleReconciler, refreshTokenService);
+
+        assertThatThrownBy(() -> handler.handle(new MaintenanceTaskRequest(
+                "eventbridge.scheduler",
+                "UNKNOWN_TASK",
+                "2026-04-26T00:00:00Z"
+        ))).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("UNKNOWN_TASK");
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
@@ -66,8 +66,9 @@ class ScrapeJobStaleReconcilerUnitTests {
                 .thenReturn(List.of(outbox));
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
-        reconciler.reconcileStaleQueuedJobs();
+        int affectedCount = reconciler.reconcileStaleQueuedJobs();
 
+        assertThat(affectedCount).isEqualTo(1);
         assertThat(job.getStatus().name()).isEqualTo("FAILED");
         assertThat(job.getErrorCode()).isEqualTo("CALLBACK_TIMEOUT");
         assertThat(job.getRetryable()).isTrue();

--- a/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
@@ -163,19 +163,21 @@ class RefreshTokenServiceUnitTests {
     void deletedExpiredTokens_executesDelete() {
         when(refreshTokenRepository.deleteByExpiryBefore(any(Date.class))).thenReturn(3);
 
-        refreshTokenService.deletedExpiredTokens();
+        int deleted = refreshTokenService.deletedExpiredTokens();
 
+        assertThat(deleted).isEqualTo(3);
         verify(refreshTokenRepository).deleteByExpiryBefore(any(Date.class));
     }
 
     @Test
-    @DisplayName("만료 토큰 정리 중 예외가 발생해도 예외를 전파하지 않는다")
-    void deletedExpiredTokens_swallowsException() {
+    @DisplayName("만료 토큰 정리 중 예외가 발생하면 호출자에게 전파한다")
+    void deletedExpiredTokens_propagatesException() {
         doThrow(new RuntimeException("db error"))
                 .when(refreshTokenRepository).deleteByExpiryBefore(any(Date.class));
 
-        refreshTokenService.deletedExpiredTokens();
-
+        assertThatThrownBy(() -> refreshTokenService.deletedExpiredTokens())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("db error");
         verify(refreshTokenRepository).deleteByExpiryBefore(any(Date.class));
     }
 }

--- a/src/test/java/com/chukchuk/haksa/global/config/SchedulingConfigTests.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/SchedulingConfigTests.java
@@ -1,0 +1,27 @@
+package com.chukchuk.haksa.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchedulingConfigTests {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(SchedulingConfig.class);
+
+    @Test
+    void taskSchedulerIsDisabledByDefault() {
+        contextRunner.run(context ->
+                assertThat(context).doesNotHaveBean(ThreadPoolTaskScheduler.class)
+        );
+    }
+
+    @Test
+    void taskSchedulerIsCreatedWhenExplicitlyEnabled() {
+        contextRunner
+                .withPropertyValues("scraping.scheduler.enabled=true")
+                .run(context -> assertThat(context).hasSingleBean(ThreadPoolTaskScheduler.class));
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandlerTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandlerTest.java
@@ -145,6 +145,28 @@ class StreamLambdaHandlerTest {
         assertThat(jsonNode.path("scheduled_at").asText()).isEqualTo("2026-04-26T00:00:00Z");
     }
 
+    @Test
+    void eventBridgeSchedulerMaintenanceEventAllowsMissingScheduledAt() throws Exception {
+        String event = """
+                {
+                  "source": "eventbridge.scheduler",
+                  "task": "REFRESH_TOKEN_CLEANUP"
+                }
+                """;
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new StreamLambdaHandler().handleRequest(
+                new ByteArrayInputStream(event.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new DummyContext()
+        );
+
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(output.toByteArray());
+        assertThat(jsonNode.path("success").asBoolean()).isTrue();
+        assertThat(jsonNode.path("task").asText()).isEqualTo("REFRESH_TOKEN_CLEANUP");
+        assertThat(jsonNode.path("scheduled_at").isNull()).isTrue();
+    }
+
     private AwsProxyResponse invoke(String path, String method, String body) throws Exception {
         HttpApiV2ProxyRequest request = new HttpApiV2ProxyRequest();
         request.setVersion("2.0");

--- a/src/test/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandlerTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/lambda/StreamLambdaHandlerTest.java
@@ -121,6 +121,30 @@ class StreamLambdaHandlerTest {
         assertThat(jsonNode.path("error").path("code").asText()).isNotBlank();
     }
 
+    @Test
+    void eventBridgeSchedulerMaintenanceEventRunsRefreshTokenCleanup() throws Exception {
+        String event = """
+                {
+                  "source": "eventbridge.scheduler",
+                  "task": "REFRESH_TOKEN_CLEANUP",
+                  "scheduled_at": "2026-04-26T00:00:00Z"
+                }
+                """;
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new StreamLambdaHandler().handleRequest(
+                new ByteArrayInputStream(event.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new DummyContext()
+        );
+
+        JsonNode jsonNode = OBJECT_MAPPER.readTree(output.toByteArray());
+        assertThat(jsonNode.path("success").asBoolean()).isTrue();
+        assertThat(jsonNode.path("task").asText()).isEqualTo("REFRESH_TOKEN_CLEANUP");
+        assertThat(jsonNode.path("affected_count").asInt()).isZero();
+        assertThat(jsonNode.path("scheduled_at").asText()).isEqualTo("2026-04-26T00:00:00Z");
+    }
+
     private AwsProxyResponse invoke(String path, String method, String body) throws Exception {
         HttpApiV2ProxyRequest request = new HttpApiV2ProxyRequest();
         request.setVersion("2.0");


### PR DESCRIPTION
### 참고 사항

백엔드 Lambda 내부 `@Scheduled` 유지보수 작업을 EventBridge Scheduler direct invoke 방식으로 전환하기 위한 백엔드 코드 변경입니다.

주요 변경 사항:
- EventBridge Scheduler payload를 `StreamLambdaHandler`에서 감지해 maintenance task로 분기
- `SCRAPE_JOB_RECONCILE_STALE`, `REFRESH_TOKEN_CLEANUP` task 라우팅 추가
- stale scrape job reconcile과 refresh token cleanup의 내부 `@Scheduled` 의존 제거
- `scraping.scheduler.enabled` 기본값을 `false`로 변경
- Lambda direct invoke / 기존 HTTP proxy 경로 회귀 테스트 추가

검증:
- `./gradlew test`
- `./gradlew build`

인프라 후속 작업:
- EventBridge Scheduler 2개 생성
- Scheduler role에 Backend Lambda invoke 권한 부여
- Backend Lambda resource permission 추가
- `SCRAPING_SCHEDULER_ENABLED=false` 명시

### 🔗 Related Issue

Closes #221

- #221