### PR TITLE
261 fix: 유효하지 않은 토큰 401 응답 처리

### DIFF
--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/checklist.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/checklist.md
@@ -1,0 +1,11 @@
+# Checklist
+
+- [x] 이슈 번호 261 기준 `feat/261` 브랜치 생성.
+- [x] Standard Spec Bundle 생성.
+- [x] JWT 필터 인증 실패 회귀 테스트 추가.
+- [x] 회귀 테스트 RED 확인.
+- [x] `JwtAuthenticationFilter`에서 invalid token을 401 entry point로 정리.
+- [x] targeted test GREEN 확인.
+- [x] 관련 테스트와 전체 테스트 실행.
+- [x] 테스트 결과를 `tasks.md`에 기록.
+- [x] 변경사항 커밋.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/clarify.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/clarify.md
@@ -1,0 +1,24 @@
+# Clarify
+
+## Open Questions
+| # | Question | Owner | Status |
+|---|----------|-------|--------|
+| 1 | 탈퇴/삭제 사용자 토큰을 어떤 에러 코드로 반환할 것인가. | User/Codex | Resolved |
+
+## Decisions
+| # | Decision | Reason | Date |
+|---|----------|--------|------|
+| 1 | invalid access token 계열은 secure endpoint에서 401로 반환한다. | 인증 정보가 유효하지 않은 상황이며 502는 gateway/upstream 실패 의미라 부적절하다. | 2026-06-14 |
+| 2 | 탈퇴/삭제 사용자 토큰은 401 `TOKEN_INVALID`로 처리한다. | 인증 필터에서 principal 로딩에 실패한 케이스이므로 리소스 조회 404가 아니라 인증 실패로 보는 것이 일관적이다. | 2026-06-14 |
+| 3 | 컨트롤러 테스트 대신 JWT 필터 또는 security chain 테스트로 회귀를 고정한다. | 기존 컨트롤러 테스트는 `addFilters = false`라 증상을 포착하지 못한다. | 2026-06-14 |
+
+## Risks / Unknowns
+- Item: 운영 502가 API 서버 500을 gateway가 502로 변환한 것인지 직접 로그는 아직 없다.
+  - Impact: 로컬 테스트에서는 status가 500으로 보일 수 있으나, 근본은 필터 밖으로 인증 예외가 새는 것이다.
+  - Mitigation: 필터 단위 테스트에서 응답 status/body가 401로 직접 작성되는지 검증한다.
+- Item: `origin/dev` 기준 컨트롤러와 DTO가 로컬 `dev`보다 최신이다.
+  - Impact: 작업 기준이 `origin/dev`여야 `/api/users/me`를 포함한 실제 대상과 맞는다.
+  - Mitigation: `feat/261`을 `origin/dev`에서 생성했다.
+
+## Follow-ups
+- [ ] 운영 배포 후 gateway 5xx 지표에서 invalid token 케이스가 사라지는지 확인한다. (Owner)

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/context-notes.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/context-notes.md
@@ -1,0 +1,10 @@
+# Context Notes
+
+## 2026-06-14
+
+- 사용자는 이슈 번호 261을 제공했고 즉시 작업 시작을 지시했다.
+- 현재 작업 브랜치는 `feat/261`이다.
+- 기존 워크트리에는 사용자 변경으로 보이는 `.codex/config.toml` 수정과 `docs/lambda-migration-backend-lessons.md` 미추적 파일이 있었다. 이번 작업에서는 건드리지 않는다.
+- 로컬 `dev`는 `origin/dev`보다 뒤처져 있었고, `GET /api/users/me`는 `origin/dev` 기준 코드에 존재한다. 작업 브랜치는 `origin/dev` 기반으로 생성했다.
+- 원인 가설은 `JwtAuthenticationFilter`에서 인증 실패 예외가 `CustomAuthenticationEntryPoint`의 401 응답 작성으로 정리되지 않고 필터 밖으로 새는 것이다.
+- 탈퇴/삭제 사용자 토큰은 컨트롤러 이후의 리소스 조회 실패가 아니라 인증 단계의 principal 로딩 실패이므로 401 `TOKEN_INVALID`로 처리한다.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/context-notes.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/context-notes.md
@@ -8,3 +8,9 @@
 - 로컬 `dev`는 `origin/dev`보다 뒤처져 있었고, `GET /api/users/me`는 `origin/dev` 기준 코드에 존재한다. 작업 브랜치는 `origin/dev` 기반으로 생성했다.
 - 원인 가설은 `JwtAuthenticationFilter`에서 인증 실패 예외가 `CustomAuthenticationEntryPoint`의 401 응답 작성으로 정리되지 않고 필터 밖으로 새는 것이다.
 - 탈퇴/삭제 사용자 토큰은 컨트롤러 이후의 리소스 조회 실패가 아니라 인증 단계의 principal 로딩 실패이므로 401 `TOKEN_INVALID`로 처리한다.
