### PR TITLE
fix: flangPassGb 한글 값 처리

### DIFF
--- a/docs/specs/20260602-fix-flang-pass-gb/checklist.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/checklist.md
@@ -1,0 +1,17 @@
+# Checklist
+
+- [x] `flangPassGb` 한글 값 매퍼 테스트 추가
+- [x] 알 수 없는 `flangPassGb` 콜백 실패 확정 테스트 추가
+- [x] RED 테스트 실행 및 실패 원인 확인
+- [x] `통과`/`미통과` 매핑 구현
+- [x] 매퍼 검증 실패를 schema invalid로 변환
+- [x] 관련 테스트 실행
+- [x] 전체 테스트 실행
+
+## Verification Log
+
+| Command | Result | Date |
+|---------|--------|------|
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Fail as RED: Korean `flangPassGb` throws `IllegalArgumentException`; unknown value is not converted to schema invalid | 2026-06-02 |
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*PortalCallbackPostProcessorTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Pass | 2026-06-02 |
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test` | Pass | 2026-06-02 |

--- a/docs/specs/20260602-fix-flang-pass-gb/checklist.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/checklist.md
@@ -7,11 +7,19 @@
 - [x] 매퍼 검증 실패를 schema invalid로 변환
 - [x] 관련 테스트 실행
 - [x] 전체 테스트 실행
+- [x] PR 리뷰 반영 테스트 추가 및 RED 확인
+- [x] 매핑 중 RuntimeException 실패 확정 반영
+- [x] `Y`/`N` 매핑 제거
+- [x] 리뷰 반영 후 관련 테스트 실행
+- [x] 리뷰 반영 후 전체 테스트 실행
 
 ## Verification Log
 
 | Command | Result | Date |
 |---------|--------|------|
 | `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Fail as RED: Korean `flangPassGb` throws `IllegalArgumentException`; unknown value is not converted to schema invalid | 2026-06-02 |
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*PortalCallbackPostProcessorTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Pass | 2026-06-02 |
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test` | Pass | 2026-06-02 |
+| `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Fail as RED: `Y`/`N` still accepted; mapper `RuntimeException` not converted to schema invalid | 2026-06-02 |
 | `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*PortalCallbackPostProcessorTests" --tests "*ScrapeResultCallbackServiceUnitTests"` | Pass | 2026-06-02 |
 | `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test` | Pass | 2026-06-02 |

--- a/docs/specs/20260602-fix-flang-pass-gb/context-notes.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/context-notes.md
@@ -1,0 +1,10 @@
+# Context Notes
+
+- 2026-06-02: 개발 서버 장애 원인은 scraper와 backend의 `flangPassGb` 값 계약 불일치다.
+- 2026-06-02: 개발 scraper는 `통과`/`미통과`를 보낼 수 있고 실패 payload에는 `미통과`가 있었다.
+- 2026-06-02: backend `PortalDataMapper`는 현재 `Y`/`N`/blank만 허용한다.
+- 2026-06-02: 매퍼 예외는 `PortalCallbackPostProcessor`의 후처리 실패 처리 범위 밖에서 발생해 job이 `POST_PROCESSING`에 남을 수 있다.
+- 2026-06-02: 이번 수정은 stale reconciler가 아니라 callback 후처리 경계에서 실패를 확정하는 방식으로 진행한다.
+- 2026-06-02: RED 확인 결과 `통과`/`미통과`는 매퍼에서 `IllegalArgumentException`을 던졌고, 알 수 없는 값은 `SCRAPE_RESULT_SCHEMA_INVALID`로 변환되지 않았다.
+- 2026-06-02: `PortalCallbackPostProcessor`는 매퍼의 `IllegalArgumentException`을 `SCRAPE_RESULT_SCHEMA_INVALID`로 변환하고, 외부 `ScrapeResultCallbackService`가 기존 `FAILED_RESULT_SCHEMA`로 job을 확정한다.
+- 2026-06-02: 로컬 기본 JDK 24에서는 Gradle test task 생성이 `Type T not present`로 실패해, 프로젝트 Java 17 toolchain에 맞춰 `JAVA_HOME`을 Temurin 17로 지정해 검증했다.

