### PR TITLE
[alpha] 강의평가 FE 테스트용 mock-inline Lambda 경로

### DIFF
--- a/docs/sql/lecture-evaluation-test-accounts/00_shared_catalog.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/00_shared_catalog.sql
@@ -1,0 +1,202 @@
+-- Shared catalog rows required by all lecture evaluation FE test accounts.
+-- Run this once before running any per-account create script.
+
+BEGIN;
+
+INSERT INTO public.departments (
+    department_code,
+    established_department_name,
+    created_at,
+    updated_at
+)
+VALUES (
+    'LEVALPHA',
+    '강의평가 테스트학부',
+    NOW(),
+    NOW()
+)
+ON CONFLICT (department_code) DO UPDATE
+SET established_department_name = EXCLUDED.established_department_name,
+    updated_at = NOW();
+
+INSERT INTO public.professor (
+    professor_code,
+    professor_name,
+    created_at,
+    department_id
+)
+SELECT
+    'LEVALPHA-PROF-01',
+    '강의평가테스트교수A',
+    NOW(),
+    d.id
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA'
+ON CONFLICT (professor_name) DO UPDATE
+SET professor_code = EXCLUDED.professor_code,
+    department_id = EXCLUDED.department_id;
+
+INSERT INTO public.professor (
+    professor_code,
+    professor_name,
+    created_at,
+    department_id
+)
+SELECT
+    'LEVALPHA-PROF-02',
+    '강의평가테스트교수B',
+    NOW(),
+    d.id
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA'
+ON CONFLICT (professor_name) DO UPDATE
+SET professor_code = EXCLUDED.professor_code,
+    department_id = EXCLUDED.department_id;
+
+INSERT INTO public.courses (
+    course_code,
+    course_name,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    'LEVALPHA-101',
+    '강의평가 테스트 과목 A',
+    NOW(),
+    NOW(),
+    NULL
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.courses
+    WHERE course_code = 'LEVALPHA-101'
+);
+
+INSERT INTO public.courses (
+    course_code,
+    course_name,
+    created_at,
+    updated_at,
+    deleted_at
+)
+SELECT
+    'LEVALPHA-102',
+    '강의평가 테스트 과목 B',
+    NOW(),
+    NOW(),
+    NULL
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.courses
+    WHERE course_code = 'LEVALPHA-102'
+);
+
+INSERT INTO public.course_offerings (
+    subject_establishment_semester,
+    is_video_lecture,
+    year,
+    semester,
+    host_department,
+    class_section,
+    schedule_summary,
+    original_area_code,
+    points,
+    deleted_at,
+    evaluation_type_code,
+    faculty_division_name,
+    raw_faculty_division_name,
+    course_id,
+    department_id,
+    professor_id,
+    area_code,
+    created_at,
+    updated_at
+)
+SELECT
+    10,
+    FALSE,
+    2026,
+    10,
+    '강의평가 테스트학부',
+    'LEVALPHA-A',
+    '월 1,2',
+    NULL,
+    3,
+    NULL,
+    'RELATIVE',
+    '전선',
+    '전선',
+    c.id,
+    d.id,
+    p.id,
+    NULL,
+    NOW(),
+    NOW()
+FROM public.courses c
+JOIN public.departments d ON d.department_code = 'LEVALPHA'
+JOIN public.professor p ON p.professor_name = '강의평가테스트교수A'
+WHERE c.course_code = 'LEVALPHA-101'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM public.course_offerings co
+      WHERE co.course_id = c.id
+        AND co.year = 2026
+        AND co.semester = 10
+        AND co.class_section = 'LEVALPHA-A'
+  );
+
+INSERT INTO public.course_offerings (
+    subject_establishment_semester,
+    is_video_lecture,
+    year,
+    semester,
+    host_department,
+    class_section,
+    schedule_summary,
+    original_area_code,
+    points,
+    deleted_at,
+    evaluation_type_code,
+    faculty_division_name,
+    raw_faculty_division_name,
+    course_id,
+    department_id,
+    professor_id,
+    area_code,
+    created_at,
+    updated_at
+)
+SELECT
+    10,
+    FALSE,
+    2026,
+    10,
+    '강의평가 테스트학부',
+    'LEVALPHA-B',
+    '화 3,4',
+    NULL,
+    3,
+    NULL,
+    'ABSOLUTE',
+    '전선',
+    '전선',
+    c.id,
+    d.id,
+    p.id,
+    NULL,
+    NOW(),
+    NOW()
+FROM public.courses c
+JOIN public.departments d ON d.department_code = 'LEVALPHA'
+JOIN public.professor p ON p.professor_name = '강의평가테스트교수B'
+WHERE c.course_code = 'LEVALPHA-102'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM public.course_offerings co
+      WHERE co.course_id = c.id
+        AND co.year = 2026
+        AND co.semester = 10
+        AND co.class_section = 'LEVALPHA-B'
+  );
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/01_not_create.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/01_not_create.sql
@@ -1,0 +1,65 @@
+-- Create NOT@test.com.
+-- State: 2026/10 courses exist, student_courses.grade = IP, lecture_evaluation_status = NOT_RELEASED.
+-- Prerequisite: run 00_shared_catalog.sql first.
+
+BEGIN;
+
+INSERT INTO public.users (
+    id, created_at, updated_at, email, profile_nickname, profile_image,
+    is_deleted, portal_connected, connected_at, deleted_at, last_synced_at
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245001', NOW(), NOW(), 'NOT@test.com',
+    'LEVALPHA NOT_RELEASED', NULL, FALSE, TRUE, NOW(), NULL, NOW()
+);
+
+INSERT INTO public.social_accounts (provider, social_id, email, user_id)
+VALUES ('KAKAO', 'levalpha-not-245', 'NOT@test.com', '00000000-0000-0000-0000-000000245001');
+
+INSERT INTO public.students (
+    student_id, created_at, updated_at, student_code, name, is_graduated,
+    admission_type, target_gpa, reconnection_required, admission_year,
+    semester_enrolled, is_transfer_student, status, grade_level,
+    completed_semesters, department_id, major_id, secondary_major_id, user_id
+)
+SELECT
+    '00000000-0000-0000-0000-000000245101', NOW(), NOW(), 'LEVALPHA245001',
+    '강의평가 NOT_RELEASED', FALSE, '신입학', 4.0, FALSE, 2023,
+    7, FALSE, '재학', 4, 6, d.id, d.id, NULL,
+    '00000000-0000-0000-0000-000000245001'
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA';
+
+INSERT INTO public.student_academic_records (
+    id, created_at, updated_at, attempted_credits_gpa, percentile,
+    cumulative_gpa, total_attempted_credits, total_earned_credits, student_id
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245301', NOW(), NOW(),
+    4.10, 90.00, 4.10, 18, 18, '00000000-0000-0000-0000-000000245101'
+);
+
+INSERT INTO public.semester_academic_records (
+    id, created_at, updated_at, semester, year, total_students, class_rank,
+    attempted_credits_gpa, semester_percentile, semester_gpa,
+    attempted_credits, earned_credits, student_id, lecture_evaluation_status
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245201', NOW(), NOW(),
+    10, 2026, 50, 5, 4.10, 90.00, 4.10, 6, 0,
+    '00000000-0000-0000-0000-000000245101', 'NOT_RELEASED'
+);
+
+INSERT INTO public.student_courses (
+    grade, points, is_retake, original_score, created_at,
+    is_retake_deleted, offering_id, student_id
+)
+SELECT
+    'IP', 3, FALSE, NULL, NOW(), FALSE, co.id,
+    '00000000-0000-0000-0000-000000245101'
+FROM public.course_offerings co
+WHERE co.year = 2026
+  AND co.semester = 10
+  AND co.class_section IN ('LEVALPHA-A', 'LEVALPHA-B');
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/01_not_delete.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/01_not_delete.sql
@@ -1,0 +1,71 @@
+-- Delete only NOT@test.com and dependent test rows.
+
+BEGIN;
+
+DELETE FROM public.course_evaluation_tags cet
+USING public.course_evaluations ce
+JOIN public.students s ON s.student_id = ce.student_id
+JOIN public.users u ON u.id = s.user_id
+WHERE cet.course_evaluation_id = ce.id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.course_evaluations ce
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ce.student_id = s.student_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.student_courses sc
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sc.student_id = s.student_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.semester_academic_records sar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sar.student_id = s.student_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.student_academic_records ar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ar.student_id = s.student_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.student_graduation_progress sgp
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sgp.student_id = s.student_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.scrape_job_outbox outbox
+USING public.scrape_jobs job
+JOIN public.users u ON u.id = job.user_id
+WHERE outbox.job_id = job.job_id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.scrape_jobs job
+USING public.users u
+WHERE job.user_id = u.id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.refresh_token rt
+USING public.users u
+WHERE rt.user_id = u.id::text
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.social_accounts sa
+USING public.users u
+WHERE sa.user_id = u.id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.students s
+USING public.users u
+WHERE s.user_id = u.id
+  AND u.email = 'NOT@test.com';
+
+DELETE FROM public.users
+WHERE email = 'NOT@test.com';
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/02_pending_create.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/02_pending_create.sql
@@ -1,0 +1,71 @@
+-- Create PENDING@test.com.
+-- State: 2026/10 courses exist, completed grades exist, lecture_evaluation_status = PENDING.
+-- Prerequisite: run 00_shared_catalog.sql first.
+
+BEGIN;
+
+INSERT INTO public.users (
+    id, created_at, updated_at, email, profile_nickname, profile_image,
+    is_deleted, portal_connected, connected_at, deleted_at, last_synced_at
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245002', NOW(), NOW(), 'PENDING@test.com',
+    'LEVALPHA PENDING', NULL, FALSE, TRUE, NOW(), NULL, NOW()
+);
+
+INSERT INTO public.social_accounts (provider, social_id, email, user_id)
+VALUES ('KAKAO', 'levalpha-pending-245', 'PENDING@test.com', '00000000-0000-0000-0000-000000245002');
+
+INSERT INTO public.students (
+    student_id, created_at, updated_at, student_code, name, is_graduated,
+    admission_type, target_gpa, reconnection_required, admission_year,
+    semester_enrolled, is_transfer_student, status, grade_level,
+    completed_semesters, department_id, major_id, secondary_major_id, user_id
+)
+SELECT
+    '00000000-0000-0000-0000-000000245102', NOW(), NOW(), 'LEVALPHA245002',
+    '강의평가 PENDING', FALSE, '신입학', 4.0, FALSE, 2023,
+    7, FALSE, '재학', 4, 6, d.id, d.id, NULL,
+    '00000000-0000-0000-0000-000000245002'
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA';
+
+INSERT INTO public.student_academic_records (
+    id, created_at, updated_at, attempted_credits_gpa, percentile,
+    cumulative_gpa, total_attempted_credits, total_earned_credits, student_id
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245302', NOW(), NOW(),
+    4.10, 90.00, 4.10, 18, 18, '00000000-0000-0000-0000-000000245102'
+);
+
+INSERT INTO public.semester_academic_records (
+    id, created_at, updated_at, semester, year, total_students, class_rank,
+    attempted_credits_gpa, semester_percentile, semester_gpa,
+    attempted_credits, earned_credits, student_id, lecture_evaluation_status
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245202', NOW(), NOW(),
+    10, 2026, 50, 5, 4.10, 90.00, 4.10, 6, 6,
+    '00000000-0000-0000-0000-000000245102', 'PENDING'
+);
+
+INSERT INTO public.student_courses (
+    grade, points, is_retake, original_score, created_at,
+    is_retake_deleted, offering_id, student_id
+)
+SELECT
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 'A+' ELSE 'B+' END,
+    3,
+    FALSE,
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 95 ELSE 88 END,
+    NOW(),
+    FALSE,
+    co.id,
+    '00000000-0000-0000-0000-000000245102'
+FROM public.course_offerings co
+WHERE co.year = 2026
+  AND co.semester = 10
+  AND co.class_section IN ('LEVALPHA-A', 'LEVALPHA-B');
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/02_pending_delete.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/02_pending_delete.sql
@@ -1,0 +1,71 @@
+-- Delete only PENDING@test.com and dependent test rows.
+
+BEGIN;
+
+DELETE FROM public.course_evaluation_tags cet
+USING public.course_evaluations ce
+JOIN public.students s ON s.student_id = ce.student_id
+JOIN public.users u ON u.id = s.user_id
+WHERE cet.course_evaluation_id = ce.id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.course_evaluations ce
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ce.student_id = s.student_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.student_courses sc
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sc.student_id = s.student_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.semester_academic_records sar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sar.student_id = s.student_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.student_academic_records ar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ar.student_id = s.student_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.student_graduation_progress sgp
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sgp.student_id = s.student_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.scrape_job_outbox outbox
+USING public.scrape_jobs job
+JOIN public.users u ON u.id = job.user_id
+WHERE outbox.job_id = job.job_id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.scrape_jobs job
+USING public.users u
+WHERE job.user_id = u.id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.refresh_token rt
+USING public.users u
+WHERE rt.user_id = u.id::text
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.social_accounts sa
+USING public.users u
+WHERE sa.user_id = u.id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.students s
+USING public.users u
+WHERE s.user_id = u.id
+  AND u.email = 'PENDING@test.com';
+
+DELETE FROM public.users
+WHERE email = 'PENDING@test.com';
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/03_skipped_create.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/03_skipped_create.sql
@@ -1,0 +1,71 @@
+-- Create SKIPPED@test.com.
+-- State: 2026/10 courses exist, completed grades exist, lecture_evaluation_status = SKIPPED.
+-- Prerequisite: run 00_shared_catalog.sql first.
+
+BEGIN;
+
+INSERT INTO public.users (
+    id, created_at, updated_at, email, profile_nickname, profile_image,
+    is_deleted, portal_connected, connected_at, deleted_at, last_synced_at
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245003', NOW(), NOW(), 'SKIPPED@test.com',
+    'LEVALPHA SKIPPED', NULL, FALSE, TRUE, NOW(), NULL, NOW()
+);
+
+INSERT INTO public.social_accounts (provider, social_id, email, user_id)
+VALUES ('KAKAO', 'levalpha-skipped-245', 'SKIPPED@test.com', '00000000-0000-0000-0000-000000245003');
+
+INSERT INTO public.students (
+    student_id, created_at, updated_at, student_code, name, is_graduated,
+    admission_type, target_gpa, reconnection_required, admission_year,
+    semester_enrolled, is_transfer_student, status, grade_level,
+    completed_semesters, department_id, major_id, secondary_major_id, user_id
+)
+SELECT
+    '00000000-0000-0000-0000-000000245103', NOW(), NOW(), 'LEVALPHA245003',
+    '강의평가 SKIPPED', FALSE, '신입학', 4.0, FALSE, 2023,
+    7, FALSE, '재학', 4, 6, d.id, d.id, NULL,
+    '00000000-0000-0000-0000-000000245003'
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA';
+
+INSERT INTO public.student_academic_records (
+    id, created_at, updated_at, attempted_credits_gpa, percentile,
+    cumulative_gpa, total_attempted_credits, total_earned_credits, student_id
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245303', NOW(), NOW(),
+    4.10, 90.00, 4.10, 18, 18, '00000000-0000-0000-0000-000000245103'
+);
+
+INSERT INTO public.semester_academic_records (
+    id, created_at, updated_at, semester, year, total_students, class_rank,
+    attempted_credits_gpa, semester_percentile, semester_gpa,
+    attempted_credits, earned_credits, student_id, lecture_evaluation_status
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245203', NOW(), NOW(),
+    10, 2026, 50, 5, 4.10, 90.00, 4.10, 6, 6,
+    '00000000-0000-0000-0000-000000245103', 'SKIPPED'
+);
+
+INSERT INTO public.student_courses (
+    grade, points, is_retake, original_score, created_at,
+    is_retake_deleted, offering_id, student_id
+)
+SELECT
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 'A+' ELSE 'B+' END,
+    3,
+    FALSE,
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 95 ELSE 88 END,
+    NOW(),
+    FALSE,
+    co.id,
+    '00000000-0000-0000-0000-000000245103'
+FROM public.course_offerings co
+WHERE co.year = 2026
+  AND co.semester = 10
+  AND co.class_section IN ('LEVALPHA-A', 'LEVALPHA-B');
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/03_skipped_delete.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/03_skipped_delete.sql
@@ -1,0 +1,71 @@
+-- Delete only SKIPPED@test.com and dependent test rows.
+
+BEGIN;
+
+DELETE FROM public.course_evaluation_tags cet
+USING public.course_evaluations ce
+JOIN public.students s ON s.student_id = ce.student_id
+JOIN public.users u ON u.id = s.user_id
+WHERE cet.course_evaluation_id = ce.id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.course_evaluations ce
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ce.student_id = s.student_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.student_courses sc
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sc.student_id = s.student_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.semester_academic_records sar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sar.student_id = s.student_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.student_academic_records ar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ar.student_id = s.student_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.student_graduation_progress sgp
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sgp.student_id = s.student_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.scrape_job_outbox outbox
+USING public.scrape_jobs job
+JOIN public.users u ON u.id = job.user_id
+WHERE outbox.job_id = job.job_id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.scrape_jobs job
+USING public.users u
+WHERE job.user_id = u.id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.refresh_token rt
+USING public.users u
+WHERE rt.user_id = u.id::text
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.social_accounts sa
+USING public.users u
+WHERE sa.user_id = u.id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.students s
+USING public.users u
+WHERE s.user_id = u.id
+  AND u.email = 'SKIPPED@test.com';
+
+DELETE FROM public.users
+WHERE email = 'SKIPPED@test.com';
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/04_completed_create.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/04_completed_create.sql
@@ -1,0 +1,103 @@
+-- Create COMPLETED@test.com.
+-- State: 2026/10 courses exist, completed grades exist, lecture_evaluation_status = COMPLETED,
+--        and course_evaluations/course_evaluation_tags are pre-populated.
+-- Prerequisite: run 00_shared_catalog.sql first.
+
+BEGIN;
+
+INSERT INTO public.users (
+    id, created_at, updated_at, email, profile_nickname, profile_image,
+    is_deleted, portal_connected, connected_at, deleted_at, last_synced_at
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245004', NOW(), NOW(), 'COMPLETED@test.com',
+    'LEVALPHA COMPLETED', NULL, FALSE, TRUE, NOW(), NULL, NOW()
+);
+
+INSERT INTO public.social_accounts (provider, social_id, email, user_id)
+VALUES ('KAKAO', 'levalpha-completed-245', 'COMPLETED@test.com', '00000000-0000-0000-0000-000000245004');
+
+INSERT INTO public.students (
+    student_id, created_at, updated_at, student_code, name, is_graduated,
+    admission_type, target_gpa, reconnection_required, admission_year,
+    semester_enrolled, is_transfer_student, status, grade_level,
+    completed_semesters, department_id, major_id, secondary_major_id, user_id
+)
+SELECT
+    '00000000-0000-0000-0000-000000245104', NOW(), NOW(), 'LEVALPHA245004',
+    '강의평가 COMPLETED', FALSE, '신입학', 4.0, FALSE, 2023,
+    7, FALSE, '재학', 4, 6, d.id, d.id, NULL,
+    '00000000-0000-0000-0000-000000245004'
+FROM public.departments d
+WHERE d.department_code = 'LEVALPHA';
+
+INSERT INTO public.student_academic_records (
+    id, created_at, updated_at, attempted_credits_gpa, percentile,
+    cumulative_gpa, total_attempted_credits, total_earned_credits, student_id
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245304', NOW(), NOW(),
+    4.10, 90.00, 4.10, 18, 18, '00000000-0000-0000-0000-000000245104'
+);
+
+INSERT INTO public.semester_academic_records (
+    id, created_at, updated_at, semester, year, total_students, class_rank,
+    attempted_credits_gpa, semester_percentile, semester_gpa,
+    attempted_credits, earned_credits, student_id, lecture_evaluation_status
+)
+VALUES (
+    '00000000-0000-0000-0000-000000245204', NOW(), NOW(),
+    10, 2026, 50, 5, 4.10, 90.00, 4.10, 6, 6,
+    '00000000-0000-0000-0000-000000245104', 'COMPLETED'
+);
+
+INSERT INTO public.student_courses (
+    grade, points, is_retake, original_score, created_at,
+    is_retake_deleted, offering_id, student_id
+)
+SELECT
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 'A+' ELSE 'B+' END,
+    3,
+    FALSE,
+    CASE WHEN co.class_section = 'LEVALPHA-A' THEN 95 ELSE 88 END,
+    NOW(),
+    FALSE,
+    co.id,
+    '00000000-0000-0000-0000-000000245104'
+FROM public.course_offerings co
+WHERE co.year = 2026
+  AND co.semester = 10
+  AND co.class_section IN ('LEVALPHA-A', 'LEVALPHA-B');
+
+INSERT INTO public.course_evaluations (
+    created_at, updated_at, student_id, course_id, professor_id,
+    year, semester, review
+)
+SELECT
+    NOW(),
+    NOW(),
+    s.student_id,
+    co.course_id,
+    co.professor_id,
+    2026,
+    10,
+    'COMPLETED@test.com seed evaluation'
+FROM public.students s
+JOIN public.student_courses sc ON sc.student_id = s.student_id
+JOIN public.course_offerings co ON co.id = sc.offering_id
+WHERE s.student_code = 'LEVALPHA245004';
+
+INSERT INTO public.course_evaluation_tags (course_evaluation_id, tag)
+SELECT
+    ce.id,
+    tag_values.tag
+FROM public.course_evaluations ce
+JOIN public.students s ON s.student_id = ce.student_id
+JOIN LATERAL (
+    VALUES ('INTERESTING_LECTURE'), ('LOW_HOMEWORK')
+) AS tag_values(tag) ON TRUE
+WHERE s.student_code = 'LEVALPHA245004'
+  AND ce.year = 2026
+  AND ce.semester = 10;
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/04_completed_delete.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/04_completed_delete.sql
@@ -1,0 +1,71 @@
+-- Delete only COMPLETED@test.com and dependent test rows.
+
+BEGIN;
+
+DELETE FROM public.course_evaluation_tags cet
+USING public.course_evaluations ce
+JOIN public.students s ON s.student_id = ce.student_id
+JOIN public.users u ON u.id = s.user_id
+WHERE cet.course_evaluation_id = ce.id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.course_evaluations ce
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ce.student_id = s.student_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.student_courses sc
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sc.student_id = s.student_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.semester_academic_records sar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sar.student_id = s.student_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.student_academic_records ar
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE ar.student_id = s.student_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.student_graduation_progress sgp
+USING public.students s
+JOIN public.users u ON u.id = s.user_id
+WHERE sgp.student_id = s.student_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.scrape_job_outbox outbox
+USING public.scrape_jobs job
+JOIN public.users u ON u.id = job.user_id
+WHERE outbox.job_id = job.job_id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.scrape_jobs job
+USING public.users u
+WHERE job.user_id = u.id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.refresh_token rt
+USING public.users u
+WHERE rt.user_id = u.id::text
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.social_accounts sa
+USING public.users u
+WHERE sa.user_id = u.id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.students s
+USING public.users u
+WHERE s.user_id = u.id
+  AND u.email = 'COMPLETED@test.com';
+
+DELETE FROM public.users
+WHERE email = 'COMPLETED@test.com';
+
+COMMIT;

