### PR TITLE
244 feat: 포털 연동 소요 시간 조회 API 추가

### DIFF
--- a/docs/specs/20260604-issue-244-portal-link-duration/clarify.md
+++ b/docs/specs/20260604-issue-244-portal-link-duration/clarify.md
@@ -1,0 +1,10 @@
+# Clarify
+
+## Decisions
+
+| # | Decision | Reason | Date |
+|---|---|---|---|
+| 1 | Use `GET /portal/link/jobs/{jobId}/duration`. | Existing job status and summary endpoints are under `/portal/link/jobs/{jobId}`. | 2026-06-04 |
+| 2 | Store duration timestamps on `scrape_jobs`, not `scrape_job_outbox`. | Outbox timestamps describe queue publication attempts, not end-to-end link processing. | 2026-06-04 |
+| 3 | Keep `finished_at` compatibility semantics and add `link_started_at`/`link_ended_at`. | Current success flow can use worker payload `finished_at`; the new API needs server-side timing. | 2026-06-04 |
+| 4 | Do not use Spring AOP for terminal timestamp writes. | Terminal status and terminal timestamp must be written in the same transaction; AOP would hide or split that boundary. | 2026-06-04 |

--- a/docs/specs/20260604-issue-244-portal-link-duration/plan.md
+++ b/docs/specs/20260604-issue-244-portal-link-duration/plan.md
@@ -1,0 +1,23 @@
+# Plan
+
+## Implementation
+
+1. Add failing tests for the duration query response and server-side terminal timestamp behavior.
+2. Add Flyway `V4__add_portal_link_duration_columns.sql` with a `created_at` backfill for existing rows.
+3. Extend `ScrapeJob` with `linkStartedAt`, `linkEndedAt`, and terminal transition methods that record server end time.
+4. Pass `requestedAt` into new job creation so `linkStartedAt` uses the request acceptance timestamp.
+5. Add `PortalLinkDto.JobDurationResponse` and `PortalLinkJobQueryService.getJobDuration`.
+6. Add `GET /portal/link/jobs/{jobId}/duration` controller/docs/wrapper support.
+7. Update OpenAPI contract coverage and static `public/openapi.yaml`.
+
+## Verification
+
+- Focused application tests:
+  - `PortalLinkJobQueryService` duration tests
+  - `PortalJobQueryControllerApiIntegrationTest`
+  - `ScrapeResultCallbackServiceUnitTests` or transaction service tests for terminal server timestamp
+- OpenAPI tests:
+  - `PortalLinkOpenApiTest`
+  - `OpenApiResponseContractTest` when static/openapi wrapper changes affect global contracts
+- Broader check:
+  - `./gradlew test` because this changes public API, persistence, and callback behavior.

--- a/docs/specs/20260604-issue-244-portal-link-duration/spec.md
+++ b/docs/specs/20260604-issue-244-portal-link-duration/spec.md
@@ -1,0 +1,109 @@
+# Spec
+
+## Context
+
+Issue: https://github.com/cchaksa/cchaksa-backend/issues/244
+
+`POST /portal/link` accepts an asynchronous portal link job and returns a `job_id`. Clients can already poll job status through `GET /portal/link/jobs/{jobId}` and fetch the completed summary through `GET /portal/link/jobs/{jobId}/summary`.
+
+This work adds a separate API for the elapsed time between server-side job acceptance and server-side terminal-state decision.
+
+## Goal
+
+Expose a job duration API that reports:
+
+- whether the job is still pending or terminal
+- whether the terminal result succeeded or failed
+- server-recorded start and end timestamps
+- elapsed time as both milliseconds and a display string
+
+Completion means `scrape_jobs.status == SUCCEEDED`. Terminal states are `SUCCEEDED` and `FAILED`.
+
+## Non-Goals
+
+- Do not change `POST /portal/link`.
+- Do not change `GET /portal/link/jobs/{jobId}`.
+- Do not change `GET /portal/link/jobs/{jobId}/summary`.
+- Do not use worker callback `finished_at` as the duration API's server end timestamp.
+- Do not move SQS dispatch, scraping, S3 fetch, or portal sync behavior.
+
+## API
+
+Endpoint:
+
+```text
+GET /portal/link/jobs/{jobId}/duration
+```
+
+Pending response:
+
+```json
+{
+  "job_id": "job-123",
+  "status": "pending",
+  "success": null,
+  "started_at": "2026-06-04T10:00:00Z",
+  "ended_at": null,
+  "elapsed_millis": null,
+  "elapsed_time": null
+}
+```
+
+Succeeded response:
+
+```json
+{
+  "job_id": "job-123",
+  "status": "succeeded",
+  "success": true,
+  "started_at": "2026-06-04T10:00:00Z",
+  "ended_at": "2026-06-04T10:00:12.345Z",
+  "elapsed_millis": 12345,
+  "elapsed_time": "12s 345ms"
+}
+```
+
+Failed response:
+
+```json
+{
+  "job_id": "job-123",
+  "status": "failed",
+  "success": false,
+  "started_at": "2026-06-04T10:00:00Z",
+  "ended_at": "2026-06-04T10:00:03.120Z",
+  "elapsed_millis": 3120,
+  "elapsed_time": "3s 120ms"
+}
+```
+
+The endpoint uses the existing authenticated job ownership check. Unknown or non-owned jobs return the same not-found behavior as existing job query APIs.
+
+## Data Model
+
+Add columns to `scrape_jobs`:
+
+- `link_started_at TIMESTAMP WITH TIME ZONE`
+- `link_ended_at TIMESTAMP WITH TIME ZONE NULL`
+
+`link_started_at` is recorded when a new job is accepted. Existing rows can be backfilled from `created_at` in the migration.
+
+`link_ended_at` is recorded when the server transitions the job into `SUCCEEDED` or `FAILED`.
+
+Existing `finished_at` stays unchanged. It may continue to reflect worker callback timing and compatibility semantics.
+
+## AOP Decision
+
+Duration measurement is separate from portal link business processing, but the end timestamp must be written atomically with the terminal status transition. A Spring AOP advice around the service methods would either need a second repository update or would obscure the transaction boundary.
+
+Therefore this implementation does not use AOP. It keeps the concern separated by adding explicit duration fields and domain methods on `ScrapeJob`, then calling them only at the existing terminal transition points.
+
+## Acceptance Criteria
+
+- `QUEUED`, `RUNNING`, and `POST_PROCESSING` jobs return `status=pending`.
+- `SUCCEEDED` jobs return `status=succeeded` and `success=true`.
+- `FAILED` jobs return `status=failed` and `success=false`.
+- Pending jobs return null elapsed fields.
+- Terminal jobs return `elapsed_millis` and `{seconds}s {millis}ms`.
+- Server end timestamp is independent of callback payload `finished_at`.
+- Existing portal link status and summary API contracts remain unchanged.