--- a/docs/specs/20260602-fix-flang-pass-gb/context-notes.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/context-notes.md
@@ -8,3 +8,5 @@
 - 2026-06-02: RED 확인 결과 `통과`/`미통과`는 매퍼에서 `IllegalArgumentException`을 던졌고, 알 수 없는 값은 `SCRAPE_RESULT_SCHEMA_INVALID`로 변환되지 않았다.
 - 2026-06-02: `PortalCallbackPostProcessor`는 매퍼의 `IllegalArgumentException`을 `SCRAPE_RESULT_SCHEMA_INVALID`로 변환하고, 외부 `ScrapeResultCallbackService`가 기존 `FAILED_RESULT_SCHEMA`로 job을 확정한다.
 - 2026-06-02: 로컬 기본 JDK 24에서는 Gradle test task 생성이 `Type T not present`로 실패해, 프로젝트 Java 17 toolchain에 맞춰 `JAVA_HOME`을 Temurin 17로 지정해 검증했다.
+- 2026-06-02: PR #252 Gemini 리뷰는 매핑 단계에서 `NullPointerException`, `ArrayIndexOutOfBoundsException` 같은 `RuntimeException`도 job을 `POST_PROCESSING`에 남길 수 있다는 지적이며 코드상 타당하다.
+- 2026-06-02: 사용자 요청으로 `flangPassGb`의 `Y`/`N` 지원은 제거하고 `통과`/`미통과`만 유효 값으로 유지한다.

--- a/docs/specs/20260602-fix-flang-pass-gb/spec-lite.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/spec-lite.md
@@ -9,8 +9,9 @@
 
 ## Key Rules
 - Rule 1: `통과`는 `true`, `미통과`는 `false`, `null`/blank는 기존처럼 `null`로 매핑한다.
-- Rule 2: 알 수 없는 `flangPassGb` 값은 조용히 기본값으로 치환하지 않고 `SCRAPE_RESULT_SCHEMA_INVALID` 경로로 실패 확정한다.
-- Rule 3: `POST_PROCESSING` job timeout 처리는 이번 변경 범위에 포함하지 않는다.
+- Rule 2: `Y`/`N`은 더 이상 유효 값으로 인정하지 않고 알 수 없는 값으로 처리한다.
+- Rule 3: 알 수 없는 `flangPassGb` 값과 매핑 중 `RuntimeException`은 조용히 기본값으로 치환하지 않고 `SCRAPE_RESULT_SCHEMA_INVALID` 경로로 실패 확정한다.
+- Rule 4: `POST_PROCESSING` job timeout 처리는 이번 변경 범위에 포함하지 않는다.
 
 ## Risks / Assumptions
 - Risk: scraper가 향후 다른 한글 값을 보내면 schema invalid로 job이 FAILED 된다.

