### PR TITLE
241 feat: analyticsId 조회 API 추가

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/UserController.java
@@ -26,6 +26,14 @@ public class UserController implements UserControllerDocs {
 
     private final UserService userService;
 
+    @GetMapping("/analytics-id")
+    public ResponseEntity<SuccessResponse<UserDto.AnalyticsIdResponse>> getAnalyticsId(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserDto.AnalyticsIdResponse response = new UserDto.AnalyticsIdResponse(userDetails.getId().toString());
+        return ResponseEntity.ok(SuccessResponse.of(response));
+    }
+
     @DeleteMapping("/delete")
     public ResponseEntity<SuccessResponse<MessageOnlyResponse>> deleteUser(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/chukchuk/haksa/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/controller/docs/UserControllerDocs.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.user.controller.docs;
 
 import com.chukchuk.haksa.domain.user.dto.UserDto;
+import com.chukchuk.haksa.domain.user.wrapper.AnalyticsIdApiResponse;
 import com.chukchuk.haksa.domain.user.wrapper.DeleteUserApiResponse;
 import com.chukchuk.haksa.domain.user.wrapper.SignInApiResponse;
 import com.chukchuk.haksa.global.common.response.MessageOnlyResponse;
@@ -19,6 +20,21 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User", description = "사용자 관련 API")
 public interface UserControllerDocs {
+
+    @Operation(
+            summary = "사용자 분석 식별자 조회",
+            description = "로그인된 사용자의 Amplitude 사용자 식별자를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "사용자 분석 식별자 조회 성공",
+                            content = @Content(schema = @Schema(implementation = AnalyticsIdApiResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 실패",
+                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<UserDto.AnalyticsIdResponse>> getAnalyticsId(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 
     @Operation(
             summary = "회원 탈퇴",

--- a/src/main/java/com/chukchuk/haksa/domain/user/dto/UserDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/dto/UserDto.java
@@ -30,4 +30,10 @@ public class UserDto {
             boolean isPortalLinked
 
     ) {}
+
+    @Schema(description = "사용자 분석 식별자 응답")
+    public record AnalyticsIdResponse(
+            @Schema(description = "Amplitude 사용자 식별자", example = "550e8400-e29b-41d4-a716-446655440000", required = true)
+            String analyticsId
+    ) {}
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/wrapper/AnalyticsIdApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/wrapper/AnalyticsIdApiResponse.java
@@ -1,0 +1,14 @@
+// 사용자 분석 식별자 조회 API의 문서용 응답 래퍼
+package com.chukchuk.haksa.domain.user.wrapper;
+
+import com.chukchuk.haksa.domain.user.dto.UserDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "AnalyticsIdApiResponse", description = "사용자 분석 식별자 조회 응답")
+public class AnalyticsIdApiResponse extends SuccessResponse<UserDto.AnalyticsIdResponse> {
+
+    public AnalyticsIdApiResponse() {
+        super(new UserDto.AnalyticsIdResponse("550e8400-e29b-41d4-a716-446655440000"), "요청 성공");
+    }
+}

--- a/src/main/resources/public/openapi.yaml
+++ b/src/main/resources/public/openapi.yaml
@@ -5,6 +5,25 @@ info:
   version: 1.0.0
 
 paths:
+  /api/users/analytics-id:
+    get:
+      summary: 사용자 분석 식별자 조회
+      description: 로그인된 사용자의 Amplitude 사용자 식별자를 조회합니다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 사용자 분석 식별자 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyticsIdResponse'
+        '401':
+          description: 인증 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
   /api/users/signin:
     post:
       summary: 회원 가입 및 로그인
@@ -35,6 +54,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDetail'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ApiResponse:
       type: object
@@ -98,6 +122,23 @@ components:
               type: string
             isPortalLinked:
               type: boolean
+        message:
+          type: string
+          nullable: true
+        error:
+          $ref: '#/components/schemas/ErrorDetail'
+    AnalyticsIdResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        data:
+          type: object
+          properties:
+            analyticsId:
+              type: string
+              description: Amplitude 사용자 식별자
+              example: 550e8400-e29b-41d4-a716-446655440000
         message:
           type: string
           nullable: true

--- a/src/test/java/com/chukchuk/haksa/domain/user/controller/UserControllerApiIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/controller/UserControllerApiIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,6 +38,18 @@ class UserControllerApiIntegrationTest extends ApiControllerWebMvcTestSupport {
 
     @MockBean
     private UserService userService;
+
+    @Test
+    @DisplayName("analyticsId 조회 성공 시 인증 사용자 ID를 반환한다")
+    void getAnalyticsId_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        authenticate(userId);
+
+        mockMvc.perform(get("/api/users/analytics-id"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.analyticsId").value(userId.toString()));
+    }
 
     @Test
     @DisplayName("signin 성공 시 성공 응답을 반환한다")


### PR DESCRIPTION
## Summary
- Add `GET /api/users/analytics-id` for authenticated users.
- Return the authenticated user's UUID string as `data.analyticsId`.
- Update controller docs, static OpenAPI, and API test coverage.

## Scope
- Login response shape is unchanged.
- No docs/spec files are included.
- No database schema change is included.

## Verification
- `./gradlew test --tests "*UserControllerApiIntegrationTest"`
- `./gradlew test`
- `./gradlew build`
- `git diff --check origin/main..HEAD`

### 🔗 Related Issue

Closes #241

