### PR TITLE
253 feat: Sentry userId 추적 보강

### DIFF
--- a/docs/specs/20260603-sentry-userid/checklist.md
+++ b/docs/specs/20260603-sentry-userid/checklist.md
@@ -1,0 +1,14 @@
+# feat/253 Sentry userId 추적 보강 작업 체크리스트
+
+- [x] feat/253 브랜치 생성.
+- [x] 변경 전 `./gradlew test` 기준 통과 확인.
+- [x] Sentry MDC tag 목록에 포털 job 추적 키 추가.
+- [x] userId 기반 Sentry/MDC scope 헬퍼 추가.
+- [x] 전역 예외 처리의 Sentry 보고 제외 정책 세분화.
+- [x] callback 후처리 구간에 userId/jobId context 적용.
+- [x] outbox dispatch 실패 구간에 userId/jobId context 적용.
+- [x] stale reconcile 로그에 userId/jobId context 적용.
+- [x] 포털 내부 예상 실패 로그 레벨 정리.
+- [x] 대상 테스트 통과 확인.
+- [x] 전체 `./gradlew test` 통과 확인.
+- [x] 커밋 생성.

--- a/docs/specs/20260603-sentry-userid/context-notes.md
+++ b/docs/specs/20260603-sentry-userid/context-notes.md
@@ -14,3 +14,4 @@
 - 중앙 예외 처리에서 capture되는 포털 실패는 내부 `ERROR` 로그를 `WARN`으로 낮춰 SentryAppender 중복 이벤트를 줄였다. outbox dead, dispatch fail, Lambda maintenance fail처럼 별도 운영 이벤트가 필요한 `ERROR`는 유지했다.
 - 최종 검증은 `./gradlew test --rerun-tasks`로 수행했다.
 - 커밋은 공통 MDC/Sentry 기반, 포털 작업 context 전파, 사용자 오류 Sentry 전송 축소, 작업 문서의 네 단위로 분리한다.
+- Gemini 리뷰 중 Sentry user context 해제와 nullable context 변환 지적을 반영했다. Sentry user는 `pushScope()` 토큰으로 격리해 close 시 이전 scope가 복구되게 하고, UUID/Enum 변환은 `SentryMdcContext.from(...)`으로 중앙화한다.

--- a/docs/specs/20260603-sentry-userid/context-notes.md
+++ b/docs/specs/20260603-sentry-userid/context-notes.md
@@ -1,0 +1,16 @@
+# feat/253 Sentry userId 추적 보강 컨텍스트 노트
+
+## 2026-06-03
+
+- 현재 worktree는 detached HEAD였고 `feat/253` 브랜치를 새로 만들었다.
+- 변경 전 기준 `./gradlew test`는 통과했다. 컴파일 경고는 기존 경고로 보고 진행한다.
+- userId 누락의 중심 원인은 인증 필터 밖 흐름이다. `/internal/scrape-results`, outbox dispatch, maintenance는 job을 조회해야 userId를 알 수 있다.
+- job 조회 전 단계의 invalid signature, malformed body 같은 오류는 userId를 알 수 없다. 이 케이스는 body hash나 jobId 힌트만 남기는 정책을 유지한다.
+- API 응답 형태와 OpenAPI 문서는 변경하지 않는다.
+- `SentryMdcContext`는 실행 구간 동안 `userId`, `jobId`, `outboxId`, `operationType`, `workerRequestId`를 MDC에 넣고 종료 시 제거한다. Sentry user context도 같은 구간에서 설정한다.
+- `ScrapeResultCallbackService`는 receipt에서 userId를 얻은 뒤 현재 request attribute에도 context를 저장한다. 전역 예외 처리기가 Sentry capture 직전에 이 context를 다시 MDC로 올려 직접 capture 이벤트에서도 tag가 유지된다.
+- `ScrapeJobOutboxPublishCandidate`에 `userId`와 `operationType`을 포함했다. publish retry와 markFailed는 같은 scope 안에서 실행된다.
+- stale reconcile은 job/outbox 단위 timeout 로그를 scope 안에서 남긴다.
+- 중앙 예외 처리에서 capture되는 포털 실패는 내부 `ERROR` 로그를 `WARN`으로 낮춰 SentryAppender 중복 이벤트를 줄였다. outbox dead, dispatch fail, Lambda maintenance fail처럼 별도 운영 이벤트가 필요한 `ERROR`는 유지했다.
+- 최종 검증은 `./gradlew test --rerun-tasks`로 수행했다.
+- 커밋은 공통 MDC/Sentry 기반, 포털 작업 context 전파, 사용자 오류 Sentry 전송 축소, 작업 문서의 네 단위로 분리한다.