--- a/docs/specs/20260604-issue-244-portal-link-duration/tasks.md
+++ b/docs/specs/20260604-issue-244-portal-link-duration/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## Checklist
+
+- [x] Add failing tests for duration response states.
+- [x] Add failing tests for server-side terminal timestamp recording.
+- [x] Add Flyway migration for `link_started_at` and `link_ended_at`.
+- [x] Extend `ScrapeJob` duration fields and transition methods.
+- [x] Add duration query service/controller/DTO.
+- [x] Update OpenAPI docs and static spec.
+- [x] Run focused tests.
+- [x] Run `./gradlew test`.
+
+## Verification Log
+
+| # | Command | Result | Date |
+|---|---|---|---|
+| 1 | `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLinkJobQueryServiceUnitTests --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.application.portal.PortalLinkJobTxServiceUnitTests --rerun-tasks --console=plain` | Failed as expected. Missing duration DTO/service/entity APIs. | 2026-06-04 |
+| 2 | `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLinkJobQueryServiceUnitTests --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.application.portal.PortalLinkJobTxServiceUnitTests --rerun-tasks --console=plain` | Passed. | 2026-06-04 |
+| 3 | `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLinkJobQueryServiceUnitTests --tests com.chukchuk.haksa.domain.portal.controller.PortalJobQueryControllerApiIntegrationTest --tests com.chukchuk.haksa.application.portal.PortalLinkJobTxServiceUnitTests --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest --tests com.chukchuk.haksa.global.config.OpenApiResponseContractTest --rerun-tasks --console=plain` | Passed. | 2026-06-04 |
+| 4 | `./gradlew test --tests com.chukchuk.haksa.application.portal.ScrapeResultCallbackServiceUnitTests --rerun-tasks --console=plain` | Passed. | 2026-06-04 |
+| 5 | `./gradlew test --console=plain` | Failed. `FlywayMigrationTest` still expected migrations V1-V3 only. | 2026-06-04 |
+| 6 | `./gradlew test --tests com.chukchuk.haksa.global.db.FlywayMigrationTest --rerun-tasks --console=plain` | Failed. H2 did not accept multi-column `ALTER TABLE ... ADD COLUMN`. | 2026-06-04 |
+| 7 | `./gradlew test --tests com.chukchuk.haksa.global.db.FlywayMigrationTest --rerun-tasks --console=plain` | Passed. | 2026-06-04 |
+| 8 | `./gradlew test --console=plain` | Passed. | 2026-06-04 |
+| 9 | `./gradlew test --console=plain` | Passed after migration backfill edge-case hardening. | 2026-06-04 |

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -66,6 +67,35 @@ public class PortalLinkJobQueryService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public PortalLinkDto.JobDurationResponse getJobDuration(UUID userId, String jobId) {
+        ScrapeJob job = findOwnedJob(userId, jobId);
+
+        if (!job.isCompleted()) {
+            return new PortalLinkDto.JobDurationResponse(
+                    job.getJobId(),
+                    "pending",
+                    null,
+                    job.getLinkStartedAt(),
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        boolean succeeded = job.getStatus() == ScrapeJobStatus.SUCCEEDED;
+        long elapsedMillis = Duration.between(job.getLinkStartedAt(), job.getLinkEndedAt()).toMillis();
+        return new PortalLinkDto.JobDurationResponse(
+                job.getJobId(),
+                job.getStatus().name().toLowerCase(Locale.ROOT),
+                succeeded,
+                job.getLinkStartedAt(),
+                job.getLinkEndedAt(),
+                elapsedMillis,
+                formatElapsedTime(elapsedMillis)
+        );
+    }
+
     private ScrapeJob findOwnedJob(UUID userId, String jobId) {
         return scrapeJobRepository.findByJobIdAndUserId(jobId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SCRAPE_JOB_NOT_FOUND));
@@ -106,5 +136,11 @@ public class PortalLinkJobQueryService {
 
     private static String defaultString(String value) {
         return value != null ? value : "";
+    }
+
+    private static String formatElapsedTime(long elapsedMillis) {
+        long seconds = elapsedMillis / 1_000;
+        long millis = elapsedMillis % 1_000;
+        return seconds + "s " + millis + "ms";
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -84,15 +85,17 @@ public class PortalLinkJobQueryService {
         }
 
         boolean succeeded = job.getStatus() == ScrapeJobStatus.SUCCEEDED;
-        long elapsedMillis = Duration.between(job.getLinkStartedAt(), job.getLinkEndedAt()).toMillis();
+        Instant startedAt = job.getLinkStartedAt();
+        Instant endedAt = job.getLinkEndedAt();
+        Long elapsedMillis = calculateElapsedMillis(startedAt, endedAt);
         return new PortalLinkDto.JobDurationResponse(
                 job.getJobId(),
                 job.getStatus().name().toLowerCase(Locale.ROOT),
                 succeeded,
-                job.getLinkStartedAt(),
-                job.getLinkEndedAt(),
+                startedAt,
+                endedAt,
                 elapsedMillis,
-                formatElapsedTime(elapsedMillis)
+                elapsedMillis != null ? formatElapsedTime(elapsedMillis) : null
         );
     }
 
@@ -142,5 +145,12 @@ public class PortalLinkJobQueryService {
         long seconds = elapsedMillis / 1_000;
         long millis = elapsedMillis % 1_000;
         return seconds + "s " + millis + "ms";
+    }
+
+    private static Long calculateElapsedMillis(Instant startedAt, Instant endedAt) {
+        if (startedAt == null || endedAt == null) {
+            return null;
+        }
+        return Math.max(0L, Duration.between(startedAt, endedAt).toMillis());
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxService.java
@@ -93,7 +93,8 @@ public class PortalLinkJobTxService {
                 operationType,
                 idempotencyKey,
                 requestFingerprint,
-                requestPayloadJson
+                requestPayloadJson,
+                requestedAt
         ));
         ScrapeJobOutbox savedOutbox = scrapeJobOutboxRepository.save(
                 ScrapeJobOutbox.createPending(

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatchTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobOutboxDispatchTxService.java
@@ -109,6 +109,7 @@ public class ScrapeJobOutboxDispatchTxService {
                         ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED.name(),
                         ErrorCode.SCRAPE_JOB_OUTBOX_DEAD.message(),
                         true,
+                        attemptedAt,
                         attemptedAt
                 );
             }

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -52,6 +52,18 @@ public class ScrapeJobStaleReconciler {
                 continue;
             }
 
+            job.markFailed(
+                    ErrorCode.CALLBACK_TIMEOUT.name(),
+                    ErrorCode.CALLBACK_TIMEOUT.message(),
+                    true,
+                    now,
+                    now
+            );
+            meterRegistry.counter("scrape.job.callback.timeout").increment();
+            recordQueuedAge(job, now);
+            affectedCount++;
+            log.warn("[BIZ] scrape.job.callback.timeout jobId={} outboxId={} attempt={} outboxStatus={} queueMessageId={}",
+                    job.getJobId(), outbox.getOutboxId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
             try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(contextFor(job, outbox))) {
                 job.markFailed(
                         ErrorCode.CALLBACK_TIMEOUT.name(),

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeJobStaleReconciler.java
@@ -52,23 +52,12 @@ public class ScrapeJobStaleReconciler {
                 continue;
             }
 
-            job.markFailed(
-                    ErrorCode.CALLBACK_TIMEOUT.name(),
-                    ErrorCode.CALLBACK_TIMEOUT.message(),
-                    true,
-                    now,
-                    now
-            );
-            meterRegistry.counter("scrape.job.callback.timeout").increment();
-            recordQueuedAge(job, now);
-            affectedCount++;
-            log.warn("[BIZ] scrape.job.callback.timeout jobId={} outboxId={} attempt={} outboxStatus={} queueMessageId={}",
-                    job.getJobId(), outbox.getOutboxId(), outbox.getAttemptCount(), outbox.getStatus(), outbox.getQueueMessageId());
             try (SentryMdcContext.MdcScope ignored = SentryMdcContext.open(contextFor(job, outbox))) {
                 job.markFailed(
                         ErrorCode.CALLBACK_TIMEOUT.name(),
                         ErrorCode.CALLBACK_TIMEOUT.message(),
                         true,
+                        now,
                         now
                 );
                 meterRegistry.counter("scrape.job.callback.timeout").increment();

--- a/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackTxService.java
@@ -68,7 +68,8 @@ public class ScrapeResultCallbackTxService {
                 errorCode,
                 errorMessage,
                 retryable,
-                finishedAt
+                finishedAt,
+                Instant.now()
         );
         recordQueuedAge(job, finishedAt);
         return CallbackReceipt.accepted(job);
@@ -96,7 +97,7 @@ public class ScrapeResultCallbackTxService {
         }
 
         Instant resolvedFinishedAt = resolveFinishedAt(finishedAt);
-        job.markSucceeded(payloadJson, resolvedFinishedAt);
+        job.markSucceeded(payloadJson, resolvedFinishedAt, Instant.now());
         recordQueuedAge(job, finishedAt, queuedAgeSeconds);
         log.info("[BIZ] scrape.job.succeeded jobId={} operationType={} payloadHash={} finishedAt={}",
                 job.getJobId(), job.getOperationType(), payloadHash, resolvedFinishedAt);
@@ -117,7 +118,7 @@ public class ScrapeResultCallbackTxService {
                     job.getJobId(), job.getStatus(), errorCode);
             return;
         }
-        job.markFailed(errorCode, message, retryable, resolveFinishedAt(finishedAt));
+        job.markFailed(errorCode, message, retryable, resolveFinishedAt(finishedAt), Instant.now());
         recordQueuedAge(job, finishedAt, queuedAgeSeconds);
     }
 

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryController.java
@@ -37,4 +37,13 @@ public class PortalJobQueryController implements PortalLinkQueryControllerDocs {
         PortalLinkDto.JobSummaryResponse response = portalLinkJobQueryService.getJobSummary(userDetails.getId(), jobId);
         return ResponseEntity.ok(SuccessResponse.of(response));
     }
+
+    @GetMapping("/{jobId}/duration")
+    public ResponseEntity<SuccessResponse<PortalLinkDto.JobDurationResponse>> getJobDuration(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String jobId
+    ) {
+        PortalLinkDto.JobDurationResponse response = portalLinkJobQueryService.getJobDuration(userDetails.getId(), jobId);
+        return ResponseEntity.ok(SuccessResponse.of(response));
+    }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLinkQueryControllerDocs.java
@@ -1,6 +1,7 @@
 package com.chukchuk.haksa.domain.portal.controller.docs;
 
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkJobDurationApiResponse;
 import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkJobStatusApiResponse;
 import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkJobSummaryApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
@@ -52,6 +53,24 @@ public interface PortalLinkQueryControllerDocs {
     )
     @SecurityRequirement(name = "bearerAuth")
     ResponseEntity<SuccessResponse<PortalLinkDto.JobSummaryResponse>> getJobSummary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable String jobId
+    );
+
+    @Operation(
+            summary = "비동기 job 소요 시간 조회",
+            description = "요청된 job_id의 서버 기준 연동 시작/종료 시각과 소요 시간을 제공합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "소요 시간 조회 성공",
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = PortalLinkJobDurationApiResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "job 미존재 또는 권한 없음",
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ErrorResponseWrapper.class)))
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    ResponseEntity<SuccessResponse<PortalLinkDto.JobDurationResponse>> getJobDuration(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable String jobId
     );

--- a/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
@@ -66,6 +66,22 @@ public class PortalLinkDto {
             Instant finished_at
     ) {}
 
+    @Schema(description = "스크래핑 job 소요 시간 응답")
+    public record JobDurationResponse(
+            @JsonProperty("job_id")
+            String job_id,
+            String status,
+            Boolean success,
+            @JsonProperty("started_at")
+            Instant started_at,
+            @JsonProperty("ended_at")
+            Instant ended_at,
+            @JsonProperty("elapsed_millis")
+            Long elapsed_millis,
+            @JsonProperty("elapsed_time")
+            String elapsed_time
+    ) {}
+
     @Schema(description = "포털 학생 요약 정보")
     public record StudentInfoSummary(
             String name,

--- a/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobDurationApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLinkJobDurationApiResponse.java
@@ -1,0 +1,24 @@
+// 포털 링크 job 소요 시간 조회 성공 응답의 Swagger 문서용 래퍼
+package com.chukchuk.haksa.domain.portal.wrapper;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(name = "PortalLinkJobDurationApiResponse", description = "포털 링크 job 소요 시간 조회 응답")
+public class PortalLinkJobDurationApiResponse extends SuccessResponse<PortalLinkDto.JobDurationResponse> {
+
+    public PortalLinkJobDurationApiResponse() {
+        super(new PortalLinkDto.JobDurationResponse(
+                "job-123",
+                "succeeded",
+                true,
+                Instant.parse("2026-06-04T10:00:00Z"),
+                Instant.parse("2026-06-04T10:00:12.345Z"),
+                12_345L,
+                "12s 345ms"
+        ), "요청 성공");
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
+++ b/src/main/java/com/chukchuk/haksa/domain/scrapejob/model/ScrapeJob.java
@@ -87,6 +87,12 @@ public class ScrapeJob extends BaseEntity {
     @Column(name = "finished_at")
     private Instant finishedAt;
 
+    @Column(name = "link_started_at", nullable = false, updatable = false)
+    private Instant linkStartedAt;
+
+    @Column(name = "link_ended_at")
+    private Instant linkEndedAt;
+
     private ScrapeJob(
             String jobId,
             UUID userId,
@@ -95,7 +101,8 @@ public class ScrapeJob extends BaseEntity {
             String idempotencyKey,
             String requestFingerprint,
             ScrapeJobStatus status,
-            String requestPayloadJson
+            String requestPayloadJson,
+            Instant linkStartedAt
     ) {
         this.jobId = jobId;
         this.userId = userId;
@@ -105,6 +112,7 @@ public class ScrapeJob extends BaseEntity {
         this.requestFingerprint = requestFingerprint;
         this.status = status;
         this.requestPayloadJson = requestPayloadJson;
+        this.linkStartedAt = linkStartedAt;
     }
 
     public static ScrapeJob createQueued(
@@ -115,6 +123,26 @@ public class ScrapeJob extends BaseEntity {
             String requestFingerprint,
             String requestPayloadJson
     ) {
+        return createQueued(
+                userId,
+                portalType,
+                operationType,
+                idempotencyKey,
+                requestFingerprint,
+                requestPayloadJson,
+                Instant.now()
+        );
+    }
+
+    public static ScrapeJob createQueued(
+            UUID userId,
+            String portalType,
+            ScrapeJobOperationType operationType,
+            String idempotencyKey,
+            String requestFingerprint,
+            String requestPayloadJson,
+            Instant linkStartedAt
+    ) {
         return new ScrapeJob(
                 UUID.randomUUID().toString(),
                 userId,
@@ -123,7 +151,8 @@ public class ScrapeJob extends BaseEntity {
                 idempotencyKey,
                 requestFingerprint,
                 ScrapeJobStatus.QUEUED,
-                requestPayloadJson
+                requestPayloadJson,
+                linkStartedAt
         );
     }
 
@@ -167,8 +196,13 @@ public class ScrapeJob extends BaseEntity {
     }
 
     public void markSucceeded(String resultPayloadJson, Instant finishedAt) {
+        markSucceeded(resultPayloadJson, finishedAt, Instant.now());
+    }
+
+    public void markSucceeded(String resultPayloadJson, Instant finishedAt, Instant linkEndedAt) {
         recordWorkerResult(resultPayloadJson, finishedAt);
         this.status = ScrapeJobStatus.SUCCEEDED;
+        this.linkEndedAt = linkEndedAt;
     }
 
     public void recordWorkerResult(String resultPayloadJson, Instant finishedAt) {
@@ -198,16 +232,34 @@ public class ScrapeJob extends BaseEntity {
             Boolean retryable,
             Instant finishedAt
     ) {
+        recordFailedCallback(attempt, receivedAt, callbackMetadataJson, errorCode, errorMessage, retryable, finishedAt, Instant.now());
+    }
+
+    public void recordFailedCallback(
+            int attempt,
+            Instant receivedAt,
+            String callbackMetadataJson,
+            String errorCode,
+            String errorMessage,
+            Boolean retryable,
+            Instant finishedAt,
+            Instant linkEndedAt
+    ) {
         recordCallbackAttempt(attempt, receivedAt);
         this.callbackMetadataJson = callbackMetadataJson;
-        markFailed(errorCode, errorMessage, retryable, finishedAt);
+        markFailed(errorCode, errorMessage, retryable, finishedAt, linkEndedAt);
     }
 
     public void markFailed(String errorCode, String errorMessage, Boolean retryable, Instant finishedAt) {
+        markFailed(errorCode, errorMessage, retryable, finishedAt, Instant.now());
+    }
+
+    public void markFailed(String errorCode, String errorMessage, Boolean retryable, Instant finishedAt, Instant linkEndedAt) {
         this.status = ScrapeJobStatus.FAILED;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.retryable = retryable;
         this.finishedAt = finishedAt;
+        this.linkEndedAt = linkEndedAt;
     }
 }

--- a/src/main/resources/db/migration/V4__add_portal_link_duration_columns.sql
+++ b/src/main/resources/db/migration/V4__add_portal_link_duration_columns.sql
@@ -1,0 +1,17 @@
+ALTER TABLE public.scrape_jobs
+    ADD COLUMN link_started_at TIMESTAMP WITH TIME ZONE NULL;
+
+ALTER TABLE public.scrape_jobs
+    ADD COLUMN link_ended_at TIMESTAMP WITH TIME ZONE NULL;
+
+UPDATE public.scrape_jobs
+SET link_started_at = COALESCE(created_at, NOW())
+WHERE link_started_at IS NULL;
+
+UPDATE public.scrape_jobs
+SET link_ended_at = COALESCE(finished_at, updated_at, link_started_at)
+WHERE status IN ('SUCCEEDED', 'FAILED')
+  AND link_ended_at IS NULL;
+
+ALTER TABLE public.scrape_jobs
+    ALTER COLUMN link_started_at SET NOT NULL;

--- a/src/main/resources/public/openapi.yaml
+++ b/src/main/resources/public/openapi.yaml
@@ -181,6 +181,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorDetail'
+
+  /portal/link/jobs/{jobId}/duration:
+    get:
+      tags:
+        - Portal Link
+      summary: 비동기 job 소요 시간 조회
+      description: 요청된 job_id의 서버 기준 연동 시작/종료 시각과 소요 시간을 제공합니다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 소요 시간 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortalLinkJobDurationApiResponse'
+        '401':
+          description: 인증 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+        '404':
+          description: job 미존재 또는 권한 없음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
 components:
   securitySchemes:
     bearerAuth:
@@ -301,6 +335,58 @@ components:
           type: boolean
           description: 포털 연동 여부
           example: true
+
+    PortalLinkJobDurationApiResponse:
+      type: object
+      required:
+        - success
+        - data
+        - message
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/JobDurationResponse'
+        message:
+          type: string
+          example: 요청 성공
+
+    JobDurationResponse:
+      type: object
+      properties:
+        job_id:
+          type: string
+          example: job-123
+        status:
+          type: string
+          enum:
+            - pending
+            - succeeded
+            - failed
+          example: succeeded
+        success:
+          type: boolean
+          nullable: true
+          example: true
+        started_at:
+          type: string
+          format: date-time
+          example: '2026-06-04T10:00:00Z'
+        ended_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2026-06-04T10:00:12.345Z'
+        elapsed_millis:
+          type: integer
+          format: int64
+          nullable: true
+          example: 12345
+        elapsed_time:
+          type: string
+          nullable: true
+          example: 12s 345ms
 
     GraduationProgressApiResponse:
       type: object

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryServiceUnitTests.java
@@ -88,6 +88,96 @@ class PortalLinkJobQueryServiceUnitTests {
     }
 
     @Test
+    @DisplayName("미완료 job duration은 pending 상태와 null 소요 시간을 반환한다")
+    void getJobDuration_returnsPendingWhenJobIsNotTerminal() {
+        UUID userId = UUID.randomUUID();
+        Instant startedAt = Instant.parse("2026-06-04T10:00:00Z");
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "finger",
+                "{\"username\":\"17019013\"}",
+                startedAt
+        );
+        when(scrapeJobRepository.findByJobIdAndUserId(eq(job.getJobId()), eq(userId))).thenReturn(Optional.of(job));
+
+        PortalLinkJobQueryService service = new PortalLinkJobQueryService(scrapeJobRepository, studentService);
+
+        PortalLinkDto.JobDurationResponse response = service.getJobDuration(userId, job.getJobId());
+
+        assertThat(response.job_id()).isEqualTo(job.getJobId());
+        assertThat(response.status()).isEqualTo("pending");
+        assertThat(response.success()).isNull();
+        assertThat(response.started_at()).isEqualTo(startedAt);
+        assertThat(response.ended_at()).isNull();
+        assertThat(response.elapsed_millis()).isNull();
+        assertThat(response.elapsed_time()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공 job duration은 서버 종료 시각 기준 소요 시간을 반환한다")
+    void getJobDuration_returnsSucceededElapsedTime() {
+        UUID userId = UUID.randomUUID();
+        Instant startedAt = Instant.parse("2026-06-04T10:00:00Z");
+        Instant workerFinishedAt = Instant.parse("2026-06-04T09:59:30Z");
+        Instant serverEndedAt = Instant.parse("2026-06-04T10:00:12.345Z");
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "finger",
+                "{\"username\":\"17019013\"}",
+                startedAt
+        );
+        job.markSucceeded("{}", workerFinishedAt, serverEndedAt);
+        when(scrapeJobRepository.findByJobIdAndUserId(eq(job.getJobId()), eq(userId))).thenReturn(Optional.of(job));
+
+        PortalLinkJobQueryService service = new PortalLinkJobQueryService(scrapeJobRepository, studentService);
+
+        PortalLinkDto.JobDurationResponse response = service.getJobDuration(userId, job.getJobId());
+
+        assertThat(response.status()).isEqualTo("succeeded");
+        assertThat(response.success()).isTrue();
+        assertThat(response.started_at()).isEqualTo(startedAt);
+        assertThat(response.ended_at()).isEqualTo(serverEndedAt);
+        assertThat(response.elapsed_millis()).isEqualTo(12_345L);
+        assertThat(response.elapsed_time()).isEqualTo("12s 345ms");
+    }
+
+    @Test
+    @DisplayName("실패 job duration은 failed 상태와 실패 소요 시간을 반환한다")
+    void getJobDuration_returnsFailedElapsedTime() {
+        UUID userId = UUID.randomUUID();
+        Instant startedAt = Instant.parse("2026-06-04T10:00:00Z");
+        Instant workerFinishedAt = Instant.parse("2026-06-04T09:59:30Z");
+        Instant serverEndedAt = Instant.parse("2026-06-04T10:00:03.120Z");
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "finger",
+                "{\"username\":\"17019013\"}",
+                startedAt
+        );
+        job.markFailed("INVALID_PAYLOAD", "missing", false, workerFinishedAt, serverEndedAt);
+        when(scrapeJobRepository.findByJobIdAndUserId(eq(job.getJobId()), eq(userId))).thenReturn(Optional.of(job));
+
+        PortalLinkJobQueryService service = new PortalLinkJobQueryService(scrapeJobRepository, studentService);
+
+        PortalLinkDto.JobDurationResponse response = service.getJobDuration(userId, job.getJobId());
+
+        assertThat(response.status()).isEqualTo("failed");
+        assertThat(response.success()).isFalse();
+        assertThat(response.ended_at()).isEqualTo(serverEndedAt);
+        assertThat(response.elapsed_millis()).isEqualTo(3_120L);
+        assertThat(response.elapsed_time()).isEqualTo("3s 120ms");
+    }
+
+    @Test
     @DisplayName("실패 job 요약 요청 시 실패 상태 예외를 던진다")
     void getJobSummary_throwsWhenJobFailed() {
         UUID userId = UUID.randomUUID();

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobQueryServiceUnitTests.java
@@ -178,6 +178,64 @@ class PortalLinkJobQueryServiceUnitTests {
     }
 
     @Test
+    @DisplayName("완료 job duration timestamp가 일부 없으면 소요 시간은 null로 반환한다")
+    void getJobDuration_returnsNullElapsedTimeWhenTerminalTimestampMissing() {
+        UUID userId = UUID.randomUUID();
+        Instant workerFinishedAt = Instant.parse("2026-06-04T10:00:03.120Z");
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "finger",
+                "{\"username\":\"17019013\"}",
+                null
+        );
+        job.markFailed("INVALID_PAYLOAD", "missing", false, workerFinishedAt, null);
+        when(scrapeJobRepository.findByJobIdAndUserId(eq(job.getJobId()), eq(userId))).thenReturn(Optional.of(job));
+
+        PortalLinkJobQueryService service = new PortalLinkJobQueryService(scrapeJobRepository, studentService);
+
+        PortalLinkDto.JobDurationResponse response = service.getJobDuration(userId, job.getJobId());
+
+        assertThat(response.status()).isEqualTo("failed");
+        assertThat(response.success()).isFalse();
+        assertThat(response.started_at()).isNull();
+        assertThat(response.ended_at()).isNull();
+        assertThat(response.elapsed_millis()).isNull();
+        assertThat(response.elapsed_time()).isNull();
+    }
+
+    @Test
+    @DisplayName("종료 시각이 시작 시각보다 빠르면 duration은 0ms로 보정한다")
+    void getJobDuration_clampsNegativeElapsedTimeToZero() {
+        UUID userId = UUID.randomUUID();
+        Instant startedAt = Instant.parse("2026-06-04T10:00:00Z");
+        Instant workerFinishedAt = Instant.parse("2026-06-04T09:59:30Z");
+        Instant serverEndedAt = Instant.parse("2026-06-04T09:59:59.500Z");
+        ScrapeJob job = ScrapeJob.createQueued(
+                userId,
+                "suwon",
+                ScrapeJobOperationType.LINK,
+                "idem-1",
+                "finger",
+                "{\"username\":\"17019013\"}",
+                startedAt
+        );
+        job.markSucceeded("{}", workerFinishedAt, serverEndedAt);
+        when(scrapeJobRepository.findByJobIdAndUserId(eq(job.getJobId()), eq(userId))).thenReturn(Optional.of(job));
+
+        PortalLinkJobQueryService service = new PortalLinkJobQueryService(scrapeJobRepository, studentService);
+
+        PortalLinkDto.JobDurationResponse response = service.getJobDuration(userId, job.getJobId());
+
+        assertThat(response.status()).isEqualTo("succeeded");
+        assertThat(response.success()).isTrue();
+        assertThat(response.elapsed_millis()).isZero();
+        assertThat(response.elapsed_time()).isEqualTo("0s 0ms");
+    }
+
+    @Test
     @DisplayName("실패 job 요약 요청 시 실패 상태 예외를 던진다")
     void getJobSummary_throwsWhenJobFailed() {
         UUID userId = UUID.randomUUID();

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxServiceUnitTests.java
@@ -61,6 +61,10 @@ class PortalLinkJobTxServiceUnitTests {
 
         assertThat(preparedJob.reused()).isFalse();
         assertThat(preparedJob.dispatchRequired()).isTrue();
+        ArgumentCaptor<ScrapeJob> jobCaptor = ArgumentCaptor.forClass(ScrapeJob.class);
+        verify(scrapeJobRepository).save(jobCaptor.capture());
+        assertThat(jobCaptor.getValue().getLinkStartedAt()).isEqualTo(Instant.parse("2026-04-17T01:02:03Z"));
+        assertThat(jobCaptor.getValue().getLinkEndedAt()).isNull();
         ArgumentCaptor<ScrapeJobOutbox> captor = ArgumentCaptor.forClass(ScrapeJobOutbox.class);
         verify(scrapeJobOutboxRepository).save(captor.capture());
         JsonNode payload = new ObjectMapper().readTree(captor.getValue().getPayloadJson());

--- a/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/ScrapeResultCallbackServiceUnitTests.java
@@ -231,11 +231,15 @@ class ScrapeResultCallbackServiceUnitTests {
 
         when(scrapeJobRepository.findForUpdateByJobId(job.getJobId())).thenReturn(Optional.of(job));
 
+        Instant beforeHandle = Instant.now();
         service.handleCallback(rawBody, timestamp, sign(timestamp, rawBody), null, null);
 
         assertThat(job.getStatus().name()).isEqualTo("FAILED");
         assertThat(job.getErrorCode()).isEqualTo("PORTAL_AUTH_FAILED");
         assertThat(job.getRetryable()).isFalse();
+        assertThat(job.getFinishedAt()).isEqualTo(Instant.parse("2026-03-14T10:01:00Z"));
+        assertThat(job.getLinkEndedAt()).isAfterOrEqualTo(beforeHandle);
+        assertThat(job.getLinkEndedAt()).isNotEqualTo(job.getFinishedAt());
         verify(resultStoreClient, never()).fetch(any());
     }
 
@@ -389,6 +393,7 @@ class ScrapeResultCallbackServiceUnitTests {
         assertThat(job.getStatus()).isEqualTo(ScrapeJobStatus.FAILED);
         assertThat(job.getErrorCode()).isEqualTo("FAILED_RESULT_SCHEMA");
         assertThat(job.getRetryable()).isFalse();
+        assertThat(job.getLinkEndedAt()).isNotNull();
         verify(portalSyncService, never()).syncWithPortal(any(), any());
     }
 

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryControllerApiIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalJobQueryControllerApiIntegrationTest.java
@@ -97,4 +97,29 @@ class PortalJobQueryControllerApiIntegrationTest extends ApiControllerWebMvcTest
                 .andExpect(jsonPath("$.data.studentInfo.name").value("홍길동"))
                 .andExpect(jsonPath("$.data.studentInfo.majorName").value("소프트웨어학과"));
     }
+
+    @Test
+    @DisplayName("완료된 job duration 조회 시 소요 시간을 반환한다")
+    void getJobDuration_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        authenticate(userId);
+        when(portalLinkJobQueryService.getJobDuration(eq(userId), eq("job-4")))
+                .thenReturn(new PortalLinkDto.JobDurationResponse(
+                        "job-4",
+                        "succeeded",
+                        true,
+                        Instant.parse("2026-06-04T10:00:00Z"),
+                        Instant.parse("2026-06-04T10:00:12.345Z"),
+                        12_345L,
+                        "12s 345ms"
+                ));
+
+        mockMvc.perform(get("/portal/link/jobs/job-4/duration"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.job_id").value("job-4"))
+                .andExpect(jsonPath("$.data.status").value("succeeded"))
+                .andExpect(jsonPath("$.data.success").value(true))
+                .andExpect(jsonPath("$.data.elapsed_millis").value(12_345))
+                .andExpect(jsonPath("$.data.elapsed_time").value("12s 345ms"));
+    }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
@@ -55,6 +55,14 @@ class PortalLinkOpenApiTest {
                 "PortalLinkJobSummaryApiResponse",
                 "JobSummaryResponse"
         );
+        assertSuccessResponseSchema(
+                apiDocs,
+                "/portal/link/jobs/{jobId}/duration",
+                "get",
+                "200",
+                "PortalLinkJobDurationApiResponse",
+                "JobDurationResponse"
+        );
     }
 
     private JsonNode apiDocs() throws Exception {

--- a/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
@@ -40,6 +40,7 @@ class OpenApiResponseContractTest {
             new OperationRef("/portal/link", "post"),
             new OperationRef("/portal/link/jobs/{jobId}", "get"),
             new OperationRef("/portal/link/jobs/{jobId}/summary", "get"),
+            new OperationRef("/portal/link/jobs/{jobId}/duration", "get"),
             new OperationRef("/api/users/analytics-id", "get"),
             new OperationRef("/api/users/me", "get"),
             new OperationRef("/api/users/delete", "delete"),

--- a/src/test/java/com/chukchuk/haksa/global/db/FlywayMigrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/db/FlywayMigrationTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FlywayMigrationTest {
 
     @Test
-    void freshDatabaseMigratesFromV1ToV3() throws Exception {
+    void freshDatabaseMigratesFromV1ToV4() throws Exception {
         String dbName = "flyway-migration-" + UUID.randomUUID();
         String url = "jdbc:h2:mem:" + dbName + ";MODE=PostgreSQL;DATABASE_TO_UPPER=false;NON_KEYWORDS=YEAR;"
                 + "DB_CLOSE_DELAY=-1;"
@@ -30,6 +30,8 @@ class FlywayMigrationTest {
 
         try (var connection = DriverManager.getConnection(url, "sa", "")) {
             assertThat(hasColumn(connection, "raw_faculty_division_name")).isFalse();
+            assertThat(hasColumn(connection, "scrape_jobs", "link_started_at")).isFalse();
+            assertThat(hasColumn(connection, "scrape_jobs", "link_ended_at")).isFalse();
             assertThat(hasTable(connection, "language_cert_policy_groups")).isFalse();
         }
 
@@ -46,7 +48,8 @@ class FlywayMigrationTest {
                 .containsExactly(
                         MigrationVersion.fromVersion("1"),
                         MigrationVersion.fromVersion("2"),
-                        MigrationVersion.fromVersion("3")
+                        MigrationVersion.fromVersion("3"),
+                        MigrationVersion.fromVersion("4")
                 );
 
         try (var connection = DriverManager.getConnection(url, "sa", "")) {
@@ -55,11 +58,17 @@ class FlywayMigrationTest {
             assertThat(hasTable(connection, "language_cert_policy_groups")).isTrue();
             assertThat(hasTable(connection, "language_cert_requirements")).isTrue();
             assertThat(hasTable(connection, "department_language_cert_policy_mappings")).isTrue();
+            assertThat(hasColumn(connection, "scrape_jobs", "link_started_at")).isTrue();
+            assertThat(hasColumn(connection, "scrape_jobs", "link_ended_at")).isTrue();
         }
     }
 
     private boolean hasColumn(Connection connection, String columnName) throws Exception {
-        try (var columns = connection.getMetaData().getColumns(null, "public", "course_offerings", columnName)) {
+        return hasColumn(connection, "course_offerings", columnName);
+    }
+
+    private boolean hasColumn(Connection connection, String tableName, String columnName) throws Exception {
+        try (var columns = connection.getMetaData().getColumns(null, "public", tableName, columnName)) {
             return columns.next();
         }
     }


### PR DESCRIPTION
## 작업 내용

- `GET /portal/link/jobs/{jobId}/duration` API 추가
- `scrape_jobs`에 서버 기준 `link_started_at`, `link_ended_at` 컬럼 추가
- `pending`, `succeeded`, `failed` duration 응답 계약 추가
- OpenAPI 문서와 관련 controller/service 테스트 갱신

## 구현 선택

- AOP는 적용하지 않음
- 종료 시각은 `SUCCEEDED`/`FAILED` 상태 전이와 같은 트랜잭션에서 기록
- 기존 `finished_at`은 유지하고 duration API는 새 서버 기준 컬럼만 사용

## 검증

- `./gradlew test --console=plain`

## 참고

- Closes #244