--- a/docs/sql/lecture-evaluation-test-accounts/99_verify.sql
+++ b/docs/sql/lecture-evaluation-test-accounts/99_verify.sql
@@ -1,0 +1,30 @@
+-- Verify lecture evaluation FE test accounts.
+
+SELECT
+    u.email,
+    u.id AS user_id,
+    s.student_id,
+    s.student_code,
+    sar.year,
+    sar.semester,
+    sar.lecture_evaluation_status,
+    COUNT(sc.id) AS course_count,
+    COUNT(sc.id) FILTER (WHERE sc.grade = 'IP') AS ip_course_count,
+    COUNT(sc.id) FILTER (WHERE sc.grade IS NOT NULL AND sc.grade <> 'IP') AS completed_course_count
+FROM public.users u
+JOIN public.students s ON s.user_id = u.id
+JOIN public.semester_academic_records sar
+    ON sar.student_id = s.student_id
+   AND sar.year = 2026
+   AND sar.semester = 10
+LEFT JOIN public.student_courses sc ON sc.student_id = s.student_id
+WHERE u.email IN ('NOT@test.com', 'PENDING@test.com', 'SKIPPED@test.com', 'COMPLETED@test.com')
+GROUP BY
+    u.email,
+    u.id,
+    s.student_id,
+    s.student_code,
+    sar.year,
+    sar.semester,
+    sar.lecture_evaluation_status
+ORDER BY u.email;

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
@@ -4,6 +4,7 @@ import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.service.UserService;
+import com.chukchuk.haksa.global.config.ScrapingProperties;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,6 +29,7 @@ public class PortalLinkJobService {
     private final ScrapeJobOutboxDispatcher scrapeJobOutboxDispatcher;
     private final UserService userService;
     private final ObjectMapper objectMapper;
+    private final ScrapingProperties scrapingProperties;
 
     public PortalLinkDto.AcceptedResponse acceptJob(UUID userId, String idempotencyKey, PortalLinkDto.LinkRequest request) {
         validateRequest(idempotencyKey, request);
@@ -113,7 +115,11 @@ public class PortalLinkJobService {
             String idempotencyKey
     ) {
         if (preparedJob.dispatchRequired()) {
-            dispatchSynchronously(preparedJob, request.portal_type(), idempotencyKey);
+            if (isMockInlineMode()) {
+                completeMockInline(preparedJob, request.portal_type(), idempotencyKey);
+            } else {
+                dispatchSynchronously(preparedJob, request.portal_type(), idempotencyKey);
+            }
         }
 
         if (preparedJob.reused()) {
@@ -157,5 +163,25 @@ public class PortalLinkJobService {
                     preparedJob.jobId(), preparedJob.outboxId(), portalType, idempotencyKey, exception);
             throw new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED, exception);
         }
+    }
+
+    private void completeMockInline(
+            PortalLinkJobTxService.PreparedJob preparedJob,
+            String portalType,
+            String idempotencyKey
+    ) {
+        try {
+            portalLinkJobTxService.completeMockInlineJob(preparedJob.outboxId());
+            log.info("[BIZ] scrape.job.mock_inline.completed jobId={} outboxId={} portalType={} idempotencyKey={}",
+                    preparedJob.jobId(), preparedJob.outboxId(), portalType, idempotencyKey);
+        } catch (RuntimeException exception) {
+            log.warn("[BIZ] scrape.job.mock_inline.exception jobId={} outboxId={} portalType={} idempotencyKey={}",
+                    preparedJob.jobId(), preparedJob.outboxId(), portalType, idempotencyKey, exception);
+            throw new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED, exception);
+        }
+    }
+
+    private boolean isMockInlineMode() {
+        return "mock-inline".equalsIgnoreCase(scrapingProperties.getMode());
     }
 }

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobTxService.java
@@ -76,6 +76,19 @@ public class PortalLinkJobTxService {
         );
     }
 