--- a/docs/specs/20260602-fix-flang-pass-gb/spec-lite.md
+++ b/docs/specs/20260602-fix-flang-pass-gb/spec-lite.md
@@ -1,0 +1,27 @@
+# Spec Lite
+
+## Summary
+- Purpose: 개발 스크래퍼가 보내는 `flangPassGb`의 `통과`/`미통과` 값을 백엔드가 수용하고, 알 수 없는 값은 콜백 job을 실패로 확정하게 한다.
+- Scope (In/Out):
+  - In: 포털 raw 데이터 매핑, 성공 콜백 후처리 중 매퍼 검증 실패 처리, 관련 단위 테스트
+  - Out: 공개 API 응답 스키마, scraper 변경, stale reconciler 정책 변경
+- Expected Impact: 개발 서버 포털 연동에서 `flangPassGb: "미통과"` payload가 후처리 예외로 멈추지 않고 정상 동기화된다.
+
+## Key Rules
+- Rule 1: `통과`는 `true`, `미통과`는 `false`, `null`/blank는 기존처럼 `null`로 매핑한다.
+- Rule 2: 알 수 없는 `flangPassGb` 값은 조용히 기본값으로 치환하지 않고 `SCRAPE_RESULT_SCHEMA_INVALID` 경로로 실패 확정한다.
+- Rule 3: `POST_PROCESSING` job timeout 처리는 이번 변경 범위에 포함하지 않는다.
+
+## Risks / Assumptions
+- Risk: scraper가 향후 다른 한글 값을 보내면 schema invalid로 job이 FAILED 된다.
+- Assumption: 현재 개발 스크래퍼 계약은 `통과`/`미통과`이며 운영 payload 미전송 케이스는 기존 `null` 처리로 유지된다.
+- Approval: 2026-06-02 사용자 요청 "PLEASE IMPLEMENT THIS PLAN"으로 Phase 2 구현을 승인받았다.
+
+## Tasks
+- [x] Tests planned
+- [x] RED verified
+- [x] Implementation complete
+- [x] Targeted tests passed
+- [x] Full tests passed
+
+> Lite 스펙은 Scope < 1 day & API 변경 없음일 때만 허용. 조건을 벗어나면 즉시 Standard 스펙으로 승격한다.

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -57,7 +57,7 @@ public class PortalCallbackPostProcessor {
         } catch (JsonProcessingException e) {
             handleParsingFailure(jobId, userId, operationType, e.getOriginalMessage(), e);
             return;
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             handleParsingFailure(jobId, userId, operationType, e.getMessage(), e);
             return;
         }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -55,7 +55,10 @@ public class PortalCallbackPostProcessor {
         try {
             portalData = toPortalData(payloadJson);
         } catch (JsonProcessingException e) {
-            handleParsingFailure(jobId, userId, operationType, finishedAt, queuedAgeSeconds, e);
+            handleParsingFailure(jobId, userId, operationType, e.getOriginalMessage(), e);
+            return;
+        } catch (IllegalArgumentException e) {
+            handleParsingFailure(jobId, userId, operationType, e.getMessage(), e);
             return;
         }
 
@@ -94,13 +97,12 @@ public class PortalCallbackPostProcessor {
             String jobId,
             UUID userId,
             ScrapeJobOperationType operationType,
-            Instant finishedAt,
-            Double queuedAgeSeconds,
-            JsonProcessingException exception
+            String message,
+            Exception exception
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").increment();
         log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
-                jobId, userId, operationType, exception.getOriginalMessage(), exception);
+                jobId, userId, operationType, message, exception);
         throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
     }
 

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapper.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapper.java
@@ -184,12 +184,6 @@ public class PortalDataMapper {
         }
 
         String normalized = flangPassGb.trim();
-        if ("Y".equalsIgnoreCase(normalized)) {
-            return true;
-        }
-        if ("N".equalsIgnoreCase(normalized)) {
-            return false;
-        }
         if ("통과".equals(normalized)) {
             return true;
         }

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapper.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapper.java
@@ -190,6 +190,12 @@ public class PortalDataMapper {
         if ("N".equalsIgnoreCase(normalized)) {
             return false;
         }
+        if ("통과".equals(normalized)) {
+            return true;
+        }
+        if ("미통과".equals(normalized)) {
+            return false;
+        }
 
         throw new IllegalArgumentException("알 수 없는 외국어 인증 값: " + flangPassGb);
     }

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -380,6 +380,43 @@ class ScrapeResultCallbackServiceUnitTests {
         verify(portalSyncService, never()).syncWithPortal(any(), any());
     }
 
+    @Test
+    @DisplayName("매핑 중 RuntimeException이 발생해도 schema invalid로 실패 확정한다")
+    void handleCallback_marksMapperRuntimeExceptionAsSchemaFailure() {
+        ScrapeResultCallbackService service = createServiceWithRealPostProcessor();
+        ScrapeJob job = createJob(UUID.randomUUID());
+        String timestamp = Instant.now().toString();
+        String rawBody = """
+                {
+                  "job_id":"%s",
+                  "status":"succeeded",
+                  "result_s3_key":"callbacks/%s/result.json"
+                }
+                """.formatted(job.getJobId(), job.getJobId());
+
+        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.fetch("callbacks/%s/result.json".formatted(job.getJobId())))
+                .thenReturn("""
+                        {
+                          "student_info":{"sno":"17019013","stud_nm":"홍길동","univ_cd":"01","univ_nm":"수원대학교","dpmj_cd":"D1","dpmj_nm":"컴퓨터학부","mjor_cd":"M1","mjor_nm":"컴퓨터학과","scrg_stat_nm":"재학","ensc_year":"2021","ensc_smr_cd":"10","ensc_dvcd":"신입","stud_grde":4,"fac_smr_cnt":8,"flang_pass_gb":"통과"},
+                          "semesters":[{"semester":"2024","courses":[]}],
+                          "academic_records":{
+                            "list_smr_cret_sum_tab_year_smr":[],
+                            "select_smr_cret_sum_tab_sj_total":{"gain_point":"120","appl_point":"130","gain_avmk":"3.8","gain_tavg_pont":"90"}
+                          }
+                        }
+                        """);
+
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, "req-1"))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code()));
+
+        assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);
+        assertThat(job.getErrorCode()).isEqualTo("FAILED_RESULT_SCHEMA");
+        assertThat(job.getRetryable()).isFalse();
+        verify(portalSyncService, never()).syncWithPortal(any(), any());
+    }
+
     private ScrapeResultCallbackService createService() {
         HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
         ScrapeResultCallbackTxService txService = new ScrapeResultCallbackTxService(

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -343,6 +343,43 @@ class ScrapeResultCallbackServiceUnitTests {
                 .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED.code()));
     }
 