+
+## 2026-06-15
+
+- PR #262 리뷰에서 JWT subject가 없을 때 `NullPointerException`이 필터 밖으로 새어 다시 500/502가 될 수 있다는 지적이 있었다.
+- `NullPointerException` catch 추가보다 subject 값을 명시적으로 검증하고 `JwtException`으로 invalid token 처리하는 쪽이 더 좁고 명확하다.
+- subject 누락 access token은 401 `TOKEN_INVALID`로 처리한다.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/plan.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/plan.md
@@ -1,0 +1,36 @@
+# Plan
+
+## Architecture / Layering
+- Domain impact: 없음.
+- Application orchestration: 없음.
+- Infrastructure touchpoints: 없음.
+- Global/config changes:
+  - `JwtAuthenticationFilter`에서 JWT 파싱 실패, 사용자 로딩 실패를 `AuthenticationEntryPoint`로 정리한다.
+  - `SecurityContextHolder`는 인증 실패 시 명시적으로 비운다.
+  - 기존 `CustomAuthenticationEntryPoint` 응답 포맷과 에러 코드를 재사용한다.
+
+## Data / Transactions
+- Repositories touched: 없음.
+- Transaction scope: 없음.
+- Consistency expectations:
+  - invalid token 요청 후 SecurityContext에 인증 객체가 남지 않는다.
+  - 인증 실패는 컨트롤러로 진행하지 않는다.
+
+## Testing Strategy
+- Domain tests: 없음.
+- Application tests: 없음.
+- Integration/API tests:
+  - `JwtAuthenticationFilter` 단위 테스트를 추가한다.
+  - 만료 토큰, invalid JWT, 사용자 없음 토큰이 각각 401로 응답되는지 검증한다.
+  - 사용자 없음 케이스는 loader가 `TokenException(USER_NOT_FOUND)`를 던지도록 구성한다.
+- Additional commands:
+  - `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests`
+  - `./gradlew test`
+
+## Rollout Considerations
+- Backward compatibility:
+  - 5xx로 새던 인증 실패를 401로 바로잡는 변경이다.
+  - JSON 에러 응답 포맷은 기존 `ErrorResponse`와 `CustomAuthenticationEntryPoint`를 유지한다.
+- Observability / metrics:
+  - invalid token 요청은 더 이상 서버 오류로 잡히지 않아야 한다.
+- Feature flags / toggles: 없음.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/spec.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/spec.md
@@ -1,0 +1,111 @@
+# Spec
+
+## 1. Feature Overview
+- Purpose: secure endpoint에서 유효하지 않은 access token 요청이 502로 새지 않고 401 인증 실패 응답으로 정리되도록 수정한다.
+- Scope
+  - In:
+    - `JwtAuthenticationFilter` 인증 실패 처리.
+    - 만료, 형식/서명 invalid, 탈퇴/삭제 사용자 토큰의 401 응답 회귀 테스트.
+    - 영향 endpoint: `GET /api/users/me`, `GET /api/student/profile` 포함 모든 secure endpoint.
+  - Out:
+    - 로그인, refresh token 정책 변경.
+    - 공개 API 응답 계약 변경.
+    - DB 스키마, 트랜잭션, 외부 API 변경.
+- Expected Impact:
+  - 클라이언트가 invalid access token을 받았을 때 502 서버 장애로 오인하지 않고 401 인증 실패로 처리할 수 있다.
+  - Gateway/ALB upstream 오류 의미를 갖는 502를 인증 실패 케이스에서 제거한다.
+- Stakeholder Confirmation:
+  - 2026-06-14 사용자 확인: GitHub issue 번호는 261이며 "바로 작업 시작해"라고 지시했다.
+  - 2026-06-14 사용자 확인: invalid token 케이스는 401로 던지는 것이 더 맞는지 확인했고, 401 처리 방향으로 진행한다.
+
+## 2. Domain Rules
+- Rule 1: access token이 만료되면 secure endpoint 인증 단계에서 `TOKEN_EXPIRED` 성격의 401을 반환한다.
+- Rule 2: access token 형식, 서명, 파싱이 유효하지 않으면 secure endpoint 인증 단계에서 `TOKEN_INVALID` 성격의 401을 반환한다.
+- Rule 3: 토큰 subject에 해당하는 사용자가 더 이상 존재하지 않으면 리소스 조회 실패가 아니라 인증 실패로 간주해 401을 반환한다.
+- Mutable Rules:
+  - 탈퇴/삭제 사용자 토큰의 상세 에러 코드는 `TOKEN_INVALID`로 통일할 수 있다.
+- Immutable Rules:
+  - secure endpoint는 유효한 인증 없이는 컨트롤러 로직에 진입하지 않는다.
+  - 인증 실패는 5xx 또는 gateway 오류로 반환하지 않는다.
+
+## 3. Use-case Scenarios
+### Normal Flow
+- Scenario Name: 유효한 access token으로 내 정보 조회.
+  - Trigger: `GET /api/users/me` 또는 `GET /api/student/profile`.
+  - Actor: 로그인 사용자.
+  - Steps:
+    - 클라이언트가 `Authorization: Bearer <valid acToken>`을 보낸다.
+    - JWT 필터가 토큰을 파싱하고 사용자 정보를 로드한다.
+    - 컨트롤러가 인증된 사용자 기준으로 응답을 반환한다.
+  - Expected Result: 기존 정상 응답을 유지한다.
+
+### Exception / Boundary Flow
+- Scenario Name: 만료된 access token.
+  - Condition: JWT expiration이 지난 access token으로 secure endpoint를 호출한다.
+  - Expected Behavior: 401과 `TOKEN_EXPIRED` 계열 에러 응답을 반환한다.
+- Scenario Name: 형식/서명이 유효하지 않은 access token.
+  - Condition: 파싱할 수 없거나 서명이 맞지 않는 access token으로 secure endpoint를 호출한다.
+  - Expected Behavior: 401과 `TOKEN_INVALID` 계열 에러 응답을 반환한다.
+- Scenario Name: 탈퇴/삭제 사용자 access token.
+  - Condition: JWT subject는 UUID 형식이지만 사용자 저장소에 해당 사용자가 없다.
+  - Expected Behavior: 401과 `TOKEN_INVALID` 계열 에러 응답을 반환한다.
+
+## 4. Transaction / Consistency
+- Transaction Start Point: 없음. 인증 필터 처리 범위다.
+- Transaction End Point: 없음.
+- Atomicity Scope: 인증 실패 시 `SecurityContextHolder`에 인증 상태가 남지 않아야 한다.
+- Eventual Consistency Allowed: 해당 없음.
+
+## 5. API List
+- Endpoint:
+  - Method: `GET`
+  - Request DTO: 없음.
+  - Response DTO: 기존 `ErrorResponse`.
+  - Authorization: Bearer access token 필요.
+  - Idempotency: 해당 없음.
+- Endpoint:
+  - Method: `GET /api/student/profile`
+  - Request DTO: 없음.
+  - Response DTO: 기존 `ErrorResponse`.
+  - Authorization: Bearer access token 필요.
+  - Idempotency: 해당 없음.
+
+## 6. Exception Policy
+- Error Code:
+  - Condition: access token 만료.
+  - Message Convention: 기존 `TOKEN_EXPIRED` 메시지 사용.
+  - Handling Layer: Global/Security.
+  - User Exposure: 401 JSON 에러 응답.
+- Error Code:
+  - Condition: access token invalid 또는 사용자 로딩 실패.
+  - Message Convention: 기존 `TOKEN_INVALID` 메시지 사용.
+  - Handling Layer: Global/Security.
+  - User Exposure: 401 JSON 에러 응답.
+
+## 7. Phase Checklist
+- [x] Phase 1 Spec fixed
+- [ ] Phase 2 Domain complete. 변경 없음.
+- [ ] Phase 3 Application complete. 변경 없음.
+- [ ] Phase 4 Infrastructure complete. 변경 없음.
+- [x] Phase 5 Global/Config complete
+- [x] Phase 6 API/Controller complete. 컨트롤러 변경 없음, security chain 테스트로 검증.
+
+## 8. Generated File List
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/spec.md`
+  - Description: issue 261 버그 수정 범위와 인증 실패 정책.
+  - Layer: Context.
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/clarify.md`
+  - Description: 확인된 결정과 리스크.
+  - Layer: Context.
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/plan.md`
+  - Description: global/security 변경 및 테스트 전략.
+  - Layer: Context.
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/tasks.md`
+  - Description: 실행 체크리스트와 테스트 로그.
+  - Layer: Context.
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/checklist.md`
+  - Description: 세부 작업 체크리스트.
+  - Layer: Context.
+- Path: `docs/specs/20260614-issue-261-secure-invalid-token-401/context-notes.md`
+  - Description: 작업 중 결정과 근거 기록.
+  - Layer: Context.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/tasks.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/tasks.md
@@ -19,8 +19,13 @@
 | 2 | `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests` | Passed. | 2026-06-14 |
 | 3 | `./gradlew test` | Passed. | 2026-06-14 |
 | 4 | `./gradlew build` | Passed. | 2026-06-14 |
+| 5 | `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests` | Failed as expected. Missing subject token raised `NullPointerException` before fix. | 2026-06-15 |
+| 6 | `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests` | Passed. | 2026-06-15 |
+| 7 | `./gradlew test` | Passed. | 2026-06-15 |
+| 8 | `./gradlew build` | Passed. | 2026-06-15 |
 
 ## Notes
 - Observation: 기존 컨트롤러 WebMvc 테스트는 `addFilters = false`라 JWT 인증 필터 실패를 검증하지 못한다.
 - Observation: `JwtAuthenticationFilter`는 `ExpiredJwtException`, `JwtException`, `IllegalStateException`만 잡고 `TokenException`은 잡지 않는다.
 - Observation: 필터에서 던진 인증 예외가 entry point 응답으로 정리되지 않으면 API 서버 500 또는 gateway 502로 관측될 수 있다.
+- Observation: subject가 없는 JWT도 invalid token으로 분류해 401 `TOKEN_INVALID`를 반환해야 한다.

--- a/docs/specs/20260614-issue-261-secure-invalid-token-401/tasks.md
+++ b/docs/specs/20260614-issue-261-secure-invalid-token-401/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## Checklist
+- [x] Phase 0 intent routing: `BUG_FIX.md`.
+- [x] Phase 1 Spec Bundle 생성.
+- [x] Clarify 결정 기록.
+- [x] Plan 작성.
+- [x] JWT 필터 회귀 테스트 작성.
+- [x] RED 테스트 실행 결과 기록.
+- [x] Global/security 수정.
+- [x] GREEN targeted test 실행 결과 기록.
+- [x] `./gradlew test` 실행 결과 기록.
+- [x] 커밋 생성.
+
+## Test / Build Log
+| Step | Command | Result | Date |
+|------|---------|--------|------|
+| 1 | `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests` | Failed as expected. 3 tests failed because authentication exceptions escaped the filter instead of returning 401. | 2026-06-14 |
+| 2 | `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests` | Passed. | 2026-06-14 |
+| 3 | `./gradlew test` | Passed. | 2026-06-14 |
+| 4 | `./gradlew build` | Passed. | 2026-06-14 |
+
+## Notes
+- Observation: 기존 컨트롤러 WebMvc 테스트는 `addFilters = false`라 JWT 인증 필터 실패를 검증하지 못한다.
+- Observation: `JwtAuthenticationFilter`는 `ExpiredJwtException`, `JwtException`, `IllegalStateException`만 잡고 `TokenException`은 잡지 않는다.
+- Observation: 필터에서 던진 인증 예외가 entry point 응답으로 정리되지 않으면 API 서버 500 또는 gateway 502로 관측될 수 있다.

--- a/src/main/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilter.java
@@ -59,6 +59,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             Claims claims = jwtProvider.parseToken(token);
             String userId = claims.getSubject();
+            if (userId == null || userId.isBlank()) {
+                throw new JwtException("Missing token subject");
+            }
 
             UserDetails userDetails = authTokenCache.getOrLoad(
                     userId,

--- a/src/main/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.chukchuk.haksa.global.security.filter;
 
+import com.chukchuk.haksa.global.exception.type.TokenException;
 import com.chukchuk.haksa.global.security.cache.AuthTokenCache;
 import com.chukchuk.haksa.global.security.service.CustomUserDetailsService;
 import com.chukchuk.haksa.global.security.service.JwtProvider;
@@ -16,6 +17,7 @@ import org.springframework.security.authentication.InsufficientAuthenticationExc
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -31,6 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService userDetailsService;
     private final AuthTokenCache authTokenCache;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
 
     private static final List<String> WHITELIST_PATHS = List.of(
             "/", "/v3/api-docs", "/swagger", "/webjars", "/swagger-config", "/error"
@@ -68,14 +71,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authToken);
 
         } catch (ExpiredJwtException e) {
-            request.setAttribute("exception", "expired");
-            throw new InsufficientAuthenticationException("Access token expired", e);
-        } catch (IllegalStateException | JwtException e) {
-            request.setAttribute("exception", "invalid");
-            throw new InsufficientAuthenticationException("Invalid token", e);
+            handleAuthenticationFailure(request, response, "expired",
+                    new InsufficientAuthenticationException("Access token expired", e));
+            return;
+        } catch (TokenException | IllegalArgumentException | IllegalStateException | JwtException e) {
+            handleAuthenticationFailure(request, response, "invalid",
+                    new InsufficientAuthenticationException("Invalid token", e));
+            return;
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void handleAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String exceptionType,
+            InsufficientAuthenticationException exception
+    ) throws IOException, ServletException {
+        SecurityContextHolder.clearContext();
+        request.setAttribute("exception", exceptionType);
+        authenticationEntryPoint.commence(request, response, exception);
     }
 
     private String extractTokenFromHeader(HttpServletRequest request) {

--- a/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
+++ b/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
@@ -130,6 +130,22 @@ class JwtAuthenticationFilterTests {
                 .andExpect(header().string("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"TOKEN_INVALID\""));
     }
 
+    @Test
+    @DisplayName("subject가 없는 acToken으로 /api/users/me 호출 시 401 TOKEN_INVALID를 반환한다")
+    void getMe_withMissingSubjectAccessToken_returns401() throws Exception {
+        String token = "missing-subject-access-token";
+        Claims claims = Jwts.claims();
+
+        when(jwtProvider.parseToken(token)).thenReturn(claims);
+
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.TOKEN_INVALID.code()))
+                .andExpect(header().string("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"TOKEN_INVALID\""));
+    }
+
     @TestConfiguration
     static class TestCorsConfig {
         @Bean("corsConfigurationSource")

--- a/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
+++ b/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
@@ -1,0 +1,147 @@
+// JWT 인증 필터의 invalid access token 401 응답을 검증하는 테스트
+package com.chukchuk.haksa.global.security.filter;
+
+import com.chukchuk.haksa.domain.student.controller.StudentController;
+import com.chukchuk.haksa.domain.student.service.StudentService;
+import com.chukchuk.haksa.domain.user.controller.UserController;
+import com.chukchuk.haksa.domain.user.service.UserService;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.TokenException;
+import com.chukchuk.haksa.global.security.SecurityConfig;
+import com.chukchuk.haksa.global.security.cache.AuthTokenCache;
+import com.chukchuk.haksa.global.security.handler.CustomAccessDeniedHandler;
+import com.chukchuk.haksa.global.security.handler.CustomAuthenticationEntryPoint;
+import com.chukchuk.haksa.global.security.service.CustomUserDetailsService;
+import com.chukchuk.haksa.global.security.service.JwtProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {UserController.class, StudentController.class})
+@AutoConfigureMockMvc(addFilters = true)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        CustomAuthenticationEntryPoint.class,
+        CustomAccessDeniedHandler.class,
+        JwtAuthenticationFilterTests.TestCorsConfig.class
+})
+class JwtAuthenticationFilterTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private CustomUserDetailsService userDetailsService;
+
+    @MockBean
+    private AuthTokenCache authTokenCache;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private StudentService studentService;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    @DisplayName("만료된 acToken으로 /api/users/me 호출 시 401 TOKEN_EXPIRED를 반환한다")
+    void getMe_withExpiredAccessToken_returns401() throws Exception {
+        String token = "expired-access-token";
+        when(jwtProvider.parseToken(token))
+                .thenThrow(new ExpiredJwtException(null, null, "expired"));
+
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.TOKEN_EXPIRED.code()))
+                .andExpect(header().string("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"TOKEN_EXPIRED\""));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 acToken으로 /api/student/profile 호출 시 401 TOKEN_INVALID를 반환한다")
+    void getStudentProfile_withInvalidAccessToken_returns401() throws Exception {
+        String token = "invalid-access-token";
+        when(jwtProvider.parseToken(token))
+                .thenThrow(new JwtException("invalid"));
+
+        mockMvc.perform(get("/api/student/profile")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.TOKEN_INVALID.code()))
+                .andExpect(header().string("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"TOKEN_INVALID\""));
+    }
+
+    @Test
+    @DisplayName("탈퇴 사용자 acToken으로 /api/users/me 호출 시 401 TOKEN_INVALID를 반환한다")
+    void getMe_withDeletedUserAccessToken_returns401() throws Exception {
+        String userId = UUID.randomUUID().toString();
+        String token = "deleted-user-access-token";
+        Claims claims = Jwts.claims().setSubject(userId);
+
+        when(jwtProvider.parseToken(token)).thenReturn(claims);
+        when(authTokenCache.getOrLoad(eq(userId), eq(token), any()))
+                .thenAnswer(invocation -> {
+                    Supplier<UserDetails> loader = invocation.getArgument(2);
+                    return loader.get();
+                });
+        when(userDetailsService.loadUserByUsername(userId))
+                .thenThrow(new TokenException(ErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value(ErrorCode.TOKEN_INVALID.code()))
+                .andExpect(header().string("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"TOKEN_INVALID\""));
+    }
+
+    @TestConfiguration
+    static class TestCorsConfig {
+        @Bean("corsConfigurationSource")
+        CorsConfigurationSource corsConfigurationSource() {
+            CorsConfiguration config = new CorsConfiguration();
+            config.addAllowedOriginPattern("*");
+            config.addAllowedMethod("*");
+            config.addAllowedHeader("*");
+
+            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+            source.registerCorsConfiguration("/**", config);
+            return source;
+        }
+    }
+}


### PR DESCRIPTION
## 개요

Closes #261

secure endpoint에서 유효하지 않은 access token 요청이 502로 새지 않고 401 인증 실패 응답으로 정리되도록 수정했습니다.

## 변경 사항

- `JwtAuthenticationFilter`에서 만료, invalid, 사용자 로딩 실패 토큰을 `AuthenticationEntryPoint`로 위임해 401 응답을 작성하도록 변경했습니다.
- 인증 실패 시 `SecurityContextHolder`를 명시적으로 비웁니다.
- `/api/users/me`, `/api/student/profile`에서 invalid token 회귀 케이스를 검증하는 security filter 테스트를 추가했습니다.
- issue 261 Spec Bundle을 `docs/specs/20260614-issue-261-secure-invalid-token-401/`에 기록했습니다.

## 원인

기존 필터는 만료/invalid JWT를 `InsufficientAuthenticationException`으로 다시 던지고, 탈퇴/삭제 사용자 토큰의 `TokenException`은 잡지 않아 필터 밖으로 예외가 전파될 수 있었습니다. 이 경우 Security의 401 entry point 응답 작성으로 정리되지 않고 서버 오류로 관측될 수 있었습니다.

## 검증

- `./gradlew test --tests com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests`
- `./gradlew test`
- `./gradlew build`