+    @Transactional
+    public void completeMockInlineJob(String outboxId) {
+        ScrapeJobOutbox outbox = scrapeJobOutboxRepository.findForUpdateByOutboxId(outboxId)
+                .orElseThrow(() -> new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED));
+        ScrapeJob job = scrapeJobRepository.findForUpdateByJobId(outbox.getJobId())
+                .orElseThrow(() -> new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED));
+
+        Instant finishedAt = Instant.now();
+        outbox.markSent("mock-inline-" + outbox.getOutboxId(), finishedAt);
+        job.markRunning();
+        job.markSucceeded("{}", finishedAt, finishedAt);
+    }
+
     private PreparedJob createNewJob(
             UUID userId,
             String idempotencyKey,

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobServiceUnitTests.java
@@ -6,6 +6,7 @@ import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobOperationType;
 import com.chukchuk.haksa.domain.scrapejob.model.ScrapeJobStatus;
 import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.service.UserService;
+import com.chukchuk.haksa.global.config.ScrapingProperties;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,7 +43,7 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("새 요청은 job/outbox 저장 후 같은 요청에서 동기 publish 한다")
     void acceptLinkJob_dispatchesSynchronously() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
+        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules(), scrapingProperties("async"));
         PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", false, true);
 
@@ -70,7 +71,7 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("이미 RUNNING 이상인 동일 요청은 기존 job을 재사용하고 publish 하지 않는다")
     void acceptLinkJob_reusesExistingJobWithoutDispatch() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