+    @Test
+    @DisplayName("알 수 없는 flangPassGb 값은 schema invalid로 실패 확정한다")
+    void handleCallback_marksUnknownLanguageCertAsSchemaFailure() {
+        ScrapeResultCallbackService service = createServiceWithRealPostProcessor();
+        ScrapeJob job = createJob(UUID.randomUUID());
+        String timestamp = Instant.now().toString();
+        String rawBody = """
+                {
+                  "job_id":"%s",
+                  "status":"succeeded",
+                  "result_s3_key":"callbacks/%s/result.json"
+                }
+                """.formatted(job.getJobId(), job.getJobId());
+
+        when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        when(resultStoreClient.fetch("callbacks/%s/result.json".formatted(job.getJobId())))
+                .thenReturn("""
+                        {
+                          "student_info":{"sno":"17019013","stud_nm":"홍길동","univ_cd":"01","univ_nm":"수원대학교","dpmj_cd":"D1","dpmj_nm":"컴퓨터학부","mjor_cd":"M1","mjor_nm":"컴퓨터학과","scrg_stat_nm":"재학","ensc_year":"2021","ensc_smr_cd":"10","ensc_dvcd":"신입","stud_grde":4,"fac_smr_cnt":8,"flang_pass_gb":"보류"},
+                          "semesters":[],
+                          "academic_records":{
+                            "list_smr_cret_sum_tab_year_smr":[],
+                            "select_smr_cret_sum_tab_sj_total":{"gain_point":"120","appl_point":"130","gain_avmk":"3.8","gain_tavg_pont":"90"}
+                          }
+                        }
+                        """);
+
+        assertThatThrownBy(() -> service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, "req-1"))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code()));
+
+        assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);
+        assertThat(job.getErrorCode()).isEqualTo("FAILED_RESULT_SCHEMA");
+        assertThat(job.getRetryable()).isFalse();
+        verify(portalSyncService, never()).syncWithPortal(any(), any());
+    }
+
     private ScrapeResultCallbackService createService() {
         HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
         ScrapeResultCallbackTxService txService = new ScrapeResultCallbackTxService(
@@ -352,6 +389,28 @@ class ScrapeResultCallbackServiceUnitTests {
         );
         return new ScrapeResultCallbackService(
                 portalCallbackPostProcessor,
+                txService,
+                resultStoreClient,
+                verifier,
+                meterRegistry,
+                new ObjectMapper().findAndRegisterModules()
+        );
+    }
+
+    private ScrapeResultCallbackService createServiceWithRealPostProcessor() {
+        HmacSignatureVerifier verifier = new HmacSignatureVerifier("secret", 300);
+        ScrapeResultCallbackTxService txService = new ScrapeResultCallbackTxService(
+                scrapeJobRepository,
+                portalSyncService,
+                meterRegistry
+        );
+        PortalCallbackPostProcessor realPostProcessor = new PortalCallbackPostProcessor(
+                new ObjectMapper().findAndRegisterModules(),
+                meterRegistry,
+                txService
+        );
+        return new ScrapeResultCallbackService(
+                realPostProcessor,
                 txService,
                 resultStoreClient,
                 verifier,

--- a/src/test/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapperTests.java
+++ b/src/test/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapperTests.java
@@ -8,29 +8,30 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PortalDataMapperTests {
 
     private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
     @Test
-    @DisplayName("flangPassGb가 Y이면 외국어 인증 통과로 변환한다")
-    void mapsLanguageCertFulfilledWhenFlagIsY() throws Exception {
+    @DisplayName("flangPassGb가 Y이면 알 수 없는 값으로 거부한다")
+    void rejectsLanguageCertWhenFlagIsY() throws Exception {
         RawPortalData raw = objectMapper.readValue(payloadWithLanguageCert("Y"), RawPortalData.class);
 
-        PortalData portalData = PortalDataMapper.toPortalData(raw);
-
-        assertThat(portalData.student().languageCertFulfilled()).isTrue();
+        assertThatThrownBy(() -> PortalDataMapper.toPortalData(raw))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("알 수 없는 외국어 인증 값: Y");
     }
 
     @Test
-    @DisplayName("flangPassGb가 N이면 외국어 인증 미통과로 변환한다")
-    void mapsLanguageCertNotFulfilledWhenFlagIsN() throws Exception {
+    @DisplayName("flangPassGb가 N이면 알 수 없는 값으로 거부한다")
+    void rejectsLanguageCertWhenFlagIsN() throws Exception {
         RawPortalData raw = objectMapper.readValue(payloadWithLanguageCert("N"), RawPortalData.class);
 
-        PortalData portalData = PortalDataMapper.toPortalData(raw);
-
-        assertThat(portalData.student().languageCertFulfilled()).isFalse();
+        assertThatThrownBy(() -> PortalDataMapper.toPortalData(raw))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("알 수 없는 외국어 인증 값: N");
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapperTests.java
+++ b/src/test/java/com/chukchuk/haksa/infrastructure/portal/mapper/PortalDataMapperTests.java
@@ -33,6 +33,26 @@ class PortalDataMapperTests {
         assertThat(portalData.student().languageCertFulfilled()).isFalse();
     }
 
+    @Test
+    @DisplayName("flangPassGb가 통과이면 외국어 인증 통과로 변환한다")
+    void mapsLanguageCertFulfilledWhenFlagIsKoreanPass() throws Exception {
+        RawPortalData raw = objectMapper.readValue(payloadWithLanguageCert("통과"), RawPortalData.class);
+
+        PortalData portalData = PortalDataMapper.toPortalData(raw);
+
+        assertThat(portalData.student().languageCertFulfilled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("flangPassGb가 미통과이면 외국어 인증 미통과로 변환한다")
+    void mapsLanguageCertNotFulfilledWhenFlagIsKoreanFail() throws Exception {
+        RawPortalData raw = objectMapper.readValue(payloadWithLanguageCert("미통과"), RawPortalData.class);
+
+        PortalData portalData = PortalDataMapper.toPortalData(raw);
+
+        assertThat(portalData.student().languageCertFulfilled()).isFalse();
+    }
+
     private static String payloadWithLanguageCert(String flangPassGb) {
         return """
                 {


### PR DESCRIPTION
### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

- 원인: 개발 스크래퍼는 `flangPassGb`로 `통과`/`미통과`를 보낼 수 있지만, 백엔드는 기존에 `Y`/`N`/blank만 허용했습니다.
- 변경: `PortalDataMapper`가 `통과`를 `true`, `미통과`를 `false`로 매핑하게 했습니다.
- 변경: `Y`/`N`은 더 이상 유효 값으로 인정하지 않고 schema invalid 경로로 처리합니다.
- 변경: 알 수 없는 `flangPassGb` 값과 매핑 중 `RuntimeException`은 `SCRAPE_RESULT_SCHEMA_INVALID` 경로로 변환해 job이 `FAILED_RESULT_SCHEMA`로 확정되게 했습니다.
- 문서: `docs/specs/20260602-fix-flang-pass-gb/`에 Lite spec, checklist, context notes를 남겼습니다.
- 검증: `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*PortalDataMapperTests" --tests "*PortalCallbackPostProcessorTests" --tests "*ScrapeResultCallbackServiceUnitTests"` 통과.
- 검증: `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test` 통과.
- 참고: 로컬 기본 JDK 24에서는 Gradle test task 생성이 `Type T not present`로 실패해, 프로젝트 Java 17 환경으로 검증했습니다.

### 🔗 Related Issue

Closes #250
