### PR TITLE
263 fix: 리프레시 토큰 갱신 임계값 적용

### DIFF
--- a/docs/specs/20260615-issue-263-refresh-token-threshold/checklist.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/checklist.md
@@ -6,6 +6,7 @@
 - [x] refresh token 유지 RED 테스트 추가.
 - [x] RED 테스트 실패 확인.
 - [x] `RefreshTokenService`에 만료 임계값 기반 갱신 조건 구현.
+- [x] 로그인 경로가 동일한 refresh token 갱신 조건을 사용하도록 변경.
 - [x] prod 기본 7일, dev 2일 설정 추가.
 - [x] targeted test GREEN 확인.
 - [x] 전체 테스트 실행.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/checklist.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/checklist.md
@@ -1,0 +1,12 @@
+# Checklist
+
+- [x] 이슈 구조를 #265 parent, #263 빠른 완화, #264 근본 해결로 정리.
+- [x] `feat/263` 브랜치 생성.
+- [x] Spec lite, checklist, context notes 생성.
+- [x] refresh token 유지 RED 테스트 추가.
+- [x] RED 테스트 실패 확인.
+- [x] `RefreshTokenService`에 만료 임계값 기반 갱신 조건 구현.
+- [x] prod 기본 7일, dev 2일 설정 추가.
+- [x] targeted test GREEN 확인.
+- [x] 전체 테스트 실행.
+- [x] 변경사항 커밋.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
@@ -8,9 +8,14 @@
 - 현재 작업은 #263 빠른 완화만 다룬다.
 - 현재 브랜치는 `feat/263`이고 `origin/dev` 기반으로 생성했다.
 - 기존 워크트리에는 사용자 변경으로 보이는 `.codex/config.toml` 수정과 `docs/lambda-migration-backend-lessons.md` 미추적 파일이 있다. 이번 작업에서는 건드리지 않는다.
-- 빠른 완화에서는 로그인 API 정책과 DB 구조를 바꾸지 않는다.
+- 빠른 완화에서는 DB 구조를 바꾸지 않는다.
 - refresh API에서 access token은 항상 새로 발급하고, refresh token은 저장된 `expiry`가 임계값 이하로 남은 경우에만 새로 발급한다.
+- 로그인 API에서도 같은 refresh token 임계값 정책을 적용한다.
+- 로그인 시 기존 refresh token이 있고 임계값보다 많이 남아 있으면 기존 token을 반환한다.
+- 로그인 시 기존 refresh token이 없거나 임계값 이하로 남아 있으면 새 token을 저장한다.
 - 임계값 설정 키는 `security.jwt.refresh-renewal-threshold`로 둔다.
 - 공통 기본값은 7일인 `604800000`ms이고, dev profile은 2일인 `172800000`ms로 override한다.
 - RED 확인: `./gradlew test --tests com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests.reissue_refreshExpiryBeyondThreshold_returnsExistingRefreshToken`가 기존 구현에서 실패했다.
 - GREEN 확인: 동일 targeted test, `RefreshTokenServiceUnitTests` 전체, `./gradlew test`가 통과했다.