+        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules(), scrapingProperties("async"));
         PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", true, false);
 
@@ -88,7 +89,7 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("동기 publish 후 SENT/RUNNING이 아니면 enqueue 실패로 처리한다")
     void acceptLinkJob_throwsWhenDispatchStateIsNotSent() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
+        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules(), scrapingProperties("async"));
         PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", false, true);
 
@@ -114,7 +115,7 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("동시성으로 최초 저장이 충돌하면 기존 job을 다시 조회해 같은 요청 흐름에서 publish 한다")
     void acceptLinkJob_resolvesConcurrentDuplicateAndDispatches() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
+        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules(), scrapingProperties("async"));
         PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", true, true);
 
@@ -138,11 +139,47 @@ class PortalLinkJobServiceUnitTests {
         verify(scrapeJobOutboxDispatcher).dispatchOnce("outbox-1");
     }
 
+    @Test
+    @DisplayName("mock-inline 모드는 SQS publish 없이 job을 성공 처리한다")
+    void acceptLinkJob_mockInlineCompletesWithoutDispatch() {
+        UUID userId = UUID.randomUUID();
+        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules(), scrapingProperties("mock-inline"));
+        PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "LEVALPHA245002", "pw");
+        PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", false, true);
+
+        when(userService.getUserById(userId)).thenReturn(connectedUser(userId));
+        when(portalLinkJobTxService.createOrLoadJob(eq(userId), eq("idem-1"), eq("suwon"), eq(ScrapeJobOperationType.REFRESH), any(), any(), eq("LEVALPHA245002"), eq("pw"), any()))
+                .thenReturn(preparedJob);
+
+        PortalLinkDto.AcceptedResponse response = service.acceptJob(userId, "idem-1", request);
+
+        assertThat(response.job_id()).isEqualTo("job-1");
+        assertThat(response.status()).isEqualTo("accepted");
+        verify(portalLinkJobTxService).completeMockInlineJob("outbox-1");
+        verify(scrapeJobOutboxDispatcher, never()).dispatchOnce(any());
+    }
+
     private static User disconnectedUser(UUID userId) {
         return User.builder()
                 .id(userId)
                 .email("disconnected@example.com")
                 .profileNickname("tester")
                 .build();
+    }
+
+    private static User connectedUser(UUID userId) {
+        User user = User.builder()
+                .id(userId)
+                .email("connected@example.com")
+                .profileNickname("tester")
+                .build();
+        user.markPortalConnected(java.time.Instant.now());
+        return user;
+    }
+
+    private static ScrapingProperties scrapingProperties(String mode) {
+        ScrapingProperties properties = new ScrapingProperties();
+        properties.setMode(mode);
+        return properties;
     }
 }


