### PR TITLE
238 fix: 복핵 학업 기록 전공 분류 수정

### DIFF
--- a/docs/specs/20260526-issue-238-dual-core-category/checklist.md
+++ b/docs/specs/20260526-issue-238-dual-core-category/checklist.md
@@ -1,0 +1,18 @@
+# Checklist
+
+- [x] origin/dev 기준 `feat/238-dev` worktree 생성
+- [x] 현재 학업 기록 분류 로직 확인
+- [x] `복핵` 전공 분류 실패 테스트 추가 및 RED 확인
+- [x] `복핵`을 전공 분류에 포함
+- [x] 관련 테스트 실행
+- [x] 전체 테스트 및 빌드 실행
+
+## Verification Log
+
+| Command | Result | Date |
+|---------|--------|------|
+| `./gradlew test --tests "*AcademicRecordServiceUnitTests"` | Fail as RED: `복핵` not in major list | 2026-05-26 |
+| `./gradlew test --tests "*AcademicRecordServiceUnitTests"` | Pass | 2026-05-26 |
+| `./gradlew test` | Pass | 2026-05-26 |
+| `./gradlew build` | Pass | 2026-05-26 |
+| `git diff --check` | Pass | 2026-05-26 |

--- a/docs/specs/20260526-issue-238-dual-core-category/context-notes.md
+++ b/docs/specs/20260526-issue-238-dual-core-category/context-notes.md
@@ -1,0 +1,6 @@
+# Context Notes
+
+- 2026-05-26: 사용자는 `origin/main`과 `origin/dev` 기준 PR을 각각 요청했다.
+- 2026-05-26: `origin/dev`에는 Issue 208의 `etc`, `rawAreaType` 응답 변경이 포함되어 있다.
+- 2026-05-26: 학업 기록 API에서 `복핵`은 전공으로, `복교`는 교양으로 분류되어야 한다.
+- 2026-05-26: 기존 `AcademicRecordService`는 `전핵`, `전선`, `복선`만 전공으로 분류해 `복핵`이 교양으로 떨어졌다.

--- a/docs/specs/20260526-issue-238-dual-core-category/spec.md
+++ b/docs/specs/20260526-issue-238-dual-core-category/spec.md
@@ -1,0 +1,15 @@
+# Issue 238 Spec
+
+## Goal
+- `/api/academic/record` 과목 분류에서 복수전공 핵심 과목(`복핵`)을 전공 목록으로 반환한다.
+- 복수전공 교양 과목(`복교`)은 기존처럼 교양 목록으로 반환한다.
+
+## Scope
+- In scope: `AcademicRecordService`의 전공/교양 분류 기준 수정.
+- In scope: `복핵`, `복교` 분류 단위 테스트 추가.
+- Out of scope: API 응답 구조 변경, 졸업요건 분석 로직 변경, DB 스키마 변경.
+
+## Acceptance Criteria
+- `FacultyDivision.복핵` 과목은 `courses.major`에 포함된다.
+- `FacultyDivision.복교` 과목은 `courses.liberal`에 포함된다.
+- 기존 `전핵`, `전선`, `복선` 전공 분류는 유지된다.

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordService.java
@@ -57,7 +57,7 @@ public class AcademicRecordService {
         }
 
         return switch (division) {
-            case 전핵, 전선, 복선 -> CourseCategory.MAJOR;
+            case 전핵, 전선, 복핵, 복선 -> CourseCategory.MAJOR;
             default -> CourseCategory.LIBERAL;
         };
     }

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordServiceUnitTests.java
@@ -93,4 +93,32 @@ class AcademicRecordServiceUnitTests {
         assertThat(result.courses().liberal()).containsExactly(liberal);
         assertThat(result.courses().etc()).isEmpty();
     }
+
+    @Test
+    @DisplayName("복핵은 전공으로, 복교는 교양으로 분류한다")
+    void getAcademicRecord_categorizesDualCoreAsMajorAndDualLiberalAsLiberal() {
+        UUID studentId = UUID.randomUUID();
+        SemesterAcademicRecordDto.SemesterGradeResponse grade =
+                new SemesterAcademicRecordDto.SemesterGradeResponse(
+                        2024, 1, 6, 6, new BigDecimal("4.00"), 1, 100, new BigDecimal("95.0")
+                );
+
+        StudentCourseDto.CourseDetailDto dualCore = new StudentCourseDto.CourseDetailDto(
+                "20", "복수전공핵심", "DMJ101", FacultyDivision.복핵, null, 3, "이교수", "A+", 3,
+                false, false, 2024, 1, 96, false
+        );
+        StudentCourseDto.CourseDetailDto dualLiberal = new StudentCourseDto.CourseDetailDto(
+                "21", "복수전공교양", "DMJ102", FacultyDivision.복교, null, 3, "김교수", "A0", 3,
+                false, false, 2024, 1, 92, false
+        );
+
+        when(semesterAcademicRecordService.getSemesterGradesByYearAndSemester(studentId, 2024, 1)).thenReturn(grade);
+        when(studentCourseService.getStudentCourses(studentId, 2024, 1)).thenReturn(List.of(dualCore, dualLiberal));
+
+        AcademicRecordResponse result = academicRecordService.getAcademicRecord(studentId, 2024, 1);
+
+        assertThat(result.courses().major()).containsExactly(dualCore);
+        assertThat(result.courses().liberal()).containsExactly(dualLiberal);
+        assertThat(result.courses().etc()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- `origin/dev` 기준으로 `/api/academic/record` 과목 분류에서 `복핵`을 전공 목록으로 분류하도록 수정했습니다.
- `복교`는 기존처럼 교양 목록으로 유지하는 회귀 테스트를 추가했습니다.
- Issue 208의 `etc/rawAreaType` 응답 변경이 포함된 dev 코드 기준으로 테스트를 맞췄습니다.

## Test Plan
- `./gradlew test --tests "*AcademicRecordServiceUnitTests"`
- `./gradlew test`
- `./gradlew build`
- `git diff --check`