+- 추가 RED 확인: `RefreshTokenServiceUnitTests.issueForSignIn_refreshExpiryBeyondThreshold_returnsExistingRefreshToken`가 `issueForSignIn` 메서드 부재로 실패했다.
+- 추가 GREEN 확인: 로그인용 refresh token 발급 테스트와 `UserServiceUnitTests`가 통과했다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
@@ -1,0 +1,16 @@
+# Context Notes
+
+## 2026-06-15
+
+- 사용자는 빠른 완화와 근본 해결을 분리하길 원했다.
+- #263은 빠른 완화 이슈로 유지하고, #264는 기기별 세션 토큰 저장 구조 도입 이슈로 만들었다.
+- #265를 상위 이슈로 만들고 #263, #264를 체크리스트로 연결했다.
+- 현재 작업은 #263 빠른 완화만 다룬다.
+- 현재 브랜치는 `feat/263`이고 `origin/dev` 기반으로 생성했다.
+- 기존 워크트리에는 사용자 변경으로 보이는 `.codex/config.toml` 수정과 `docs/lambda-migration-backend-lessons.md` 미추적 파일이 있다. 이번 작업에서는 건드리지 않는다.
+- 빠른 완화에서는 로그인 API 정책과 DB 구조를 바꾸지 않는다.
+- refresh API에서 access token은 항상 새로 발급하고, refresh token은 저장된 `expiry`가 임계값 이하로 남은 경우에만 새로 발급한다.
+- 임계값 설정 키는 `security.jwt.refresh-renewal-threshold`로 둔다.
+- 공통 기본값은 7일인 `604800000`ms이고, dev profile은 2일인 `172800000`ms로 override한다.
+- RED 확인: `./gradlew test --tests com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests.reissue_refreshExpiryBeyondThreshold_returnsExistingRefreshToken`가 기존 구현에서 실패했다.
+- GREEN 확인: 동일 targeted test, `RefreshTokenServiceUnitTests` 전체, `./gradlew test`가 통과했다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/context-notes.md
@@ -19,3 +19,5 @@
 - GREEN 확인: 동일 targeted test, `RefreshTokenServiceUnitTests` 전체, `./gradlew test`가 통과했다.
 - 추가 RED 확인: `RefreshTokenServiceUnitTests.issueForSignIn_refreshExpiryBeyondThreshold_returnsExistingRefreshToken`가 `issueForSignIn` 메서드 부재로 실패했다.
 - 추가 GREEN 확인: 로그인용 refresh token 발급 테스트와 `UserServiceUnitTests`가 통과했다.
+- PR #266 리뷰에서 저장된 refresh token의 `expiry`가 null이면 `shouldRenewRefreshToken`에서 NPE가 날 수 있다는 지적이 있었다.
+- `expiry`가 null인 refresh token은 남은 만료기간을 신뢰할 수 없으므로 갱신 대상으로 처리한다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/plan.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/plan.md
@@ -1,0 +1,18 @@
+# Plan
+
+## Goal
+
+Refresh API 호출 시 access token은 항상 새로 발급하되, refresh token은 만료 임계값 이하로 남은 경우에만 갱신한다.
+
+## Steps
+
+1. 현재 refresh token 재발급 흐름과 테스트 구조를 확인한다.
+   - Verify: `RefreshTokenService.reissue()`와 `RefreshTokenServiceUnitTests`를 읽는다.
+2. 만료 임계값보다 많이 남은 refresh token은 유지되는 RED 테스트를 추가한다.
+   - Verify: targeted test가 기존 구현에서 실패한다.
+3. `RefreshTokenService`에 저장된 `expiry` 기준 갱신 조건을 추가한다.
+   - Verify: targeted test가 통과한다.
+4. prod 기본 7일, dev 2일 설정을 추가한다.
+   - Verify: `application.yml`, `application-dev.yml`에 설정값이 반영된다.
+5. 관련 단위 테스트와 전체 테스트를 실행한다.
+   - Verify: `./gradlew test --tests com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests`와 `./gradlew test`가 통과한다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/plan.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/plan.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Refresh API 호출 시 access token은 항상 새로 발급하되, refresh token은 만료 임계값 이하로 남은 경우에만 갱신한다.
+Refresh API와 로그인 API에서 access token은 항상 새로 발급하되, refresh token은 만료 임계값 이하로 남은 경우에만 갱신한다.
 
 ## Steps
 
@@ -12,7 +12,9 @@ Refresh API 호출 시 access token은 항상 새로 발급하되, refresh token
    - Verify: targeted test가 기존 구현에서 실패한다.
 3. `RefreshTokenService`에 저장된 `expiry` 기준 갱신 조건을 추가한다.
    - Verify: targeted test가 통과한다.
