### PR TITLE
246 fix: 포털 링크 Swagger 응답 래퍼 정합성 수정

### DIFF
--- a/docs/specs/20260529-issue-246-portal-link-swagger/checklist.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/checklist.md
@@ -1,0 +1,8 @@
+# Checklist
+
+- [x] `origin/dev` 기준 작업 브랜치 생성.
+- [x] 문제 범위 확인.
+- [x] RED 테스트 작성 및 실패 확인.
+- [x] Swagger wrapper 구현.
+- [x] 관련 테스트 및 전체 테스트 통과 확인.
+- [ ] 커밋.

--- a/docs/specs/20260529-issue-246-portal-link-swagger/clarify.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/clarify.md
@@ -1,0 +1,20 @@
+# Clarify
+
+## Open Questions
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | 실제 응답 body를 변경해야 하는가? | Codex | Resolved |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | 실제 응답은 유지하고 Swagger schema만 실제 구조에 맞춘다. | 사진과 live `/v3/api-docs`에서 문서 schema가 내부 DTO만 참조하는 것이 원인으로 확인됐다. | 2026-05-29 |
+| 2 | `*/*`로 보이는 성공/오류 응답 content type은 포털 링크 docs에서 `application/json`으로 명시한다. | Swagger UI의 media type 표시도 사용자 혼란을 만든다. | 2026-05-29 |
+
+## Risks / Unknowns
+- Item: 다른 도메인 API에도 `*/*` media type이 남아 있을 수 있다.
+  - Impact: 이번 이슈 범위를 벗어난 Swagger 표시 불일치가 남을 수 있다.
+  - Mitigation: 사용자 사진과 live mismatch가 확인된 포털 링크 API 범위로 제한한다.
+
+## Follow-ups
+- [ ] 필요하면 별도 이슈로 전체 API Swagger media type 정리를 진행한다.

--- a/docs/specs/20260529-issue-246-portal-link-swagger/context-notes.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/context-notes.md
@@ -1,0 +1,6 @@
+# Context Notes
+
+- 2026-05-29: 사용자 사진과 live dev `/v3/api-docs` 확인 결과, `/portal/link` 202 성공 응답이 실제로는 `SuccessResponse<AcceptedResponse>`인데 Swagger는 `AcceptedResponse`를 직접 참조한다.
+- 2026-05-29: `/portal/link/jobs/{jobId}`와 `/portal/link/jobs/{jobId}/summary`도 각각 `JobStatusResponse`, `JobSummaryResponse`를 직접 참조하므로 같은 방식으로 수정한다.
+- 2026-05-29: 실제 응답 body는 이미 원하는 구조이므로 컨트롤러 반환 로직은 바꾸지 않는다.
+- 2026-05-29: `@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, ...)`를 포털 링크 docs에 명시해 Swagger UI의 media type도 `application/json`으로 보이게 한다.

--- a/docs/specs/20260529-issue-246-portal-link-swagger/plan.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/plan.md
@@ -1,0 +1,24 @@
+# Plan
+
+## Architecture / Layering
+- Domain impact: 없음.
+- Application orchestration: 없음.
+- Infrastructure touchpoints: 없음.
+- Global/config changes: 없음.
+- API documentation: 포털 링크 성공 응답용 wrapper class를 추가하고 docs annotation에서 해당 wrapper를 참조한다.
+
+## Data / Transactions
+- Repositories touched: 없음.
+- Transaction scope: 없음.
+- Consistency expectations: 실제 JSON과 Swagger schema가 일치해야 한다.
+
+## Testing Strategy
+- Domain tests: 없음.
+- Application tests: 없음.
+- Integration/API tests: `/v3/api-docs`의 포털 링크 response schema가 wrapper를 참조하는지 검증한다.
+- Additional commands: 포털 링크 컨트롤러 테스트와 OpenAPI smoke 테스트를 함께 실행한다.
+
+## Rollout Considerations
+- Backward compatibility: 런타임 응답 body를 바꾸지 않으므로 클라이언트 호환성 영향 없음.
+- Observability / metrics: 영향 없음.
+- Feature flags / toggles: 없음.