--- a/src/main/java/com/chukchuk/haksa/application/portal/InitializePortalConnectionService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/InitializePortalConnectionService.java
@@ -60,7 +60,7 @@ public class InitializePortalConnectionService {
 
             // StudentInitializationDataType 생성
             if (department == null) {
-                log.error("[BIZ] portal.init.fail userId={} reason=dept_init_failed", userId);
+                log.warn("[BIZ] portal.init.fail userId={} reason=dept_init_failed", userId);
                 return failure("학과/전공 정보 초기화 실패");
             }
 
@@ -101,7 +101,7 @@ public class InitializePortalConnectionService {
             }
             return success(raw.studentCode(), studentInfo);
         } catch (Exception e) {
-            log.error("[BIZ] portal.init.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
+            log.warn("[BIZ] portal.init.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
             throw new RuntimeException("포털 연동 중 오류가 발생했습니다.", e);
         }
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -136,7 +136,7 @@ public class PortalCallbackPostProcessor {
             Exception exception
     ) {
         meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").increment();
-        log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
+        log.warn("[BIZ] scrape.job.callback.postprocess.fail jobId={} userId={} operationType={} reason=invalid_payload message={}",
                 jobId, userId, operationType, message, exception);
         throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
     }
@@ -159,7 +159,7 @@ public class PortalCallbackPostProcessor {
                 failureDetail + ":" + exception.getMessage(),
                 false
         );
-        log.error("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} detail={}",
+        log.warn("[BIZ] scrape.job.callback.postprocess.fail jobId={} operationType={} reason={} detail={}",
                 jobId, operationType, reason, failureDetail, exception);
         throw new CommonException(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED, exception);
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
+import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
 import com.chukchuk.haksa.infrastructure.portal.dto.raw.RawPortalData;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import com.chukchuk.haksa.infrastructure.portal.mapper.PortalDataMapper;
@@ -40,6 +41,40 @@ public class PortalCallbackPostProcessor {
     }
 
     public void process(
+            String jobId,
+            UUID userId,
+            ScrapeJobOperationType operationType,
+            String payloadJson,
+            Instant finishedAt,
+            Double queuedAgeSeconds,
+            int attempt,
+            String workerRequestId,
+            String payloadHash
+    ) {
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(
+                new SentryMdcContext.Context(
+                        userId.toString(),
+                        jobId,
+                        null,
+                        operationType.name(),
+                        workerRequestId
+                )
+        )) {
+            processWithContext(
+                    jobId,
+                    userId,
+                    operationType,
+                    payloadJson,
+                    finishedAt,
+                    queuedAgeSeconds,
+                    attempt,
+                    workerRequestId,
+                    payloadHash
+            );
+        }
+    }
+
+    private void processWithContext(
             String jobId,
             UUID userId,
             ScrapeJobOperationType operationType,

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessor.java
@@ -52,13 +52,7 @@ public class PortalCallbackPostProcessor {
             String payloadHash
     ) {
         try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(
-                new SentryMdcContext.Context(
-                        userId.toString(),
-                        jobId,
-                        null,
-                        operationType.name(),
-                        workerRequestId
-                )
+                SentryMdcContext.from(userId, jobId, null, operationType, workerRequestId)
         )) {
             processWithContext(
                     jobId,

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
@@ -61,7 +61,7 @@ public class PortalLinkJobService {
         } catch (CommonException exception) {
             throw exception;
         } catch (RuntimeException exception) {
-            log.error("[BIZ] scrape.job.enqueue.fail userId={} portalType={} idempotencyKey={}",
+            log.warn("[BIZ] scrape.job.enqueue.fail userId={} portalType={} idempotencyKey={}",
                     userId, request.portal_type(), idempotencyKey, exception);
             throw new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED, exception);
         }
@@ -139,7 +139,7 @@ public class PortalLinkJobService {
             scrapeJobOutboxDispatcher.dispatchOnce(preparedJob.outboxId());
             PortalLinkJobTxService.DispatchSnapshot snapshot = portalLinkJobTxService.loadDispatchSnapshot(preparedJob.outboxId());
             if (!snapshot.isSent()) {
-                log.error("[BIZ] scrape.job.enqueue.sync.fail jobId={} outboxId={} portalType={} idempotencyKey={} jobStatus={} outboxStatus={} queueMessageId={} lastError={}",
+                log.warn("[BIZ] scrape.job.enqueue.sync.fail jobId={} outboxId={} portalType={} idempotencyKey={} jobStatus={} outboxStatus={} queueMessageId={} lastError={}",
                         snapshot.jobId(),
                         snapshot.outboxId(),
                         portalType,
@@ -153,7 +153,7 @@ public class PortalLinkJobService {
         } catch (CommonException exception) {
             throw exception;
         } catch (RuntimeException exception) {
-            log.error("[BIZ] scrape.job.enqueue.sync.exception jobId={} outboxId={} portalType={} idempotencyKey={}",
+            log.warn("[BIZ] scrape.job.enqueue.sync.exception jobId={} outboxId={} portalType={} idempotencyKey={}",
                     preparedJob.jobId(), preparedJob.outboxId(), portalType, idempotencyKey, exception);
             throw new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED, exception);
         }

--- a/src/main/java/com/chukchuk/haksa/application/portal/RefreshPortalConnectionService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/RefreshPortalConnectionService.java
@@ -52,7 +52,7 @@ public class RefreshPortalConnectionService {
                     : null;
 
             if (department == null) {
-                log.error("[BIZ] portal.conn.fail userId={} reason=dept_init_failed deptCode={}", userId, raw.department().code());
+                log.warn("[BIZ] portal.conn.fail userId={} reason=dept_init_failed deptCode={}", userId, raw.department().code());
                 return failure("학과/전공 정보 초기화 실패");
             }
 
@@ -87,7 +87,7 @@ public class RefreshPortalConnectionService {
             return success(raw.studentCode(), studentInfo);
 
         } catch (Exception e) {
-            log.error("[BIZ] portal.conn.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
+            log.warn("[BIZ] portal.conn.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
             throw new RuntimeException("포털 연동 중 오류가 발생했습니다.", e);
         }
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatchTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatchTxService.java
@@ -138,6 +138,8 @@ public class ScrapeJobOutboxDispatchTxService {
             candidates.add(new ScrapeJobOutboxPublishCandidate(
                     outbox.getOutboxId(),
                     outbox.getJobId(),
+                    job.getUserId(),
+                    job.getOperationType(),
                     outbox.getPayloadJson(),
                     outbox.getAttemptCount(),
                     outbox.getStatus(),

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
@@ -2,6 +2,7 @@ package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutboxStatus;
 import com.chukchuk.haksa.global.config.ScrapingProperties;
+import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
@@ -116,14 +117,26 @@ public class ScrapeJobOutboxDispatcher {
     }
 
     private void publishSingle(ScrapeJobOutboxPublishCandidate candidate, Instant attemptedAt, String trigger) {
-        try {
-            log.info("[BIZ] scrape.outbox.publish.start trigger={} outboxId={} jobId={} attempt={} outboxStatus={} queueMessageId={}",
-                    trigger, candidate.outboxId(), candidate.jobId(), candidate.attemptCount(), candidate.status(), candidate.queueMessageId());
-            String queueMessageId = publishWithBoundedRetry(candidate, trigger);
-            dispatchTxService.markSent(candidate.outboxId(), queueMessageId, attemptedAt, trigger);
-        } catch (RuntimeException e) {
-            dispatchTxService.markFailed(candidate.outboxId(), attemptedAt, trigger, e);
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(contextFor(candidate))) {
+            try {
+                log.info("[BIZ] scrape.outbox.publish.start trigger={} outboxId={} jobId={} attempt={} outboxStatus={} queueMessageId={}",
+                        trigger, candidate.outboxId(), candidate.jobId(), candidate.attemptCount(), candidate.status(), candidate.queueMessageId());
+                String queueMessageId = publishWithBoundedRetry(candidate, trigger);
+                dispatchTxService.markSent(candidate.outboxId(), queueMessageId, attemptedAt, trigger);
+            } catch (RuntimeException e) {
+                dispatchTxService.markFailed(candidate.outboxId(), attemptedAt, trigger, e);
+            }
         }
+    }
+
+    private SentryMdcContext.Context contextFor(ScrapeJobOutboxPublishCandidate candidate) {
+        return new SentryMdcContext.Context(
+                candidate.userId().toString(),
+                candidate.jobId(),
+                candidate.outboxId(),
+                candidate.operationType().name(),
+                null
+        );
     }
 
     private String publishWithBoundedRetry(ScrapeJobOutboxPublishCandidate candidate, String trigger) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcher.java
@@ -130,11 +130,11 @@ public class ScrapeJobOutboxDispatcher {
     }
 
     private SentryMdcContext.Context contextFor(ScrapeJobOutboxPublishCandidate candidate) {
-        return new SentryMdcContext.Context(
-                candidate.userId().toString(),
+        return SentryMdcContext.from(
+                candidate.userId(),
                 candidate.jobId(),
                 candidate.outboxId(),
-                candidate.operationType().name(),
+                candidate.operationType(),
                 null
         );
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxPublishCandidate.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxPublishCandidate.java
@@ -1,10 +1,15 @@
 package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutboxStatus;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
+
+import java.util.UUID;
 
 public record ScrapeJobOutboxPublishCandidate(
         String outboxId,
         String jobId,
+        UUID userId,
+        ScrapeJobOperationType operationType,
         String payloadJson,
         int attemptCount,
         ScrapeJobOutboxStatus status,

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -70,11 +70,11 @@ public class ScrapeJobStaleReconciler {
     }
 
     private SentryMdcContext.Context contextFor(ScrapeJob job, ScrapeJobOutbox outbox) {
-        return new SentryMdcContext.Context(
-                job.getUserId().toString(),
+        return SentryMdcContext.from(
+                job.getUserId(),
                 job.getJobId(),
                 outbox.getOutboxId(),
-                job.getOperationType().name(),
+                job.getOperationType(),
                 null
         );
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -8,6 +8,7 @@ import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobOutboxRepository;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.config.ScrapingProperties;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,19 +52,31 @@ public class ScrapeJobStaleReconciler {
                 continue;
             }
 
-            job.markFailed(
-                    ErrorCode.CALLBACK_TIMEOUT.name(),
-                    ErrorCode.CALLBACK_TIMEOUT.message(),
-                    true,
-                    now
-            );
-            meterRegistry.counter("scrape.job.callback.timeout").increment();
-            recordQueuedAge(job, now);
-            affectedCount++;
-            log.warn("[BIZ] scrape.job.callback.timeout jobId={} outboxId={} attempt={} outboxStatus={} queueMessageId={}",
-                    job.getJobId(), outbox.getOutboxId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
+            try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(contextFor(job, outbox))) {
+                job.markFailed(
+                        ErrorCode.CALLBACK_TIMEOUT.name(),
+                        ErrorCode.CALLBACK_TIMEOUT.message(),
+                        true,
+                        now
+                );
+                meterRegistry.counter("scrape.job.callback.timeout").increment();
+                recordQueuedAge(job, now);
+                affectedCount++;
+                log.warn("[BIZ] scrape.job.callback.timeout jobId={} outboxId={} attempt={} outboxStatus={} queueMessageId={}",
+                        job.getJobId(), outbox.getOutboxId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
+            }
         }
         return affectedCount;
+    }
+
+    private SentryMdcContext.Context contextFor(ScrapeJob job, ScrapeJobOutbox outbox) {
+        return new SentryMdcContext.Context(
+                job.getUserId().toString(),
+                job.getJobId(),
+                outbox.getOutboxId(),
+                job.getOperationType().name(),
+                null
+        );
     }
 
     private void recordQueuedAge(ScrapeJob job, Instant finishedAt) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
+import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
 import com.chukchuk.haksa.infrastructure.portal.client.ScrapeResultStoreClient;
 import com.chukchuk.haksa.infrastructure.portal.exception.ScrapeResultPayloadAccessException;
 import com.chukchuk.haksa.infrastructure.security.HmacSignatureVerifier;
@@ -127,106 +128,110 @@ public class ScrapeResultCallbackService {
                 attempt,
                 bodyHash
         );
-        logStage(
-                "receipt_committed",
-                receipt.jobId(),
-                attempt,
-                receipt.status(),
-                request.result_s3_key(),
-                workerRequestId,
-                elapsedMillis(receiptStartedAt)
-        );
-        if (receipt.duplicate()) {
-            handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
-            return;
-        }
-
-        try {
-            long s3StartedAt = System.nanoTime();
-            PayloadBundle payloadBundle = fetchAndNormalizePayload(request.result_s3_key());
-            verifyChecksum(request.resultChecksum(), payloadBundle.rawPayloadJson());
+        SentryMdcContext.Context context = contextFor(receipt, workerRequestId);
+        SentryMdcContext.bindToCurrentRequest(context);
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(context)) {
             logStage(
-                    "payload_ready",
+                    "receipt_committed",
                     receipt.jobId(),
                     attempt,
                     receipt.status(),
                     request.result_s3_key(),
                     workerRequestId,
-                    elapsedMillis(s3StartedAt)
+                    elapsedMillis(receiptStartedAt)
             );
+            if (receipt.duplicate()) {
+                handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
+                return;
+            }
 
-            meterRegistry.counter("scrape.job.callback.persisted").increment();
-            String payloadHash = hashRawBody(payloadBundle.rawPayloadJson());
-            log.info("[BIZ] scrape.job.callback.persisted jobId={} attempt={} requestId={} payloadHash={}",
-                    receipt.jobId(), attempt, workerRequestId, payloadHash);
+            try {
+                long s3StartedAt = System.nanoTime();
+                PayloadBundle payloadBundle = fetchAndNormalizePayload(request.result_s3_key());
+                verifyChecksum(request.resultChecksum(), payloadBundle.rawPayloadJson());
+                logStage(
+                        "payload_ready",
+                        receipt.jobId(),
+                        attempt,
+                        receipt.status(),
+                        request.result_s3_key(),
+                        workerRequestId,
+                        elapsedMillis(s3StartedAt)
+                );
 
-            long postProcessStartedAt = System.nanoTime();
-            portalCallbackPostProcessor.process(
-                    receipt.jobId(),
-                    receipt.userId(),
-                    receipt.operationType(),
-                    payloadBundle.normalizedPayloadJson(),
-                    finishedAt,
-                    receipt.queuedAgeSeconds(),
-                    attempt,
-                    workerRequestId,
-                    payloadHash
-            );
-            logStage(
-                    "postprocess_committed",
-                    receipt.jobId(),
-                    attempt,
-                    "succeeded",
-                    request.result_s3_key(),
-                    workerRequestId,
-                    elapsedMillis(postProcessStartedAt)
-            );
-        } catch (CommonException exception) {
-            if (shouldMarkSchemaFailure(exception)) {
+                meterRegistry.counter("scrape.job.callback.persisted").increment();
+                String payloadHash = hashRawBody(payloadBundle.rawPayloadJson());
+                log.info("[BIZ] scrape.job.callback.persisted jobId={} attempt={} requestId={} payloadHash={}",
+                        receipt.jobId(), attempt, workerRequestId, payloadHash);
+
+                long postProcessStartedAt = System.nanoTime();
+                portalCallbackPostProcessor.process(
+                        receipt.jobId(),
+                        receipt.userId(),
+                        receipt.operationType(),
+                        payloadBundle.normalizedPayloadJson(),
+                        finishedAt,
+                        receipt.queuedAgeSeconds(),
+                        attempt,
+                        workerRequestId,
+                        payloadHash
+                );
+                logStage(
+                        "postprocess_committed",
+                        receipt.jobId(),
+                        attempt,
+                        "succeeded",
+                        request.result_s3_key(),
+                        workerRequestId,
+                        elapsedMillis(postProcessStartedAt)
+                );
+            } catch (CommonException exception) {
+                if (shouldMarkSchemaFailure(exception)) {
+                    scrapeResultCallbackTxService.markFailed(
+                            receipt.jobId(),
+                            finishedAt,
+                            receipt.queuedAgeSeconds(),
+                            FAILED_RESULT_SCHEMA,
+                            exception.getMessage(),
+                            false
+                    );
+                }
+                throw exception;
+            } catch (ScrapeResultPayloadAccessException exception) {
+                scrapeResultCallbackTxService.markFailed(
+                        receipt.jobId(),
+                        finishedAt,
+                        receipt.queuedAgeSeconds(),
+                        FAILED_S3_READ,
+                        exception.getMessage(),
+                        exception.isRetryable()
+                );
+                log.error("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
+                        receipt.jobId(), request.result_s3_key(), attempt, exception.getMessage());
+                throw new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED, exception);
+            } catch (JsonProcessingException exception) {
                 scrapeResultCallbackTxService.markFailed(
                         receipt.jobId(),
                         finishedAt,
                         receipt.queuedAgeSeconds(),
                         FAILED_RESULT_SCHEMA,
-                        exception.getMessage(),
+                        exception.getOriginalMessage(),
                         false
                 );
+                log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_parse jobId={} resultS3Key={} message={}",
+                        receipt.jobId(), request.result_s3_key(), exception.getOriginalMessage());
+                throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
+            } finally {
+                logStage(
+                        "completed",
+                        receipt.jobId(),
+                        attempt,
+                        normalizedStatus(request.status()),
+                        request.result_s3_key(),
+                        workerRequestId,
+                        elapsedMillis(startedAt)
+                );
             }
-            throw exception;
-        } catch (ScrapeResultPayloadAccessException exception) {
-            scrapeResultCallbackTxService.markFailed(
-                    receipt.jobId(),
-                    finishedAt,
-                    receipt.queuedAgeSeconds(),
-                    FAILED_S3_READ,
-                    exception.getMessage(),
-                    exception.isRetryable()
-            );
-            log.error("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
-                    receipt.jobId(), request.result_s3_key(), attempt, exception.getMessage());
-            throw new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED, exception);
-        } catch (JsonProcessingException exception) {
-            scrapeResultCallbackTxService.markFailed(
-                    receipt.jobId(),
-                    finishedAt,
-                    receipt.queuedAgeSeconds(),
-                    FAILED_RESULT_SCHEMA,
-                    exception.getOriginalMessage(),
-                    false
-            );
-            log.warn("[BIZ] scrape.job.callback.invalid_payload stage=result_payload_parse jobId={} resultS3Key={} message={}",
-                    receipt.jobId(), request.result_s3_key(), exception.getOriginalMessage());
-            throw new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID, exception);
-        } finally {
-            logStage(
-                    "completed",
-                    receipt.jobId(),
-                    attempt,
-                    normalizedStatus(request.status()),
-                    request.result_s3_key(),
-                    workerRequestId,
-                    elapsedMillis(startedAt)
-            );
         }
     }
 
@@ -248,20 +253,37 @@ public class ScrapeResultCallbackService {
                 attempt,
                 bodyHash
         );
-        if (receipt.duplicate()) {
-            handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
-            return;
+        SentryMdcContext.Context context = contextFor(receipt, workerRequestId);
+        SentryMdcContext.bindToCurrentRequest(context);
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(context)) {
+            if (receipt.duplicate()) {
+                handleDuplicate(receipt, attempt, workerRequestId, request.result_s3_key());
+                return;
+            }
+            log.info("[BIZ] scrape.job.failed jobId={} errorCode={} retryable={} attempt={} requestId={}",
+                    receipt.jobId(), request.error_code(), request.retryable(), attempt, workerRequestId);
+            logStage(
+                    "completed",
+                    receipt.jobId(),
+                    attempt,
+                    receipt.status(),
+                    request.result_s3_key(),
+                    workerRequestId,
+                    elapsedMillis(startedAt)
+            );
         }
-        log.info("[BIZ] scrape.job.failed jobId={} errorCode={} retryable={} attempt={} requestId={}",
-                receipt.jobId(), request.error_code(), request.retryable(), attempt, workerRequestId);
-        logStage(
-                "completed",
+    }
+
+    private SentryMdcContext.Context contextFor(
+            ScrapeResultCallbackTxService.CallbackReceipt receipt,
+            String workerRequestId
+    ) {
+        return new SentryMdcContext.Context(
+                receipt.userId().toString(),
                 receipt.jobId(),
-                attempt,
-                receipt.status(),
-                request.result_s3_key(),
-                workerRequestId,
-                elapsedMillis(startedAt)
+                null,
+                receipt.operationType().name(),
+                workerRequestId
         );
     }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -278,11 +278,11 @@ public class ScrapeResultCallbackService {
             ScrapeResultCallbackTxService.CallbackReceipt receipt,
             String workerRequestId
     ) {
-        return new SentryMdcContext.Context(
-                receipt.userId().toString(),
+        return SentryMdcContext.from(
+                receipt.userId(),
                 receipt.jobId(),
                 null,
-                receipt.operationType().name(),
+                receipt.operationType(),
                 workerRequestId
         );
     }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackService.java
@@ -206,7 +206,7 @@ public class ScrapeResultCallbackService {
                         exception.getMessage(),
                         exception.isRetryable()
                 );
-                log.error("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
+                log.warn("[BIZ] scrape.job.s3.fail jobId={} key={} attempt={} reason={}",
                         receipt.jobId(), request.result_s3_key(), attempt, exception.getMessage());
                 throw new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED, exception);
             } catch (JsonProcessingException exception) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -60,7 +60,7 @@ public class SyncAcademicRecordService {
             }
             return new SyncAcademicRecordResult(true, null);
         } catch (Exception e) {
-            log.error("[BIZ] sync.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
+            log.warn("[BIZ] sync.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
             return new SyncAcademicRecordResult(false, "동기화 실패: " + e.getMessage());
         }
     }
@@ -77,7 +77,7 @@ public class SyncAcademicRecordService {
             }
             return new SyncAcademicRecordResult(true, null);
         } catch (Exception e) {
-            log.error("[BIZ] sync.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
+            log.warn("[BIZ] sync.ex userId={} ex={}", userId, e.getClass().getSimpleName(), e);
             return new SyncAcademicRecordResult(false, "동기화 실패: " + e.getMessage());
         }
     }
@@ -136,7 +136,7 @@ public class SyncAcademicRecordService {
                 .map(e -> {
                     CourseOffering off = offerings.get((long) e.getOfferingId());
                     if (off == null) {
-                        log.error("CourseOffering이 존재하지 않는 과목 정보입니다. offeringId={}", e.getOfferingId());
+                        log.warn("CourseOffering이 존재하지 않는 과목 정보입니다. offeringId={}", e.getOfferingId());
                         return null;
                     }
                     return StudentCourseBulkRow.from(e);
@@ -261,7 +261,7 @@ public class SyncAcademicRecordService {
             CourseOfferingService.CourseOfferingKey serviceKey = offeringKeyMap.get(entry.getKey());
             CourseOffering courseOffering = offeringEntities.get(serviceKey);
             if (courseOffering == null) {
-                log.error("CourseOffering not found for key {}", resolvedOfferingKeys.get(entry.getKey()));
+                log.warn("CourseOffering not found for key {}", resolvedOfferingKeys.get(entry.getKey()));
                 continue;
             }
             PortalOfferingCreationData offering = entry.getValue().getOffering();

--- a/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.chukchuk.haksa.global.exception.type.BaseException;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.global.logging.sanitize.LogSanitizer;
+import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
 import com.chukchuk.haksa.global.logging.sentry.SentryMdcTagBinder;
 import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,10 +29,15 @@ import java.util.Set;
 @Slf4j
 public class GlobalExceptionHandler {
 
-    private static final Set<String> SCRAPE_JOB_CLIENT_ERROR_CODES = Set.of(
+    private static final Set<String> EXPECTED_CLIENT_ERROR_CODES = Set.of(
             ErrorCode.SCRAPE_JOB_FAILED_RESULT.code(),
             ErrorCode.SCRAPE_JOB_NOT_COMPLETED.code(),
-            ErrorCode.SCRAPE_JOB_NOT_FOUND.code()
+            ErrorCode.SCRAPE_JOB_NOT_FOUND.code(),
+            ErrorCode.PORTAL_LOGIN_FAILED.code(),
+            ErrorCode.PORTAL_ACCOUNT_LOCKED.code(),
+            ErrorCode.INVALID_CALLBACK_SIGNATURE.code(),
+            ErrorCode.SCRAPE_INVALID_CALLBACK_REQUEST.code(),
+            ErrorCode.SCRAPE_INVALID_S3_KEY.code()
     );
 
     /** 비즈니스 예외(대부분 4xx)*/
@@ -39,17 +45,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBase(BaseException ex, HttpServletRequest req) {
 
         if (shouldReportBaseException(ex)) {
-            Sentry.withScope(scope -> {
-                scope.setTag("error.type", "BASE_EXCEPTION");
-                scope.setTag("error.code", ex.getCode());
-                scope.setFingerprint(List.of("BASE_EXCEPTION", ex.getCode()));
-                scope.setLevel(io.sentry.SentryLevel.WARNING); // 4xx 의미 유지
+            try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
+                Sentry.withScope(scope -> {
+                    scope.setTag("error.type", "BASE_EXCEPTION");
+                    scope.setTag("error.code", ex.getCode());
+                    scope.setFingerprint(List.of("BASE_EXCEPTION", ex.getCode()));
+                    scope.setLevel(io.sentry.SentryLevel.WARNING); // 4xx 의미 유지
 
-                // MDC → Sentry Tag 승격 (있을 때만)
-                SentryMdcTagBinder.bind(scope);
+                    // MDC → Sentry Tag 승격 (있을 때만)
+                    SentryMdcTagBinder.bind(scope);
 
-                Sentry.captureException(ex);
-            });
+                    Sentry.captureException(ex);
+                });
+            }
         }
 
         return ResponseEntity.status(ex.getStatus())
@@ -85,14 +93,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex, HttpServletRequest req) {
 
-        Sentry.withScope(scope -> {
-            scope.setTag("error.type", "ENTITY_NOT_FOUND");
-            scope.setTag("error.code", ex.getCode());
-            scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
-            scope.setLevel(io.sentry.SentryLevel.WARNING);
-            SentryMdcTagBinder.bind(scope);
-            Sentry.captureException(ex);
-        });
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
+            Sentry.withScope(scope -> {
+                scope.setTag("error.type", "ENTITY_NOT_FOUND");
+                scope.setTag("error.code", ex.getCode());
+                scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
+                scope.setLevel(io.sentry.SentryLevel.WARNING);
+                SentryMdcTagBinder.bind(scope);
+                Sentry.captureException(ex);
+            });
+        }
 
         return ResponseEntity.status(ex.getStatus())
                 .body(ErrorResponse.of(ex.getCode(), ex.getMessage(), null));
@@ -101,10 +111,12 @@ public class GlobalExceptionHandler {
     /** 예상 못한 서버 오류 → Sentry 단일 캡처 */
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleRuntime(RuntimeException ex, HttpServletRequest req) {
-        Sentry.withScope(scope -> {
-            SentryMdcTagBinder.bind(scope);
-            Sentry.captureException(ex);
-        }); // 중복 방지: log.error는 메시지만
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
+            Sentry.withScope(scope -> {
+                SentryMdcTagBinder.bind(scope);
+                Sentry.captureException(ex);
+            });
+        } // 중복 방지: log.error는 메시지만
         log.error("[RuntimeException] ctx={}", ctx(req));
         return ResponseEntity.internalServerError()
                 .body(ErrorResponse.of("INTERNAL_ERROR", "서버 오류가 발생했습니다.", null));
@@ -113,10 +125,12 @@ public class GlobalExceptionHandler {
     /** 최후 보루 */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleAny(Exception ex, HttpServletRequest req) {
-        Sentry.withScope(scope -> {
-            SentryMdcTagBinder.bind(scope);
-            Sentry.captureException(ex);
-        });
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
+            Sentry.withScope(scope -> {
+                SentryMdcTagBinder.bind(scope);
+                Sentry.captureException(ex);
+            });
+        }
         log.error("[Unhandled] type={} ctx={}", ex.getClass().getSimpleName(), ctx(req));
         return ResponseEntity.internalServerError()
                 .body(ErrorResponse.of("E-UNHANDLED", "서버 오류가 발생했습니다.", null));
@@ -145,7 +159,7 @@ public class GlobalExceptionHandler {
 
     boolean shouldReportBaseException(BaseException ex) {
         if (ex instanceof CommonException) {
-            return !SCRAPE_JOB_CLIENT_ERROR_CODES.contains(ex.getCode());
+            return !EXPECTED_CLIENT_ERROR_CODES.contains(ex.getCode());
         }
         return true;
     }

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContext.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContext.java
@@ -1,6 +1,7 @@
 // Sentry 이벤트 검색을 위한 MDC 컨텍스트 스코프 헬퍼
 package com.chukchuk.haksa.global.logging.sentry;
 
+import io.sentry.ISentryLifecycleToken;
 import io.sentry.Sentry;
 import io.sentry.protocol.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 public final class SentryMdcContext {
@@ -39,6 +41,22 @@ public final class SentryMdcContext {
 
     public static MdcScope open(Context context) {
         return new MdcScope(context);
+    }
+
+    public static Context from(
+            UUID userId,
+            String jobId,
+            String outboxId,
+            Enum<?> operationType,
+            String workerRequestId
+    ) {
+        return new Context(
+                userId != null ? userId.toString() : null,
+                jobId,
+                outboxId,
+                operationType != null ? operationType.name() : null,
+                workerRequestId
+        );
     }
 
     public static void bindToCurrentRequest(Context context) {
@@ -79,9 +97,11 @@ public final class SentryMdcContext {
     public static final class MdcScope implements AutoCloseable {
         private final Map<String, String> previousValues = new LinkedHashMap<>();
         private final boolean noop;
+        private final ISentryLifecycleToken sentryScopeToken;
 
         private MdcScope(Context context) {
             this.noop = false;
+            this.sentryScopeToken = hasText(context.userId()) ? Sentry.pushScope() : null;
             put(USER_ID, context.userId());
             put(JOB_ID, context.jobId());
             put(OUTBOX_ID, context.outboxId());
@@ -97,6 +117,7 @@ public final class SentryMdcContext {
 
         private MdcScope() {
             this.noop = true;
+            this.sentryScopeToken = null;
         }
 
         private static MdcScope noop() {
@@ -124,7 +145,9 @@ public final class SentryMdcContext {
                     MDC.put(key, value);
                 }
             });
-            Sentry.setUser(null);
+            if (sentryScopeToken != null) {
+                sentryScopeToken.close();
+            }
         }
 
         private boolean hasText(String value) {

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContext.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContext.java
@@ -1,0 +1,164 @@
+// Sentry 이벤트 검색을 위한 MDC 컨텍스트 스코프 헬퍼
+package com.chukchuk.haksa.global.logging.sentry;
+
+import io.sentry.Sentry;
+import io.sentry.protocol.User;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public final class SentryMdcContext {
+
+    private static final String USER_ID = "userId";
+    private static final String JOB_ID = "jobId";
+    private static final String OUTBOX_ID = "outboxId";
+    private static final String OPERATION_TYPE = "operationType";
+    private static final String WORKER_REQUEST_ID = "workerRequestId";
+    private static final String ATTR_PREFIX = SentryMdcContext.class.getName() + ".";
+
+    private SentryMdcContext() {
+    }
+
+    public static void run(Context context, Runnable action) {
+        try (MdcScope ignored = open(context)) {
+            action.run();
+        }
+    }
+
+    public static <T> T supply(Context context, Supplier<T> supplier) {
+        try (MdcScope ignored = open(context)) {
+            return supplier.get();
+        }
+    }
+
+    public static MdcScope open(Context context) {
+        return new MdcScope(context);
+    }
+
+    public static void bindToCurrentRequest(Context context) {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes servletAttributes) {
+            bindToRequest(servletAttributes.getRequest(), context);
+        }
+    }
+
+    public static void bindToRequest(HttpServletRequest request, Context context) {
+        if (request == null || context == null) {
+            return;
+        }
+        setAttribute(request, USER_ID, context.userId());
+        setAttribute(request, JOB_ID, context.jobId());
+        setAttribute(request, OUTBOX_ID, context.outboxId());
+        setAttribute(request, OPERATION_TYPE, context.operationType());
+        setAttribute(request, WORKER_REQUEST_ID, context.workerRequestId());
+    }
+
+    public static MdcScope openFromRequest(HttpServletRequest request) {
+        Context context = contextFromRequest(request);
+        if (context == null) {
+            return MdcScope.noop();
+        }
+        return open(context);
+    }
+
+    public record Context(
+            String userId,
+            String jobId,
+            String outboxId,
+            String operationType,
+            String workerRequestId
+    ) {
+    }
+
+    public static final class MdcScope implements AutoCloseable {
+        private final Map<String, String> previousValues = new LinkedHashMap<>();
+        private final boolean noop;
+
+        private MdcScope(Context context) {
+            this.noop = false;
+            put(USER_ID, context.userId());
+            put(JOB_ID, context.jobId());
+            put(OUTBOX_ID, context.outboxId());
+            put(OPERATION_TYPE, context.operationType());
+            put(WORKER_REQUEST_ID, context.workerRequestId());
+
+            if (hasText(context.userId())) {
+                User sentryUser = new User();
+                sentryUser.setId(context.userId());
+                Sentry.setUser(sentryUser);
+            }
+        }
+
+        private MdcScope() {
+            this.noop = true;
+        }
+
+        private static MdcScope noop() {
+            return new MdcScope();
+        }
+
+        private void put(String key, String value) {
+            previousValues.put(key, MDC.get(key));
+            if (hasText(value)) {
+                MDC.put(key, value);
+            } else {
+                MDC.remove(key);
+            }
+        }
+
+        @Override
+        public void close() {
+            if (noop) {
+                return;
+            }
+            previousValues.forEach((key, value) -> {
+                if (value == null) {
+                    MDC.remove(key);
+                } else {
+                    MDC.put(key, value);
+                }
+            });
+            Sentry.setUser(null);
+        }
+
+        private boolean hasText(String value) {
+            return value != null && !value.isBlank();
+        }
+    }
+
+    private static Context contextFromRequest(HttpServletRequest request) {
+        if (request == null) {
+            return null;
+        }
+        String userId = attribute(request, USER_ID);
+        String jobId = attribute(request, JOB_ID);
+        String outboxId = attribute(request, OUTBOX_ID);
+        String operationType = attribute(request, OPERATION_TYPE);
+        String workerRequestId = attribute(request, WORKER_REQUEST_ID);
+        if (!hasText(userId) && !hasText(jobId) && !hasText(outboxId) && !hasText(operationType) && !hasText(workerRequestId)) {
+            return null;
+        }
+        return new Context(userId, jobId, outboxId, operationType, workerRequestId);
+    }
+
+    private static void setAttribute(HttpServletRequest request, String key, String value) {
+        if (hasText(value)) {
+            request.setAttribute(ATTR_PREFIX + key, value);
+        }
+    }
+
+    private static String attribute(HttpServletRequest request, String key) {
+        Object value = request.getAttribute(ATTR_PREFIX + key);
+        return value instanceof String stringValue ? stringValue : null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
@@ -15,6 +15,10 @@ public final class SentryMdcTagBinder {
 
     private static final List<String> TAG_KEYS = List.of(
             "userId",
+            "jobId",
+            "outboxId",
+            "operationType",
+            "workerRequestId",
             "student_code",
             "admission_year",
             "primary_department_id",

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
@@ -40,7 +40,7 @@ public class PortalClient {
 
         } catch (Exception e) {
             long tookMs = LogTime.elapsedMs(t0);
-            log.error("[EXT] method=POST uri={} unexpected_error took_ms={}", uri, tookMs, e);
+            log.warn("[EXT] method=POST uri={} unexpected_error took_ms={}", uri, tookMs, e);
             throw new PortalScrapeException(ErrorCode.PORTAL_SCRAPE_FAILED, e);
         }
     }
@@ -51,7 +51,7 @@ public class PortalClient {
         long tookMs = LogTime.elapsedMs(t0);
         int status = e.getStatusCode().value();
 
-        if (status >= 500) log.error("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
+        if (status >= 500) log.warn("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
         else               log.warn ("[EXT] method=POST uri={} status={} took_ms={}", uri, status, tookMs);
     }
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,6 +30,10 @@
         <stacktrace.app.packages>com.chukchuk.haksa</stacktrace.app.packages>
         <mdcTags>
             <tag>userId</tag>
+            <tag>jobId</tag>
+            <tag>outboxId</tag>
+            <tag>operationType</tag>
+            <tag>workerRequestId</tag>
             <tag>student_code</tag>
             <tag>admission_year</tag>
             <tag>primary_department_id</tag>
@@ -45,6 +49,10 @@
         <stacktrace.app.packages>com.chukchuk.haksa</stacktrace.app.packages>
         <mdcTags>
             <tag>userId</tag>
+            <tag>jobId</tag>
+            <tag>outboxId</tag>
+            <tag>operationType</tag>
+            <tag>workerRequestId</tag>
             <tag>student_code</tag>
             <tag>admission_year</tag>
             <tag>primary_department_id</tag>

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -70,6 +72,12 @@ class PortalCallbackPostProcessorTests {
     void handle_linkSuccess() {
         ScrapeJob job = newJob(ScrapeJobOperationType.LINK);
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
+        doAnswer(invocation -> {
+            assertThat(MDC.get("userId")).isEqualTo(job.getUserId().toString());
+            assertThat(MDC.get("jobId")).isEqualTo(job.getJobId());
+            assertThat(MDC.get("operationType")).isEqualTo(ScrapeJobOperationType.LINK.name());
+            return null;
+        }).when(portalSyncService).syncWithPortal(eq(job.getUserId()), any());
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
         processor.process(
                 job.getJobId(),
@@ -86,6 +94,8 @@ class PortalCallbackPostProcessorTests {
         verify(portalSyncService).syncWithPortal(eq(job.getUserId()), any());
         assertThat(meterRegistry.counter("scrape.job.callback.postprocess.success").count()).isEqualTo(1.0);
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.SUCCEEDED);
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("jobId")).isNull();
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalCallbackPostProcessorTests.java
@@ -9,6 +9,10 @@ import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -157,21 +162,32 @@ class PortalCallbackPostProcessorTests {
         job.markPostProcessing("callbacks/" + job.getJobId() + "/result.json", null, null, 1, Instant.now());
         Instant finishedAt = Instant.parse("2026-04-08T00:00:00Z");
 
-        assertThatThrownBy(() -> processor.process(
-            job.getJobId(),
-            job.getUserId(),
-            ScrapeJobOperationType.LINK,
-            "{invalid-json}",
-            finishedAt,
-            1.0,
-            1,
-            "",
-            "invalid"
-        )).isInstanceOf(CommonException.class)
-                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code()));
+        Logger logger = (Logger) LoggerFactory.getLogger(PortalCallbackPostProcessor.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            assertThatThrownBy(() -> processor.process(
+                job.getJobId(),
+                job.getUserId(),
+                ScrapeJobOperationType.LINK,
+                "{invalid-json}",
+                finishedAt,
+                1.0,
+                1,
+                "",
+                "invalid"
+            )).isInstanceOf(CommonException.class)
+                    .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID.code()));
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
 
         assertThat(meterRegistry.counter("scrape.job.callback.postprocess.fail", "reason", "invalid_payload").count()).isEqualTo(1.0);
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.POST_PROCESSING);
+        assertThat(appender.list).noneMatch(event -> event.getLevel().equals(Level.ERROR));
         verify(scrapeJobRepository, never()).findForUpdateByJobId(job.getJobId());
     }
 

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcherUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatcherUnitTests.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.application.portal;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJob;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutbox;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOutboxStatus;
+import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobOutboxRepository;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import org.springframework.core.env.Environment;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -114,7 +116,13 @@ class ScrapeJobOutboxDispatcherUnitTests {
         when(scrapeJobOutboxRepository.findPublishTargetForUpdateByOutboxId(eq(outbox.getOutboxId()), any(), any())).thenReturn(Optional.of(outbox));
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
         when(scrapeJobOutboxRepository.findForUpdateByOutboxId(outbox.getOutboxId())).thenReturn(Optional.of(outbox));
-        when(scrapeJobPublisher.publish(outbox.getPayloadJson())).thenThrow(SdkClientException.create("temporary failure"));
+        when(scrapeJobPublisher.publish(outbox.getPayloadJson())).thenAnswer(invocation -> {
+            assertThat(MDC.get("userId")).isEqualTo(job.getUserId().toString());
+            assertThat(MDC.get("jobId")).isEqualTo(job.getJobId());
+            assertThat(MDC.get("outboxId")).isEqualTo(outbox.getOutboxId());
+            assertThat(MDC.get("operationType")).isEqualTo(ScrapeJobOperationType.LINK.name());
+            throw SdkClientException.create("temporary failure");
+        });
         when(environment.getActiveProfiles()).thenReturn(new String[]{"test"});
 
         dispatcher.dispatchOnce(outbox.getOutboxId());
@@ -122,6 +130,8 @@ class ScrapeJobOutboxDispatcherUnitTests {
         assertThat(outbox.getStatus()).isEqualTo(ScrapeJobOutboxStatus.RETRYABLE_FAILED);
         assertThat(outbox.getNextAttemptAt()).isNotNull();
         assertThat(outbox.getAttemptCount()).isEqualTo(1);
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("jobId")).isNull();
         verify(scrapeJobPublisher, times(3)).publish(outbox.getPayloadJson());
     }
 
@@ -227,7 +237,7 @@ class ScrapeJobOutboxDispatcherUnitTests {
         return ScrapeJob.createQueued(
                 UUID.randomUUID(),
                 "suwon",
-                com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType.LINK,
+                ScrapeJobOperationType.LINK,
                 "idem-1",
                 "fingerprint",
                 "{\"username\":\"17019013\",\"password\":\"pw\"}"

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconcilerUnitTests.java
@@ -8,6 +8,9 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobOutboxRepository;
 import com.chukchuk.haksa.domain.scrapejob.repository.ScrapeJobRepository;
 import com.chukchuk.haksa.global.config.ScrapingProperties;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.List;
@@ -66,11 +70,30 @@ class ScrapeJobStaleReconcilerUnitTests {
                 .thenReturn(List.of(outbox));
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
-        int affectedCount = reconciler.reconcileStaleQueuedJobs();
+        Logger logger = (Logger) LoggerFactory.getLogger(ScrapeJobStaleReconciler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        int affectedCount;
+        try {
+            affectedCount = reconciler.reconcileStaleQueuedJobs();
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
 
         assertThat(affectedCount).isEqualTo(1);
         assertThat(job.getStatus().name()).isEqualTo("FAILED");
         assertThat(job.getErrorCode()).isEqualTo("CALLBACK_TIMEOUT");
         assertThat(job.getRetryable()).isTrue();
+        assertThat(appender.list)
+                .filteredOn(event -> event.getFormattedMessage().contains("scrape.job.callback.timeout"))
+                .singleElement()
+                .satisfies(event -> assertThat(event.getMDCPropertyMap())
+                        .containsEntry("userId", job.getUserId().toString())
+                        .containsEntry("jobId", job.getJobId())
+                        .containsEntry("outboxId", outbox.getOutboxId())
+                        .containsEntry("operationType", ScrapeJobOperationType.REFRESH.name()));
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 
 import java.time.Instant;
 import java.security.MessageDigest;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -123,6 +125,14 @@ class ScrapeResultCallbackServiceUnitTests {
                           \"academic_records\":{\"listSmrCretSumTabYearSmr\":[{\"cretGainYear\":\"2024\",\"gainPoint\":\"18\"}]}
                         }
                         """);
+        doAnswer(invocation -> {
+            assertThat(MDC.get("userId")).isEqualTo(userId.toString());
+            assertThat(MDC.get("jobId")).isEqualTo(job.getJobId());
+            assertThat(MDC.get("operationType")).isEqualTo("LINK");
+            assertThat(MDC.get("workerRequestId")).isEqualTo("req-1");
+            return null;
+        }).when(portalCallbackPostProcessor)
+                .process(any(), any(), any(), any(), any(), any(), anyInt(), any(), any());
 
         service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), "2", "req-1");
 
@@ -140,6 +150,8 @@ class ScrapeResultCallbackServiceUnitTests {
         );
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.POST_PROCESSING);
         assertThat(job.getResultS3Key()).isEqualTo("callbacks/%s/result.json".formatted(job.getJobId()));
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("jobId")).isNull();
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -19,8 +19,20 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
-    void shouldReportOtherCommonExceptions() {
-        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.INVALID_ARGUMENT))).isTrue();
+    void shouldSkipSentryCaptureForExpectedPortalClientErrors() {
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.PORTAL_LOGIN_FAILED))).isFalse();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.PORTAL_ACCOUNT_LOCKED))).isFalse();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.INVALID_CALLBACK_SIGNATURE))).isFalse();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_INVALID_CALLBACK_REQUEST))).isFalse();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_INVALID_S3_KEY))).isFalse();
+    }
+
+    @Test
+    void shouldReportSystemPortalExceptions() {
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED))).isTrue();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED))).isTrue();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID))).isTrue();
+        assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_POST_PROCESSING_FAILED))).isTrue();
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContextTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContextTest.java
@@ -1,12 +1,22 @@
 // Sentry 요청 컨텍스트 바인딩 동작을 검증하는 테스트
 package com.chukchuk.haksa.global.logging.sentry;
 
+import io.sentry.ISentryLifecycleToken;
+import io.sentry.Sentry;
+import io.sentry.protocol.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 class SentryMdcContextTest {
 
@@ -61,5 +71,70 @@ class SentryMdcContextTest {
 
         assertThat(MDC.get("userId")).isNull();
         assertThat(MDC.get("jobId")).isNull();
+    }
+
+    @Test
+    void openWithUserPushesSentryScopeAndClosesIt() {
+        ISentryLifecycleToken token = Mockito.mock(ISentryLifecycleToken.class);
+
+        try (MockedStatic<Sentry> sentry = Mockito.mockStatic(Sentry.class)) {
+            sentry.when(Sentry::pushScope).thenReturn(token);
+
+            try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(new SentryMdcContext.Context(
+                    "user-1",
+                    "job-1",
+                    null,
+                    "LINK",
+                    null
+            ))) {
+                assertThat(MDC.get("userId")).isEqualTo("user-1");
+            }
+
+            sentry.verify(Sentry::pushScope, times(1));
+            sentry.verify(() -> Sentry.setUser(any(User.class)), times(1));
+            Mockito.verify(token).close();
+            sentry.verify(() -> Sentry.setUser(null), never());
+        }
+    }
+
+    @Test
+    void openWithoutUserDoesNotClearSentryUserOnClose() {
+        try (MockedStatic<Sentry> sentry = Mockito.mockStatic(Sentry.class)) {
+            try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(new SentryMdcContext.Context(
+                    null,
+                    "job-1",
+                    null,
+                    "LINK",
+                    null
+            ))) {
+                assertThat(MDC.get("jobId")).isEqualTo("job-1");
+            }
+
+            sentry.verify(() -> Sentry.setUser(any(User.class)), never());
+            sentry.verify(() -> Sentry.setUser(null), never());
+        }
+    }
+
+    @Test
+    void fromConvertsNullableUserAndEnumValues() {
+        UUID userId = UUID.randomUUID();
+
+        SentryMdcContext.Context populated = SentryMdcContext.from(
+                userId,
+                "job-1",
+                "outbox-1",
+                TestOperation.REFRESH,
+                "worker-req-1"
+        );
+        SentryMdcContext.Context empty = SentryMdcContext.from(null, "job-2", "outbox-2", null, null);
+
+        assertThat(populated.userId()).isEqualTo(userId.toString());
+        assertThat(populated.operationType()).isEqualTo("REFRESH");
+        assertThat(empty.userId()).isNull();
+        assertThat(empty.operationType()).isNull();
+    }
+
+    private enum TestOperation {
+        REFRESH
     }
 }

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContextTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcContextTest.java
@@ -1,0 +1,65 @@
+// Sentry 요청 컨텍스트 바인딩 동작을 검증하는 테스트
+package com.chukchuk.haksa.global.logging.sentry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SentryMdcContextTest {
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+    }
+
+    @Test
+    void runBindsValuesDuringActionAndClearsAfterward() {
+        SentryMdcContext.Context context = new SentryMdcContext.Context(
+                "user-1",
+                "job-1",
+                "outbox-1",
+                "LINK",
+                "worker-req-1"
+        );
+
+        SentryMdcContext.run(context, () -> {
+            assertThat(MDC.get("userId")).isEqualTo("user-1");
+            assertThat(MDC.get("jobId")).isEqualTo("job-1");
+            assertThat(MDC.get("outboxId")).isEqualTo("outbox-1");
+            assertThat(MDC.get("operationType")).isEqualTo("LINK");
+            assertThat(MDC.get("workerRequestId")).isEqualTo("worker-req-1");
+        });
+
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("jobId")).isNull();
+        assertThat(MDC.get("outboxId")).isNull();
+        assertThat(MDC.get("operationType")).isNull();
+        assertThat(MDC.get("workerRequestId")).isNull();
+    }
+
+    @Test
+    void openFromRequestBindsStoredContextAndClearsAfterward() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SentryMdcContext.bindToRequest(request, new SentryMdcContext.Context(
+                "user-1",
+                "job-1",
+                "outbox-1",
+                "REFRESH",
+                "worker-req-1"
+        ));
+
+        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(request)) {
+            assertThat(MDC.get("userId")).isEqualTo("user-1");
+            assertThat(MDC.get("jobId")).isEqualTo("job-1");
+            assertThat(MDC.get("outboxId")).isEqualTo("outbox-1");
+            assertThat(MDC.get("operationType")).isEqualTo("REFRESH");
+            assertThat(MDC.get("workerRequestId")).isEqualTo("worker-req-1");
+        }
+
+        assertThat(MDC.get("userId")).isNull();
+        assertThat(MDC.get("jobId")).isNull();
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
@@ -18,6 +18,10 @@ class SentryMdcTagBinderTest {
     @Test
     void collectReturnsOnlyPresentMdcValues() {
         MDC.put("userId", "user-1");
+        MDC.put("jobId", "job-1");
+        MDC.put("outboxId", "outbox-1");
+        MDC.put("operationType", "LINK");
+        MDC.put("workerRequestId", "worker-req-1");
         MDC.put("student_code", "20201234");
         MDC.put("admission_year", "2020");
 
@@ -25,6 +29,10 @@ class SentryMdcTagBinderTest {
 
         assertThat(tags)
                 .containsEntry("userId", "user-1")
+                .containsEntry("jobId", "job-1")
+                .containsEntry("outboxId", "outbox-1")
+                .containsEntry("operationType", "LINK")
+                .containsEntry("workerRequestId", "worker-req-1")
                 .containsEntry("student_code", "20201234")
                 .containsEntry("admission_year", "2020")
                 .doesNotContainKey("secondary_department_id");


### PR DESCRIPTION
## 한 줄 요약

포털 스크래핑 비동기 흐름에서도 Sentry 이벤트를 `userId`, `jobId`, `operationType` 중심으로 추적할 수 있게 보강합니다.

## 배경

기존에는 인증 필터 안에서 처리되는 API 예외는 `userId`로 추적하기 쉬웠지만, 포털 연동 일부 흐름은 인증 요청 밖에서 동작했습니다.

- `/internal/scrape-results` callback은 worker가 호출하므로 요청 인증 context가 없습니다.
- outbox dispatch, stale reconcile, maintenance 계열 작업은 scheduler/worker 흐름이라 MDC가 비어 있을 수 있습니다.
- 포털 로그인 실패, polling 상태 오류, invalid callback처럼 예상 가능한 사용자/클라이언트 오류도 Sentry 직접 캡처나 `ERROR` 로그를 통해 중복 유입될 수 있었습니다.

이 PR은 job을 조회한 뒤 알 수 있는 `userId`와 운영 추적 키를 Sentry/MDC에 묶고, 실제 시스템 오류와 예상 가능한 사용자 오류를 분리합니다.

## 변경 사항

### 1. Sentry/MDC 공통 context 추가

- `SentryMdcContext`를 추가해 실행 구간 동안 아래 값을 MDC와 Sentry user scope에 바인딩합니다.
  - `userId`
  - `jobId`
  - `outboxId`
  - `operationType`
  - `workerRequestId`
- `try-with-resources` 기반 scope로 종료 시 MDC를 이전 값으로 복원합니다.
- Sentry user는 `pushScope()` 토큰으로 격리해 내부 scope 종료가 상위 request user를 지우지 않게 했습니다.
- `SentryMdcContext.from(...)`으로 `UUID`와 `Enum` 변환을 중앙화해 context 생성 중 NPE가 나지 않게 했습니다.

### 2. 포털 비동기 흐름에 user context 적용

- `ScrapeResultCallbackService`는 callback receipt에서 job과 user를 확인한 뒤 callback 처리 전체를 user context 안에서 실행합니다.
- `PortalCallbackPostProcessor`는 post-process와 portal sync 호출 구간에서도 `userId`, `jobId`, `operationType`, `workerRequestId`를 유지합니다.
- outbox dispatch는 `ScrapeJobOutboxPublishCandidate`에 `userId`와 `operationType`을 포함하고, publish/retry/markFailed 구간을 같은 context로 묶습니다.
- stale reconcile은 timeout 처리와 운영 로그가 job/outbox context를 가진 상태로 남도록 변경했습니다.

### 3. Sentry 직접 캡처 대상 세분화

`GlobalExceptionHandler`에서 예상 가능한 사용자/클라이언트 오류는 Sentry 직접 캡처 대상에서 제외했습니다.

- 포털 로그인 실패.
- 포털 계정 잠김.
- polling 중 아직 완료되지 않은 job 상태.
- 이미 실패한 scrape job 결과 조회.
- invalid callback signature/request.
- invalid S3 key.

반대로 S3 read 실패, schema 오류, post-process 실패, enqueue 실패처럼 시스템 조치가 필요한 오류는 계속 Sentry에 남깁니다.

### 4. noisy ERROR 로그 축소

예상 가능한 포털 내부 실패는 `ERROR`에서 `WARN`으로 낮췄습니다. SentryAppender가 `ERROR` 로그를 이벤트로 올리는 경로와 전역 예외 처리의 직접 capture가 중복되는 것을 줄이기 위한 변경입니다.

이번에 하향한 로그는 다음입니다.

- `InitializePortalConnectionService`.
  - `portal.init.fail`, `reason=dept_init_failed`.
  - `portal.init.ex`, 포털 초기 연동 중 내부 예외를 상위로 다시 던지는 경로.
- `RefreshPortalConnectionService`.
  - `portal.conn.fail`, `reason=dept_init_failed`.
  - `portal.conn.ex`, 포털 refresh 중 내부 예외를 상위로 다시 던지는 경로.
- `PortalCallbackPostProcessor`.
  - `scrape.job.callback.postprocess.fail`, `reason=invalid_payload`.
  - `scrape.job.callback.postprocess.fail`, `reason=user_missing`, `portal_conn_fail`, `data_integrity`, `unexpected`.
- `ScrapeResultCallbackService`.
  - `scrape.job.s3.fail`, callback 결과 payload 조회 실패 후 `SCRAPE_RESULT_S3_FAILED`로 전역 예외 처리에 넘기는 경로.
- `PortalLinkJobService`.
  - `scrape.job.enqueue.fail`, scrape job enqueue 실패.
  - `scrape.job.enqueue.sync.fail`, 즉시 dispatch 후 outbox가 sent 상태가 아닌 경로.
  - `scrape.job.enqueue.sync.exception`, 즉시 dispatch 중 예외 발생 경로.
- `SyncAcademicRecordService`.
  - `sync.ex`, 포털 동기화 실패 결과를 반환하는 경로.
  - `CourseOffering` 누락 로그.
- `PortalClient`.
  - 외부 포털 호출 중 `unexpected_error`.
  - 외부 포털 HTTP `5xx` 응답 로그.

다만 outbox dead, dispatch fail, Lambda maintenance fail처럼 운영 알림으로 봐야 하는 `ERROR` 로그는 유지했습니다.

### 5. 리뷰 반영

Gemini 리뷰 중 실제 반영 가치가 있는 두 항목을 추가로 반영했습니다.

- `MdcScope.close()`가 `Sentry.setUser(null)`로 상위 Sentry user를 지울 수 있던 문제를 `pushScope()` 기반으로 보완했습니다.
- `userId`나 `operationType`이 비정상적으로 비어 있어도 context 생성부에서 NPE로 worker 루프가 중단되지 않도록 null-safe 변환을 공통화했습니다.

## 테스트

- `./gradlew test --tests "com.chukchuk.haksa.global.logging.sentry.SentryMdcContextTest"`
- `./gradlew test --tests "com.chukchuk.haksa.global.logging.sentry.*"`
- `./gradlew test --tests "com.chukchuk.haksa.global.exception.handler.GlobalExceptionHandlerTest"`
- `./gradlew test --tests "com.chukchuk.haksa.application.portal.*"`
- `git diff --check`
- `./gradlew test --rerun-tasks`

## 영향 범위

- API 응답 형식과 public contract는 변경하지 않았습니다.
- OpenAPI 문서 변경은 없습니다.
- job을 찾기 전 단계의 invalid signature, malformed body는 여전히 `userId`를 알 수 없습니다. 이 구간은 기존처럼 jobId 힌트나 body hash 중심으로 추적합니다.
- Sentry 검색과 운영 로그의 추적 키가 늘어나는 변경이며, 비즈니스 처리 흐름 자체는 유지합니다.

Closes #253.