### PR DESCRIPTION
## 목적

이 PR은 dev 병합 목적이 아니라 FE 강의평가 플로우 검증용 alpha Lambda 배포 SHA를 만들기 위한 alpha 전용 변경입니다.

## 변경 사항

1. `scraping.mode=mock-inline`일 때 `/portal/link`가 SQS/scraper/S3를 우회하고 scrape job을 즉시 `SUCCEEDED` 처리합니다.
2. 기존 `async` 모드는 변경하지 않아 dev/prod 기본 동작은 기존 SQS publish 경로를 유지합니다.
3. `NOT/PENDING/SKIPPED/COMPLETED@test.com` 계정별 delete/create SQL seed를 분리했습니다.

## 배포/운영 의도

- 이 브랜치의 커밋 SHA로 `portal-mock-test-api` alpha Lambda를 생성/배포합니다.
- alpha Lambda env에 `SCRAPING_MODE=mock-inline`을 설정해야 mock 경로가 활성화됩니다.
- `LECTURE_EVALUATION_TARGET_YEAR=2026`, `LECTURE_EVALUATION_TARGET_SEMESTER=10` 기준입니다.
- Function URL은 FE 테스트용 backend base URL로 사용합니다.

## 검증

- `./gradlew test --tests 'com.chukchuk.haksa.application.portal.PortalLinkJobServiceUnitTests' --tests 'com.chukchuk.haksa.domain.lectureevaluations.service.LectureEvaluationServiceUnitTests' --tests 'com.chukchuk.haksa.global.db.FlywayMigrationTest'`
- `./gradlew test`
- `./gradlew clean lambdaZip -x test`

## 리스크

- dev 병합 대상 변경이 아닙니다. 테스트 종료 후 PR close 또는 branch 삭제 대상입니다.
- seed SQL은 dev DB 테스트 계정 데이터를 삭제/재생성합니다.