--- a/docs/specs/20260529-issue-246-portal-link-swagger/spec.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/spec.md
@@ -1,0 +1,69 @@
+# 20260529-issue-246-portal-link-swagger Spec
+
+## 1. Feature Overview
+- Purpose: `origin/dev` 기준 포털 링크 API의 실제 `SuccessResponse` 응답 구조와 Swagger 성공 응답 schema/example을 일치시킨다.
+- Scope.
+  - In: `/portal/link`, `/portal/link/jobs/{jobId}`, `/portal/link/jobs/{jobId}/summary` 성공 응답 Swagger schema.
+  - Out: 실제 런타임 응답 body 변경, 포털 연동 비즈니스 로직 변경, DB/schema 변경.
+- Expected Impact: Swagger UI의 Example Value가 실제 응답처럼 `success`, `data`, `message` 래퍼를 포함한다.
+- Stakeholder Confirmation: 사용자 요청 “오케이 문제인 부분 모두 해결하자 feat/246 만들어서 해결해.”를 구현 승인으로 기록한다.
+
+## 2. Domain Rules
+- Rule 1: 실제 API 응답 구조는 기존 `SuccessResponse<T>`를 유지한다.
+- Rule 2: Swagger 문서의 성공 응답 schema는 실제 최상위 JSON 구조와 일치해야 한다.
+- Rule 3: 내부 DTO인 `AcceptedResponse`, `JobStatusResponse`, `JobSummaryResponse`의 필드명은 변경하지 않는다.
+- Mutable Rules: Swagger wrapper class와 controller docs annotation은 변경 가능하다.
+- Immutable Rules: 포털 링크 job 생성/조회의 상태 전이, 서비스 로직, 엔드포인트 path는 변경하지 않는다.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: 포털 링크 job 생성 Swagger 확인.
+  - Trigger: Swagger UI에서 `/portal/link` 202 Example Value를 확인한다.
+  - Actor: 프론트엔드 개발자.
+  - Steps: API 문서를 열고 202 성공 응답 schema/example을 본다.
+  - Expected Result: 최상위에 `success`, `data`, `message`가 있고 `data` 안에 `job_id`, `polling_endpoint`, `status`가 있다.
+
+### Exception / Boundary Flow
+- Scenario Name: 실제 응답 body 보존.
+  - Condition: 컨트롤러 테스트가 기존 성공 응답 body를 검증한다.
+  - Expected Behavior: 런타임 JSON 필드는 기존과 동일하다.
+
+## 4. Transaction / Consistency
+- Transaction Start Point: 없음.
+- Transaction End Point: 없음.
+- Atomicity Scope: 문서 schema 변경만 수행한다.
+- Eventual Consistency Allowed: 해당 없음.
+
+## 5. API List
+- Endpoint: `/portal/link`.
+  - Method: POST.
+  - Request DTO: `PortalLinkDto.LinkRequest`.
+  - Response DTO: `SuccessResponse<PortalLinkDto.AcceptedResponse>`.
+  - Authorization: Bearer.
+  - Idempotency: `Idempotency-Key`.
+- Endpoint: `/portal/link/jobs/{jobId}`.
+  - Method: GET.
+  - Response DTO: `SuccessResponse<PortalLinkDto.JobStatusResponse>`.
+- Endpoint: `/portal/link/jobs/{jobId}/summary`.
+  - Method: GET.
+  - Response DTO: `SuccessResponse<PortalLinkDto.JobSummaryResponse>`.
+
+## 6. Exception Policy
+- Error Code: 기존 ErrorResponseWrapper 유지.
+  - Condition: 입력 오류, 인증 오류, 중복 요청, job 없음.
+  - Message Convention: 기존 예외 처리 정책 유지.
+  - Handling Layer: 기존 GlobalExceptionHandler 유지.
+  - User Exposure: Swagger schema media type만 JSON으로 명시한다.
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed.
+- [ ] Phase 6 API/Controller documentation fixed.
+- [ ] Tests pass.
+
+## 8. Generated File List
+- Path: `src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java`.
+  - Description: 포털 링크 Swagger 성공 응답 wrapper schema 검증.
+  - Layer: API test.
+- Path: `src/main/java/com/chukchuk/haksa/domain/portal/wrapper/*.java`.
+  - Description: 포털 링크 성공 응답 문서용 wrapper.
+  - Layer: API documentation.