-4. prod 기본 7일, dev 2일 설정을 추가한다.
+4. 로그인 경로가 `RefreshTokenService`의 임계값 기반 발급 정책을 사용하도록 변경한다.
+   - Verify: `UserServiceUnitTests`가 통과한다.
+5. prod 기본 7일, dev 2일 설정을 추가한다.
    - Verify: `application.yml`, `application-dev.yml`에 설정값이 반영된다.
-5. 관련 단위 테스트와 전체 테스트를 실행한다.
+6. 관련 단위 테스트와 전체 테스트를 실행한다.
    - Verify: `./gradlew test --tests com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests`와 `./gradlew test`가 통과한다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/spec-lite.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/spec-lite.md
@@ -1,0 +1,37 @@
+# Spec Lite
+
+## Overview
+
+- Issue: #263.
+- Parent issue: #265.
+- Purpose: refresh API 호출 때마다 refresh token을 재발급해 저장하지 않고, 만료가 가까운 경우에만 갱신한다.
+- Scope in:
+  - `RefreshTokenService.reissue()`의 refresh token 갱신 조건.
+  - prod 기본 임계값 7일.
+  - dev profile 임계값 2일.
+  - 관련 단위 테스트.
+- Scope out:
+  - 기기별 또는 세션별 refresh token 저장 구조.
+  - 로그인 API의 refresh token 저장 정책 변경.
+  - DB 스키마 변경.
+  - 공개 API 필드 변경.
+
+## Behavior
+
+- refresh token 검증, 저장 token 일치 여부 확인, 사용자 조회는 기존 순서를 유지한다.
+- access token은 refresh API 호출마다 새로 발급한다.
+- 저장된 refresh token의 `expiry`가 현재 시각 기준 갱신 임계값보다 많이 남아 있으면 기존 refresh token을 응답한다.
+- 저장된 refresh token의 `expiry`가 현재 시각 기준 갱신 임계값 이하로 남아 있으면 새 refresh token을 발급하고 저장한 뒤 응답한다.
+- prod 기본값은 7일이다.
+- dev profile 값은 2일이다.
+
+## Risks
+
+- 이 작업은 빠른 완화책이다. `refresh_token`이 `userId` 단일 row로 저장되는 구조는 그대로 유지한다.
+- 여러 기기 동시 로그인의 근본 해결은 #264에서 별도 브랜치로 처리한다.
+
+## Verification
+
+- `RefreshTokenServiceUnitTests`에 기존 refresh token 유지 케이스를 추가한다.
+- 기존 refresh token 갱신 케이스가 계속 통과하는지 확인한다.
+- 관련 단위 테스트를 먼저 실행하고, 이후 전체 테스트를 실행한다.

--- a/docs/specs/20260615-issue-263-refresh-token-threshold/spec-lite.md
+++ b/docs/specs/20260615-issue-263-refresh-token-threshold/spec-lite.md
@@ -4,15 +4,15 @@
 
 - Issue: #263.
 - Parent issue: #265.
-- Purpose: refresh API 호출 때마다 refresh token을 재발급해 저장하지 않고, 만료가 가까운 경우에만 갱신한다.
+- Purpose: refresh API와 로그인 API에서 refresh token을 매번 재발급해 저장하지 않고, 만료가 가까운 경우에만 갱신한다.
 - Scope in:
   - `RefreshTokenService.reissue()`의 refresh token 갱신 조건.
+  - 로그인 응답 생성 시 refresh token 발급 조건.
   - prod 기본 임계값 7일.
   - dev profile 임계값 2일.
   - 관련 단위 테스트.
 - Scope out:
   - 기기별 또는 세션별 refresh token 저장 구조.
-  - 로그인 API의 refresh token 저장 정책 변경.
   - DB 스키마 변경.
   - 공개 API 필드 변경.
 
@@ -22,6 +22,8 @@
 - access token은 refresh API 호출마다 새로 발급한다.
 - 저장된 refresh token의 `expiry`가 현재 시각 기준 갱신 임계값보다 많이 남아 있으면 기존 refresh token을 응답한다.
 - 저장된 refresh token의 `expiry`가 현재 시각 기준 갱신 임계값 이하로 남아 있으면 새 refresh token을 발급하고 저장한 뒤 응답한다.
