### PR TITLE
257 feat: 선교 영역 코드 응답 및 Swagger 보강

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/AcademicRecordControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/controller/docs/AcademicRecordControllerDocs.java
@@ -22,7 +22,7 @@ public interface AcademicRecordControllerDocs {
 
     @Operation(
             summary = "학기별 성적 및 수강 과목 정보 조회",
-            description = "지정한 학기(year, semester)에 해당하는 성적 및 수강 과목 정보를 조회합니다.",
+            description = "지정한 학기(year, semester)에 해당하는 성적 및 수강 과목 정보를 조회합니다. courses.liberal[] 중 areaType이 선교인 과목은 liberalAreaCode를 포함할 수 있습니다. areaType이 선교가 아닌 과목은 liberalAreaCode 키가 응답에 포함되지 않습니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "지정 학기 성적 및 수강 과목 조회 성공",
                             content = @Content(schema = @Schema(implementation = AcademicRecordApiResponse.class))),

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
@@ -2,6 +2,8 @@ package com.chukchuk.haksa.domain.academic.record.dto;
 
 import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
 import com.chukchuk.haksa.domain.course.model.FacultyDivision;
+import com.chukchuk.haksa.domain.course.model.LiberalArtsAreaCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Objects;
@@ -25,6 +27,13 @@ public class StudentCourseDto {
             @Schema(description = "이수 연도") Integer year,
             @Schema(description = "이수 학기") Integer semester,
             @Schema(description = "원점수") Integer originalScore,
+            @Schema(
+                    description = "선교 영역 세부 코드 (LiberalArtsAreaCode). areaType 이 선교인 과목에 한해 노출되며, 그 외 영역에서는 응답에서 omit된다.",
+                    example = "7",
+                    nullable = true
+            )
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            Integer liberalAreaCode,
             @Schema(description = "재수강 삭제 과목 여부") boolean isRetakeDelete
     ) {
         public static CourseDetailDto from(StudentCourse course) {
@@ -43,8 +52,18 @@ public class StudentCourseDto {
                     course.getOffering().getYear(),
                     course.getOffering().getSemester(),
                     course.getOriginalScore() != null ? course.getOriginalScore() : 0,
+                    missionLiberalAreaCode(course),
                     course.isRetakeDeleted()
             );
+        }
+
+        private static Integer missionLiberalAreaCode(StudentCourse course) {
+            if (course.getOffering().getFacultyDivisionName() != FacultyDivision.선교) {
+                return null;
+            }
+
+            LiberalArtsAreaCode areaCode = course.getOffering().getLiberalArtsAreaCode();
+            return areaCode != null ? areaCode.getCode() : null;
         }
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
@@ -17,6 +17,7 @@ public interface StudentCourseRepository extends JpaRepository<StudentCourse, Lo
         JOIN FETCH sc.offering co
         JOIN FETCH co.course c
         LEFT JOIN FETCH co.professor p
+        LEFT JOIN FETCH co.liberalArtsAreaCode lac
         WHERE sc.student.id = :studentId
         AND co.year = :year
         AND co.semester = :semester

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/controller/docs/GraduationControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/controller/docs/GraduationControllerDocs.java
@@ -21,7 +21,7 @@ public interface GraduationControllerDocs {
 
     @Operation(
             summary = "졸업 요건 진행 상황 조회",
-            description = "로그인된 사용자의 졸업 요건 충족 여부와 외국어 졸업 인증 통과 여부를 조회합니다.",
+            description = "로그인된 사용자의 졸업 요건 충족 여부와 외국어 졸업 인증 통과 여부를 조회합니다. areaType이 선교인 영역의 courses[] 과목은 liberalAreaCode를 포함할 수 있습니다. areaType이 선교가 아닌 영역의 courses[] 과목은 liberalAreaCode 키가 응답에 포함되지 않습니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
@@ -386,7 +386,14 @@ public class GraduationQueryRepository {
                 dto.getCredits(),
                 dto.getGrade(),
                 dto.getSemester(),
-                dto.getLiberalAreaCode()
+                missionLiberalAreaCode(dto)
         );
+    }
+
+    private Integer missionLiberalAreaCode(CourseInternalDto dto) {
+        if (!FacultyDivision.선교.name().equals(dto.getAreaType())) {
+            return null;
+        }
+        return dto.getLiberalAreaCode();
     }
 }

--- a/src/main/resources/public/openapi.yaml
+++ b/src/main/resources/public/openapi.yaml
@@ -61,6 +61,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDetail'
 
+  /api/academic/record:
+    get:
+      tags:
+        - AcademicRecord
+      summary: 학기별 성적 및 수강 과목 정보 조회
+      description: 지정한 학기(year, semester)에 해당하는 성적 및 수강 과목 정보를 조회합니다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int32
+          description: 이수 연도
+          example: 2024
+        - name: semester
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int32
+          description: "학기 코드 (10: 1학기, 15: 여름학기, 20: 2학기, 25: 겨울학기)"
+          example: 10
+      responses:
+        '200':
+          description: 지정 학기 성적 및 수강 과목 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcademicRecordApiResponse'
+        '401':
+          description: 인증 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+        '404':
+          description: 해당 학기 성적 데이터 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
   /api/users/analytics-id:
     get:
       summary: 사용자 분석 식별자 조회
@@ -506,3 +551,218 @@ components:
           format: int32
           description: 이수 학기
           example: 10
+        liberalAreaCode:
+          type: integer
+          format: int32
+          nullable: true
+          description: 선교 영역 세부 코드. areaType이 선교인 과목에 한해 노출됩니다. areaType이 선교가 아닌 과목은 이 키가 응답에 포함되지 않습니다.
+          example: 7
+
+    AcademicRecordApiResponse:
+      type: object
+      required:
+        - success
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/AcademicRecordResponse'
+        message:
+          type: string
+          nullable: true
+          example: 요청 성공
+        error:
+          $ref: '#/components/schemas/ErrorDetail'
+          nullable: true
+
+    AcademicRecordResponse:
+      type: object
+      required:
+        - semesterGrade
+        - courses
+      properties:
+        semesterGrade:
+          $ref: '#/components/schemas/SemesterGrade'
+        courses:
+          $ref: '#/components/schemas/AcademicRecordCourses'
+
+    SemesterGrade:
+      type: object
+      required:
+        - year
+        - semester
+        - earnedCredits
+        - attemptedCredits
+        - semesterGpa
+        - percentile
+      properties:
+        year:
+          type: integer
+          format: int32
+          description: 이수 연도
+          example: 2024
+        semester:
+          type: integer
+          format: int32
+          description: "학기 코드 (10: 1학기, 15: 여름학기, 20: 2학기, 25: 겨울학기)"
+          example: 10
+        earnedCredits:
+          type: integer
+          format: int32
+          description: 취득 학점
+          example: 15
+        attemptedCredits:
+          type: integer
+          format: int32
+          description: 신청 학점
+          example: 18
+        semesterGpa:
+          type: number
+          description: 학기 GPA
+          example: 3.85
+        classRank:
+          type: integer
+          format: int32
+          nullable: true
+          description: 석차
+          example: 5
+        totalStudents:
+          type: integer
+          format: int32
+          nullable: true
+          description: 전체 학생 수
+          example: 150
+        percentile:
+          type: number
+          description: 백분율
+          example: 92.4
+
+    AcademicRecordCourses:
+      type: object
+      required:
+        - major
+        - liberal
+        - etc
+      properties:
+        major:
+          type: array
+          description: 전공 과목 목록
+          items:
+            $ref: '#/components/schemas/StudentCourseDetail'
+        liberal:
+          type: array
+          description: 교양 과목 목록. areaType이 선교인 과목은 liberalAreaCode를 포함할 수 있고, 선교가 아닌 과목은 해당 키가 응답에 포함되지 않습니다.
+          items:
+            $ref: '#/components/schemas/StudentCourseDetail'
+        etc:
+          type: array
+          description: 기타 과목 목록
+          items:
+            $ref: '#/components/schemas/StudentCourseDetail'
+
+    StudentCourseDetail:
+      type: object
+      required:
+        - id
+        - courseName
+        - courseCode
+        - areaType
+        - credits
+        - professor
+        - grade
+        - score
+        - isRetake
+        - isOnline
+        - year
+        - semester
+        - originalScore
+        - isRetakeDelete
+      properties:
+        id:
+          type: string
+          description: 수강 ID
+          example: "123"
+        courseName:
+          type: string
+          description: 과목명
+          example: 기독교의 이해
+        courseCode:
+          type: string
+          description: 학수번호
+          example: GEN001
+        areaType:
+          type: string
+          description: 영역 유형
+          enum:
+            - 중핵
+            - 기교
+            - 선교
+            - 소교
+            - 전교
+            - 전취
+            - 전핵
+            - 전선
+            - 일선
+            - 복선
+            - 복핵
+            - 복교
+            - 기타
+          example: 선교
+        rawAreaType:
+          type: string
+          nullable: true
+          description: 포털 원본 이수 구분
+          example: 교직
+        credits:
+          type: integer
+          format: int32
+          description: 학점
+          example: 3
+        professor:
+          type: string
+          description: 교수명
+          example: 김교수
+        grade:
+          type: string
+          description: 성적
+          example: A+
+        score:
+          type: integer
+          format: int32
+          description: 실 점수
+          example: 3
+        isRetake:
+          type: boolean
+          description: 재수강 여부
+          example: false
+        isOnline:
+          type: boolean
+          description: 사이버 강의 여부
+          example: false
+        year:
+          type: integer
+          format: int32
+          description: 이수 연도
+          example: 2024
+        semester:
+          type: integer
+          format: int32
+          description: 이수 학기
+          example: 10
+        originalScore:
+          type: integer
+          format: int32
+          description: 원점수
+          example: 95
+        liberalAreaCode:
+          type: integer
+          format: int32
+          nullable: true
+          description: 선교 영역 세부 코드. areaType이 선교인 과목에 한해 노출됩니다. areaType이 선교가 아닌 과목은 이 키가 응답에 포함되지 않습니다.
+          example: 7
+        isRetakeDelete:
+          type: boolean
+          description: 재수강 삭제 과목 여부
+          example: false

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDtoTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDtoTests.java
@@ -5,9 +5,12 @@ import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
 import com.chukchuk.haksa.domain.course.model.Course;
 import com.chukchuk.haksa.domain.course.model.CourseOffering;
 import com.chukchuk.haksa.domain.course.model.FacultyDivision;
+import com.chukchuk.haksa.domain.course.model.LiberalArtsAreaCode;
 import com.chukchuk.haksa.domain.professor.model.Professor;
 import com.chukchuk.haksa.domain.student.model.Grade;
 import com.chukchuk.haksa.domain.student.model.GradeType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,6 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class StudentCourseDtoTests {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     @DisplayName("기타 과목 응답은 canonical areaType과 포털 원본 rawAreaType을 함께 반환한다")
@@ -50,5 +55,80 @@ class StudentCourseDtoTests {
 
         assertThat(result.areaType()).isEqualTo(FacultyDivision.기타);
         assertThat(result.rawAreaType()).isEqualTo("교직");
+    }
+
+    @Test
+    @DisplayName("선교 과목 응답은 liberalAreaCode 를 반환한다")
+    void from_whenMissionCourseHasAreaCode_returnsLiberalAreaCode() {
+        CourseOffering offering = offering(FacultyDivision.선교, areaCode(7));
+        StudentCourse studentCourse = studentCourse(offering);
+
+        StudentCourseDto.CourseDetailDto result = StudentCourseDto.CourseDetailDto.from(studentCourse);
+
+        assertThat(result.areaType()).isEqualTo(FacultyDivision.선교);
+        assertThat(result.liberalAreaCode()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("선교가 아닌 과목 응답은 liberalAreaCode 를 반환하지 않는다")
+    void from_whenNonMissionCourseHasAreaCode_omitsLiberalAreaCode() {
+        CourseOffering offering = offering(FacultyDivision.중핵, areaCode(7));
+        StudentCourse studentCourse = studentCourse(offering);
+
+        StudentCourseDto.CourseDetailDto result = StudentCourseDto.CourseDetailDto.from(studentCourse);
+
+        assertThat(result.areaType()).isEqualTo(FacultyDivision.중핵);
+        assertThat(result.liberalAreaCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("liberalAreaCode 가 null 이면 JSON 응답에서 키가 omit 된다")
+    void serializesWithoutLiberalAreaCodeWhenNull() throws JsonProcessingException {
+        CourseOffering offering = offering(FacultyDivision.중핵, areaCode(7));
+        StudentCourse studentCourse = studentCourse(offering);
+
+        StudentCourseDto.CourseDetailDto result = StudentCourseDto.CourseDetailDto.from(studentCourse);
+        String json = objectMapper.writeValueAsString(result);
+
+        assertThat(json).doesNotContain("liberalAreaCode");
+    }
+
+    private CourseOffering offering(FacultyDivision division, LiberalArtsAreaCode areaCode) {
+        Course course = mock(Course.class);
+        when(course.getCourseName()).thenReturn("기독교의 이해");
+        when(course.getCourseCode()).thenReturn("GEN001");
+
+        Professor professor = mock(Professor.class);
+        when(professor.getProfessorName()).thenReturn("김교수");
+
+        CourseOffering offering = mock(CourseOffering.class);
+        when(offering.getCourse()).thenReturn(course);
+        when(offering.getFacultyDivisionName()).thenReturn(division);
+        when(offering.getRawFacultyDivisionName()).thenReturn(null);
+        when(offering.getPoints()).thenReturn(3);
+        when(offering.getProfessor()).thenReturn(professor);
+        when(offering.getIsVideoLecture()).thenReturn(false);
+        when(offering.getYear()).thenReturn(2024);
+        when(offering.getSemester()).thenReturn(1);
+        when(offering.getLiberalArtsAreaCode()).thenReturn(areaCode);
+        return offering;
+    }
+
+    private LiberalArtsAreaCode areaCode(Integer code) {
+        LiberalArtsAreaCode areaCode = mock(LiberalArtsAreaCode.class);
+        when(areaCode.getCode()).thenReturn(code);
+        return areaCode;
+    }
+
+    private StudentCourse studentCourse(CourseOffering offering) {
+        StudentCourse studentCourse = mock(StudentCourse.class);
+        when(studentCourse.getId()).thenReturn(11L);
+        when(studentCourse.getOffering()).thenReturn(offering);
+        when(studentCourse.getGrade()).thenReturn(new Grade(GradeType.A_PLUS));
+        when(studentCourse.getPoints()).thenReturn(3);
+        when(studentCourse.getIsRetake()).thenReturn(false);
+        when(studentCourse.getOriginalScore()).thenReturn(95);
+        when(studentCourse.isRetakeDeleted()).thenReturn(false);
+        return studentCourse;
     }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/service/AcademicRecordServiceUnitTests.java
@@ -41,19 +41,19 @@ class AcademicRecordServiceUnitTests {
 
         StudentCourseDto.CourseDetailDto major = new StudentCourseDto.CourseDetailDto(
                 "1", "자료구조", "CSE101", FacultyDivision.전핵, null, 3, "홍길동", "A+", 3,
-                false, false, 2024, 1, 95, false
+                false, false, 2024, 1, 95, null, false
         );
         StudentCourseDto.CourseDetailDto liberal = new StudentCourseDto.CourseDetailDto(
                 "2", "글쓰기", "LBA101", FacultyDivision.중핵, null, 2, "김교수", "B+", 2,
-                false, false, 2024, 1, 88, false
+                false, false, 2024, 1, 88, null, false
         );
         StudentCourseDto.CourseDetailDto etc = new StudentCourseDto.CourseDetailDto(
                 "3", "특별과정", "ETC101", FacultyDivision.기타, "교직", 1, "최교수", "P", 1,
-                false, false, 2024, 1, 80, false
+                false, false, 2024, 1, 80, null, false
         );
         StudentCourseDto.CourseDetailDto etcUnknown = new StudentCourseDto.CourseDetailDto(
                 "4", "미지정과정", "UNK001", null, null, 1, "미지정", "P", 1,
-                false, false, 2024, 1, 70, false
+                false, false, 2024, 1, 70, null, false
         );
 
         when(semesterAcademicRecordService.getSemesterGradesByYearAndSemester(studentId, 2024, 1)).thenReturn(grade);
@@ -81,7 +81,7 @@ class AcademicRecordServiceUnitTests {
 
         StudentCourseDto.CourseDetailDto liberal = new StudentCourseDto.CourseDetailDto(
                 "10", "영어회화", "ENG201", FacultyDivision.중핵, null, 2, "박교수", "A0", 2,
-                false, false, 2023, 2, 90, false
+                false, false, 2023, 2, 90, null, false
         );
 
         when(semesterAcademicRecordService.getSemesterGradesByYearAndSemester(studentId, 2023, 2)).thenReturn(grade);
@@ -105,11 +105,11 @@ class AcademicRecordServiceUnitTests {
 
         StudentCourseDto.CourseDetailDto dualCore = new StudentCourseDto.CourseDetailDto(
                 "20", "복수전공핵심", "DMJ101", FacultyDivision.복핵, null, 3, "이교수", "A+", 3,
-                false, false, 2024, 1, 96, false
+                false, false, 2024, 1, 96, null, false
         );
         StudentCourseDto.CourseDetailDto dualLiberal = new StudentCourseDto.CourseDetailDto(
                 "21", "복수전공교양", "DMJ102", FacultyDivision.복교, null, 3, "김교수", "A0", 3,
-                false, false, 2024, 1, 92, false
+                false, false, 2024, 1, 92, null, false
         );
 
         when(semesterAcademicRecordService.getSemesterGradesByYearAndSemester(studentId, 2024, 1)).thenReturn(grade);

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryMapperTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryMapperTest.java
@@ -75,4 +75,26 @@ class GraduationQueryRepositoryMapperTest {
         assertThat(dto.getYear()).isEqualTo(2023);
         assertThat(dto.getCourseName()).isEqualTo("자료구조");
     }
+
+    @Test
+    @DisplayName("toCourseResponseDto 는 선교가 아닌 과목의 liberalAreaCode 를 노출하지 않는다")
+    void toCourseResponseDto_omitsLiberalAreaCodeForNonMissionCourse() {
+        GraduationQueryRepository repository = newRepository();
+        CourseInternalDto internal = new CourseInternalDto(
+                3L,
+                "전핵",
+                3,
+                "A+",
+                "자료구조",
+                20,
+                2024,
+                "CSE101",
+                95,
+                7
+        );
+
+        CourseDto dto = repository.toCourseResponseDto(internal);
+
+        assertThat(dto.getLiberalAreaCode()).isNull();
+    }
 }

--- a/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
@@ -144,6 +144,31 @@ class OpenApiResponseContractTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void staticOpenApiDocumentsMissionLiberalAreaCodeForGraduationAndAcademicRecord() throws Exception {
+        Map<String, Object> staticOpenApi;
+        try (InputStream inputStream = Files.newInputStream(Path.of("src/main/resources/public/openapi.yaml"))) {
+            staticOpenApi = new Yaml().load(inputStream);
+        }
+
+        Map<String, Object> paths = (Map<String, Object>) staticOpenApi.get("paths");
+        assertThat(paths).containsKeys("/api/graduation/progress", "/api/academic/record");
+
+        Map<String, Object> components = (Map<String, Object>) staticOpenApi.get("components");
+        Map<String, Object> schemas = (Map<String, Object>) components.get("schemas");
+
+        Map<String, Object> graduationCourse = (Map<String, Object>) schemas.get("GraduationCourse");
+        Map<String, Object> graduationCourseProperties = (Map<String, Object>) graduationCourse.get("properties");
+        Map<String, Object> graduationLiberalAreaCode = (Map<String, Object>) graduationCourseProperties.get("liberalAreaCode");
+        assertThat(graduationLiberalAreaCode.get("type")).isEqualTo("integer");
+
+        Map<String, Object> studentCourseDetail = (Map<String, Object>) schemas.get("StudentCourseDetail");
+        Map<String, Object> studentCourseDetailProperties = (Map<String, Object>) studentCourseDetail.get("properties");
+        Map<String, Object> academicLiberalAreaCode = (Map<String, Object>) studentCourseDetailProperties.get("liberalAreaCode");
+        assertThat(academicLiberalAreaCode.get("type")).isEqualTo("integer");
+    }
+
+    @Test
     void jsonResponsesDoNotUseWildcardMediaType() throws Exception {
         JsonNode apiDocs = apiDocs();
 


### PR DESCRIPTION
## 1. Actual implementation changes
- `GET /api/graduation/progress`의 과목 응답에서 `areaType == 선교`인 경우에만 `liberalAreaCode`를 노출하도록 보강했습니다.
- `GET /api/academic/record`의 `courses.liberal[]` 과목 응답에도 선교 영역 전용 `liberalAreaCode`를 추가했습니다.
- 비-선교 과목은 DB에 `area_code` 값이 있더라도 응답에서 `liberalAreaCode`가 omit되도록 매핑을 제한했습니다.
- `src/main/resources/public/openapi.yaml`에 `/api/academic/record` path와 두 API의 `liberalAreaCode` schema를 반영했습니다.

## 2. Review focus
- 선교 외 영역에서 `liberalAreaCode`가 노출되지 않는 계약이 의도와 맞는지 확인해 주세요.
- 정적 OpenAPI 문서의 `AcademicRecordResponse`/`StudentCourseDetail` 스키마가 프론트 개발에 충분한지 확인해 주세요.

## 3. Intentional implementation choices
- 졸업 진행도와 학업기록 모두 `areaType == 선교` 조건에서만 `course_offerings.area_code`를 응답 값으로 사용했습니다.
- `StudentCourseRepository`는 `co.liberalArtsAreaCode`를 fetch join해 학업기록 DTO 매핑 시 추가 lazy select를 피했습니다.
- 기존 응답 호환성을 위해 nullable 필드는 `@JsonInclude(NON_NULL)`로 omit합니다.

## 4. Verification
- `./gradlew test --tests com.chukchuk.haksa.domain.academic.record.dto.StudentCourseDtoTests --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryMapperTest --tests com.chukchuk.haksa.global.config.OpenApiResponseContractTest`
- `./gradlew test`
- `git diff --check`

## 5. Risks and follow-up
- historical NULL 선교 row는 기존 정책대로 `liberalAreaCode`가 omit됩니다. 재스크래핑 backfill 이후 값이 채워집니다.

Closes #257
Related #226
Related #231