--- a/docs/specs/20260529-issue-246-portal-link-swagger/tasks.md
+++ b/docs/specs/20260529-issue-246-portal-link-swagger/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Checklist
+- [x] origin/dev 기준 feat/246 worktree 생성.
+- [x] 기존 포털 링크/API docs 관련 테스트 기준선 확인.
+- [x] OpenAPI mismatch RED 테스트 추가.
+- [x] 포털 링크 성공 응답 wrapper 추가.
+- [x] Controller docs schema와 media type 수정.
+- [x] 관련 테스트 실행.
+- [x] 전체 테스트 실행.
+- [ ] 커밋 생성.
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkControllerApiIntegrationTest --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest.apiDocsRespondWithJsonBody --rerun-tasks --console=plain` | Passed | 2026-05-29 |
+| 2 | `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --rerun-tasks --console=plain` | Failed as expected. Missing `application/json` and wrapper schema. | 2026-05-29 |
+| 3 | `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --rerun-tasks --console=plain` | Passed | 2026-05-29 |
+| 4 | `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkControllerApiIntegrationTest --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest.apiDocsRespondWithJsonBody --rerun-tasks --console=plain` | Passed | 2026-05-29 |
+| 5 | `./gradlew test --console=plain` | Passed | 2026-05-29 |
+
+## Notes
+- Observation: live dev `/v3/api-docs`에서 `/portal/link` 202는 `AcceptedResponse`를 직접 참조하고 실제 body의 `SuccessResponse` wrapper와 불일치했다.

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCommandControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkCommandControllerDocs.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.portal.controller.docs;
 
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkAcceptedApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,13 +28,17 @@ public interface PortalLinkCommandControllerDocs {
             description = "포털 자격 증명을 받아 비동기 스크래핑 job을 생성하고 polling endpoint를 반환합니다.",
             responses = {
                     @ApiResponse(responseCode = "202", description = "요청 수락",
-                            content = @Content(schema = @Schema(implementation = PortalLinkDto.AcceptedResponse.class))),
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = PortalLinkAcceptedApiResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 입력 (INVALID_ARGUMENT)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
                     @ApiResponse(responseCode = "401", description = "자격 증명 오류 (PORTAL_LOGIN_FAILED)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class))),
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class))),
                     @ApiResponse(responseCode = "409", description = "중복 요청 (SCRAPE_JOB_DUPLICATED)",
-                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
             }
     )
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
@@ -1,6 +1,8 @@
 package com.chukchuk.haksa.domain.portal.controller.docs;
 
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkJobStatusApiResponse;
+import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkJobSummaryApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,9 +25,11 @@ public interface PortalLinkQueryControllerDocs {
             description = "요청된 job_id의 진행 상태, 오류 코드, 완료 시점 등을 제공합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "상태 조회 성공",
-                            content = @Content(schema = @Schema(implementation = PortalLinkDto.JobStatusResponse.class))),
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = PortalLinkJobStatusApiResponse.class))),
                     @ApiResponse(responseCode = "404", description = "job 미존재 또는 권한 없음",
-                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
             }
     )
     @SecurityRequirement(name = "bearerAuth")
@@ -38,9 +43,11 @@ public interface PortalLinkQueryControllerDocs {
             description = "job이 성공적으로 완료된 경우 최신 학생 요약 데이터를 반환합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "요약 조회 성공",
-                            content = @Content(schema = @Schema(implementation = PortalLinkDto.JobSummaryResponse.class))),
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = PortalLinkJobSummaryApiResponse.class))),
                     @ApiResponse(responseCode = "404", description = "job 미존재 또는 권한 없음",
-                            content = @Content(schema = @Schema(implementation = ErrorResponseWrapper.class)))
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
             }
     )
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkAcceptedApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkAcceptedApiResponse.java
@@ -1,0 +1,18 @@
+// 포털 링크 job 생성 성공 응답의 Swagger 문서용 래퍼
+package com.chukchuk.haksa.domain.portal.wrapper;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PortalLinkAcceptedApiResponse", description = "포털 링크 job 생성 수락 응답")
+public class PortalLinkAcceptedApiResponse extends SuccessResponse<PortalLinkDto.AcceptedResponse> {
+
+    public PortalLinkAcceptedApiResponse() {
+        super(new PortalLinkDto.AcceptedResponse(
+                "job-123",
+                "accepted",
+                "/portal/link/jobs/job-123"
+        ), "요청 성공");
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobStatusApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobStatusApiResponse.java
@@ -1,0 +1,26 @@
+// 포털 링크 job 상태 조회 성공 응답의 Swagger 문서용 래퍼
+package com.chukchuk.haksa.domain.portal.wrapper;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(name = "PortalLinkJobStatusApiResponse", description = "포털 링크 job 상태 조회 응답")
+public class PortalLinkJobStatusApiResponse extends SuccessResponse<PortalLinkDto.JobStatusResponse> {
+
+    public PortalLinkJobStatusApiResponse() {
+        super(new PortalLinkDto.JobStatusResponse(
+                "job-123",
+                "suwon",
+                "queued",
+                null,
+                null,
+                null,
+                Instant.parse("2026-05-29T08:00:00Z"),
+                Instant.parse("2026-05-29T08:00:00Z"),
+                null
+        ), "요청 성공");
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobSummaryApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobSummaryApiResponse.java
@@ -1,0 +1,29 @@
+// 포털 링크 job 요약 조회 성공 응답의 Swagger 문서용 래퍼
+package com.chukchuk.haksa.domain.portal.wrapper;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(name = "PortalLinkJobSummaryApiResponse", description = "포털 링크 job 요약 조회 응답")
+public class PortalLinkJobSummaryApiResponse extends SuccessResponse<PortalLinkDto.JobSummaryResponse> {
+
+    public PortalLinkJobSummaryApiResponse() {
+        super(new PortalLinkDto.JobSummaryResponse(
+                "job-123",
+                "succeeded",
+                new PortalLinkDto.StudentInfoSummary(
+                        "홍길동",
+                        "수원대학교",
+                        "소프트웨어학과",
+                        "17019013",
+                        2,
+                        "재학",
+                        1
+                ),
+                Instant.parse("2026-05-29T08:10:00Z")
+        ), "요청 성공");
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
@@ -1,0 +1,90 @@
+// 포털 링크 API의 Swagger 성공 응답 래퍼 구조를 검증하는 테스트
+package com.chukchuk.haksa.domain.portal.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "scraping.scheduler.enabled=false",
+        "scraping.publisher.enabled=false",
+        "scraping.stale.enabled=false"
+})
+@AutoConfigureMockMvc(addFilters = false)
+class PortalLinkOpenApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void portalLinkSuccessResponsesDocumentSuccessResponseWrappers() throws Exception {
+        JsonNode apiDocs = apiDocs();
+
+        assertSuccessResponseSchema(
+                apiDocs,
+                "/portal/link",
+                "post",
+                "202",
+                "PortalLinkAcceptedApiResponse",
+                "AcceptedResponse"
+        );
+        assertSuccessResponseSchema(
+                apiDocs,
+                "/portal/link/jobs/{jobId}",
+                "get",
+                "200",
+                "PortalLinkJobStatusApiResponse",
+                "JobStatusResponse"
+        );
+        assertSuccessResponseSchema(
+                apiDocs,
+                "/portal/link/jobs/{jobId}/summary",
+                "get",
+                "200",
+                "PortalLinkJobSummaryApiResponse",
+                "JobSummaryResponse"
+        );
+    }
+
+    private JsonNode apiDocs() throws Exception {
+        String body = mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(body);
+    }
+
+    private void assertSuccessResponseSchema(
+            JsonNode apiDocs,
+            String path,
+            String method,
+            String responseCode,
+            String wrapperSchema,
+            String dataSchema
+    ) {
+        JsonNode response = apiDocs.path("paths").path(path).path(method).path("responses").path(responseCode);
+
+        assertThat(response.path("content").has("application/json")).isTrue();
+        assertThat(response.path("content").has("*/*")).isFalse();
+        assertThat(response.path("content").path("application/json").path("schema").path("$ref").asText())
+                .isEqualTo("#/components/schemas/" + wrapperSchema);
+
+        JsonNode component = apiDocs.path("components").path("schemas").path(wrapperSchema);
+        assertThat(component.path("properties").has("success")).isTrue();
+        assertThat(component.path("properties").path("data").path("$ref").asText())
+                .isEqualTo("#/components/schemas/" + dataSchema);
+        assertThat(component.path("properties").has("message")).isTrue();
+    }
+}


### PR DESCRIPTION
## 요약
- `/portal/link` 202 응답 Swagger schema가 실제 `SuccessResponse<AcceptedResponse>` 구조를 보도록 문서용 wrapper를 추가했습니다.
- `/portal/link/jobs/{jobId}`, `/portal/link/jobs/{jobId}/summary` 성공 응답도 각각 `SuccessResponse` 래퍼 schema로 맞췄습니다.
- 포털 링크 API 문서의 response media type을 `application/json`으로 명시했습니다.

## 원인
- 실제 컨트롤러는 `SuccessResponse<T>`를 반환하지만 Swagger docs annotation은 내부 DTO인 `AcceptedResponse`, `JobStatusResponse`, `JobSummaryResponse`를 직접 참조해 Example Value에서 `success`, `data`, `message`가 빠졌습니다.

## 검증
- `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --rerun-tasks --console=plain`
- `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkControllerApiIntegrationTest --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.global.lambda.StreamLambdaHandlerTest.apiDocsRespondWithJsonBody --rerun-tasks --console=plain`
- `./gradlew test --console=plain`
- `git diff --check`

### 🔗 Related Issue

Closes #246