+- 로그인 시 저장된 refresh token이 있고 갱신 임계값보다 많이 남아 있으면 기존 refresh token을 응답한다.
+- 로그인 시 저장된 refresh token이 없거나 갱신 임계값 이하로 남아 있으면 새 refresh token을 발급하고 저장한다.
 - prod 기본값은 7일이다.
 - dev profile 값은 2일이다.
 
@@ -33,5 +35,6 @@
 ## Verification
 
 - `RefreshTokenServiceUnitTests`에 기존 refresh token 유지 케이스를 추가한다.
+- `UserServiceUnitTests`에서 로그인 경로가 `RefreshTokenService`의 로그인용 발급 정책에 위임하는지 확인한다.
 - 기존 refresh token 갱신 케이스가 계속 통과하는지 확인한다.
 - 관련 단위 테스트를 먼저 실행하고, 이후 전체 테스트를 실행한다.

--- a/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
@@ -42,6 +42,18 @@ public class RefreshTokenService {
         refreshTokenRepository.save(token);
     }
 
+    @Transactional
+    public AuthDto.RefreshTokenWithExpiry issueForSignIn(String userId) {
+        return refreshTokenRepository.findById(userId)
+                .filter(saved -> !shouldRenewRefreshToken(saved.getExpiry()))
+                .map(saved -> new AuthDto.RefreshTokenWithExpiry(saved.getToken(), saved.getExpiry()))
+                .orElseGet(() -> {
+                    AuthDto.RefreshTokenWithExpiry refresh = jwtProvider.createRefreshToken(userId);
+                    save(userId, refresh.token(), refresh.expiry());
+                    return refresh;
+                });
+    }
+
     /* 토큰 재발급 */
     @Transactional
     public AuthDto.RefreshResponse reissue(String refreshToken) {

--- a/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
@@ -95,6 +95,9 @@ public class RefreshTokenService {
     }
 
     private boolean shouldRenewRefreshToken(Date expiry) {
+        if (expiry == null) {
+            return true;
+        }
         long remainingMs = expiry.getTime() - System.currentTimeMillis();
         return remainingMs <= refreshTokenRenewalThresholdMs;
     }

--- a/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenService.java
@@ -13,6 +13,7 @@ import com.chukchuk.haksa.global.security.service.JwtProvider;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,9 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+
+    @Value("${security.jwt.refresh-renewal-threshold:604800000}")
+    private long refreshTokenRenewalThresholdMs = 604800000L;
 
     /* Refresh Token 저장 */
     @Transactional
@@ -64,14 +68,23 @@ public class RefreshTokenService {
                 });
 
         String newAccessToken = jwtProvider.createAccessToken(userId, user.getEmail(), "USER");
-        AuthDto.RefreshTokenWithExpiry newRefresh = jwtProvider.createRefreshToken(userId);
-        save(userId, newRefresh.token(), newRefresh.expiry());
+        String responseRefreshToken = saved.getToken();
+        if (shouldRenewRefreshToken(saved.getExpiry())) {
+            AuthDto.RefreshTokenWithExpiry newRefresh = jwtProvider.createRefreshToken(userId);
+            save(userId, newRefresh.token(), newRefresh.expiry());
+            responseRefreshToken = newRefresh.token();
+        }
 
         long tookMs = LogTime.elapsedMs(t0);
         if (tookMs >= SLOW_MS) {
             log.info("[BIZ] auth.refresh.issued userId={} took_ms={}", userId, tookMs);
         }
-        return new AuthDto.RefreshResponse(newAccessToken, newRefresh.token());
+        return new AuthDto.RefreshResponse(newAccessToken, responseRefreshToken);
+    }
+
+    private boolean shouldRenewRefreshToken(Date expiry) {
+        long remainingMs = expiry.getTime() - System.currentTimeMillis();
+        return remainingMs <= refreshTokenRenewalThresholdMs;
     }
 
     public RefreshToken findByUserId(String userId) {

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -171,8 +171,7 @@ public class UserService {
     private AuthDto.SignInTokenResponse generateSignInResponse(User user) {
         String userId = user.getId().toString();
         String accessToken = jwtProvider.createAccessToken(userId, user.getEmail(), "USER");
-        AuthDto.RefreshTokenWithExpiry refresh = jwtProvider.createRefreshToken(userId);
-        refreshTokenService.save(userId, refresh.token(), refresh.expiry());
+        AuthDto.RefreshTokenWithExpiry refresh = refreshTokenService.issueForSignIn(userId);
 
         return new AuthDto.SignInTokenResponse(accessToken, refresh.token(), user.getPortalConnected());
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,6 +32,8 @@ sentry:
   environment: dev
 
 security:
+  jwt:
+    refresh-renewal-threshold: ${JWT_REFRESH_RENEWAL_THRESHOLD:172800000}
   cookie:
     dev-mode: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ security:
     secret: ${JWT_SECRET}
     access-expiration: ${JWT_ACCESS_EXPIRATION}
     refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+    refresh-renewal-threshold: ${JWT_REFRESH_RENEWAL_THRESHOLD:604800000}
   appKey: ${APP_KEY}
   nativeAppKey: ${APP_NATIVE_KEY:}
   apple:

--- a/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
@@ -124,6 +124,38 @@ class RefreshTokenServiceUnitTests {
     }
 
     @Test
+    @DisplayName("reissue는 저장된 refresh token 만료시각이 없으면 새 refresh token을 저장한다")
+    void reissue_refreshExpiryNull_renewsRefreshToken() {
+        UUID userId = UUID.randomUUID();
+        String userIdText = userId.toString();
+        String oldRefresh = "old-refresh";
+        Date newExpiry = new Date(System.currentTimeMillis() + Duration.ofDays(14).toMillis());
+
+        Claims claims = Jwts.claims();
+        claims.setSubject(userIdText);
+
+        User user = User.builder()
+                .id(userId)
+                .email("user@example.com")
+                .profileNickname("user")
+                .build();
+
+        when(jwtProvider.parseToken(oldRefresh)).thenReturn(claims);
+        when(refreshTokenRepository.findById(userIdText))
+                .thenReturn(Optional.of(new RefreshToken(userIdText, oldRefresh, null)));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(jwtProvider.createAccessToken(userIdText, "user@example.com", "USER")).thenReturn("new-access");
+        when(jwtProvider.createRefreshToken(userIdText))
+                .thenReturn(new AuthDto.RefreshTokenWithExpiry("new-refresh", newExpiry));
+
+        AuthDto.RefreshResponse response = refreshTokenService.reissue(oldRefresh);
+
+        assertThat(response.accessToken()).isEqualTo("new-access");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh");
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
     @DisplayName("로그인 토큰 발급은 refresh token 만료가 임계값보다 많이 남으면 기존 refresh token을 반환한다")
     void issueForSignIn_refreshExpiryBeyondThreshold_returnsExistingRefreshToken() {
         String userId = UUID.randomUUID().toString();

--- a/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,6 +90,37 @@ class RefreshTokenServiceUnitTests {
         assertThat(response.accessToken()).isEqualTo("new-access");
         assertThat(response.refreshToken()).isEqualTo("new-refresh");
         verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("reissue는 refresh token 만료가 임계값보다 많이 남으면 기존 refresh token을 반환한다")
+    void reissue_refreshExpiryBeyondThreshold_returnsExistingRefreshToken() {
+        UUID userId = UUID.randomUUID();
+        String userIdText = userId.toString();
+        String oldRefresh = "old-refresh";
+        Date savedExpiry = new Date(System.currentTimeMillis() + Duration.ofDays(8).toMillis());
+
+        Claims claims = Jwts.claims();
+        claims.setSubject(userIdText);
+
+        User user = User.builder()
+                .id(userId)
+                .email("user@example.com")
+                .profileNickname("user")
+                .build();
+
+        when(jwtProvider.parseToken(oldRefresh)).thenReturn(claims);
+        when(refreshTokenRepository.findById(userIdText))
+                .thenReturn(Optional.of(new RefreshToken(userIdText, oldRefresh, savedExpiry)));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(jwtProvider.createAccessToken(userIdText, "user@example.com", "USER")).thenReturn("new-access");
+
+        AuthDto.RefreshResponse response = refreshTokenService.reissue(oldRefresh);
+
+        assertThat(response.accessToken()).isEqualTo("new-access");
+        assertThat(response.refreshToken()).isEqualTo(oldRefresh);
+        verify(jwtProvider, never()).createRefreshToken(userIdText);
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
     }
 
     @Test

--- a/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/auth/service/RefreshTokenServiceUnitTests.java
@@ -124,6 +124,40 @@ class RefreshTokenServiceUnitTests {
     }
 
     @Test
+    @DisplayName("로그인 토큰 발급은 refresh token 만료가 임계값보다 많이 남으면 기존 refresh token을 반환한다")
+    void issueForSignIn_refreshExpiryBeyondThreshold_returnsExistingRefreshToken() {
+        String userId = UUID.randomUUID().toString();
+        Date savedExpiry = new Date(System.currentTimeMillis() + Duration.ofDays(8).toMillis());
+        RefreshToken saved = new RefreshToken(userId, "saved-refresh", savedExpiry);
+
+        when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(saved));
+
+        AuthDto.RefreshTokenWithExpiry refresh = refreshTokenService.issueForSignIn(userId);
+
+        assertThat(refresh.token()).isEqualTo("saved-refresh");
+        assertThat(refresh.expiry()).isEqualTo(savedExpiry);
+        verify(jwtProvider, never()).createRefreshToken(userId);
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("로그인 토큰 발급은 refresh token이 없으면 새 refresh token을 저장한다")
+    void issueForSignIn_refreshNotFound_savesNewRefreshToken() {
+        String userId = UUID.randomUUID().toString();
+        Date newExpiry = new Date(System.currentTimeMillis() + Duration.ofDays(14).toMillis());
+
+        when(refreshTokenRepository.findById(userId)).thenReturn(Optional.empty());
+        when(jwtProvider.createRefreshToken(userId))
+                .thenReturn(new AuthDto.RefreshTokenWithExpiry("new-refresh", newExpiry));
+
+        AuthDto.RefreshTokenWithExpiry refresh = refreshTokenService.issueForSignIn(userId);
+
+        assertThat(refresh.token()).isEqualTo("new-refresh");
+        assertThat(refresh.expiry()).isEqualTo(newExpiry);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
     @DisplayName("저장된 refresh token이 없으면 REFRESH_TOKEN_NOT_FOUND 예외를 던진다")
     void reissue_refreshNotFound_throws() {
         UUID userId = UUID.randomUUID();

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceTests.java
@@ -78,7 +78,7 @@ class UserServiceTests {
 
         when(jwtProvider.createAccessToken(userId.toString(), "apple@example.com", "USER"))
                 .thenReturn("access");
-        when(jwtProvider.createRefreshToken(userId.toString()))
+        when(refreshTokenService.issueForSignIn(userId.toString()))
                 .thenReturn(new AuthDto.RefreshTokenWithExpiry("refresh", new Date()));
 
         UserService userService = new UserService(
@@ -106,6 +106,6 @@ class UserServiceTests {
 
         verify(socialAccountRepository).findByProviderAndSocialId(providerCaptor.capture(), eq("apple-sub"));
         assertThat(providerCaptor.getValue()).isEqualTo(OidcProvider.APPLE);
-        verify(refreshTokenService).save(eq(userId.toString()), eq("refresh"), any(Date.class));
+        verify(refreshTokenService).issueForSignIn(userId.toString());
     }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
@@ -324,14 +324,14 @@ class UserServiceUnitTests {
                 .thenReturn(Optional.of(existingAccount));
         when(jwtProvider.createAccessToken(existingUser.getId().toString(), "existing@example.com", "USER"))
                 .thenReturn("access-token");
-        when(jwtProvider.createRefreshToken(existingUser.getId().toString()))
+        when(refreshTokenService.issueForSignIn(existingUser.getId().toString()))
                 .thenReturn(new AuthDto.RefreshTokenWithExpiry("refresh-token", new Date()));
 
         AuthDto.SignInTokenResponse response = userService.signIn(new UserDto.SignInRequest(OidcProvider.KAKAO, "id-token", "nonce"));
 
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
-        verify(refreshTokenService).save(eq(existingUser.getId().toString()), eq("refresh-token"), any(Date.class));
+        verify(refreshTokenService).issueForSignIn(existingUser.getId().toString());
         verify(userRepository, never()).save(any(User.class));
         verify(socialAccountRepository, never()).save(any(SocialAccount.class));
     }
@@ -357,7 +357,7 @@ class UserServiceUnitTests {
         when(userRepository.save(any(User.class))).thenReturn(savedUser);
         when(jwtProvider.createAccessToken(savedUser.getId().toString(), "new@example.com", "USER"))
                 .thenReturn("new-access-token");
-        when(jwtProvider.createRefreshToken(savedUser.getId().toString()))
+        when(refreshTokenService.issueForSignIn(savedUser.getId().toString()))
                 .thenReturn(new AuthDto.RefreshTokenWithExpiry("new-refresh-token", new Date()));
 
         AuthDto.SignInTokenResponse response = userService.signIn(new UserDto.SignInRequest(OidcProvider.KAKAO, "id-token", "nonce"));
@@ -374,7 +374,7 @@ class UserServiceUnitTests {
         assertThat(response.accessToken()).isEqualTo("new-access-token");
         assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
         assertThat(response.isPortalLinked()).isFalse();
-        verify(refreshTokenService).save(eq(savedUser.getId().toString()), eq("new-refresh-token"), any(Date.class));
+        verify(refreshTokenService).issueForSignIn(savedUser.getId().toString());
     }
 
     @Test


### PR DESCRIPTION
## 개요

- Closes #263.
- Parent: #265.
- refresh API와 로그인 API에서 access token은 기존처럼 항상 재발급하되, refresh token은 만료 임계값 이하로 남은 경우에만 갱신하도록 변경했습니다.
- 기본 임계값은 7일이고, dev profile은 2일입니다.

## 변경 사항

- `RefreshTokenService.reissue()`에서 저장된 refresh token의 `expiry`를 기준으로 갱신 여부를 판단합니다.
- 로그인 응답 생성 시 `RefreshTokenService.issueForSignIn()`을 통해 같은 임계값 정책을 사용합니다.
- 임계값보다 많이 남아 있으면 기존 refresh token을 그대로 응답하고 저장하지 않습니다.
- 임계값 이하로 남아 있거나 로그인 시 저장된 refresh token이 없으면 새 refresh token을 발급하고 저장합니다.
- `security.jwt.refresh-renewal-threshold` 설정을 추가했습니다.
- #263 작업용 spec lite와 context notes를 갱신했습니다.

## 주의 사항

- 이 PR은 빠른 완화책입니다.
- `userId`당 refresh token 1개 저장 구조는 유지됩니다.
- 여러 기기 동시 로그인의 근본 해결은 #264에서 별도 브랜치로 진행합니다.

## 검증

- `./gradlew test --tests com.chukchuk.haksa.domain.auth.service.RefreshTokenServiceUnitTests` 통과.
- `./gradlew test --tests com.chukchuk.haksa.domain.user.service.UserServiceUnitTests` 통과.
- `./gradlew test --tests com.chukchuk.haksa.domain.user.service.UserServiceTests.signIn_usesProviderFromRequest_andReturnsTokens` 통과.
- `./gradlew test` 통과.