### PR TITLE
267 feat: 포털 로그인 검증 분리

### DIFF
--- a/docs/specs/20260616-portal-login-split/checklist.md
+++ b/docs/specs/20260616-portal-login-split/checklist.md
@@ -1,0 +1,16 @@
+# 포털 로그인 검증 분리 Checklist
+
+- [x] `feat/267` 격리 worktree 생성.
+- [x] 현재 포털 연동 API 구조 확인.
+- [x] spec bundle 생성.
+- [x] baseline 테스트 확인.
+- [x] 단일 `/portal/link` 선검증 구현.
+- [x] 광고 UX 기준으로 `/portal/login`과 `/portal/link` 분리 결정.
+- [x] `/portal/login` 실패 테스트 작성.
+- [x] verification token 실패 테스트 작성.
+- [x] `/portal/link` token 검증 실패 테스트 작성.
+- [x] 최소 구현.
+- [x] OpenAPI 문서 갱신.
+- [x] 관련 테스트 실행.
+- [x] 전체 테스트 실행.
+- [x] 커밋 생성.

--- a/docs/specs/20260616-portal-login-split/clarify.md
+++ b/docs/specs/20260616-portal-login-split/clarify.md
@@ -1,0 +1,18 @@
+# 포털 연동 로그인 선검증 Clarify
+
+## 결정 사항
+
+- 클라이언트는 `POST /portal/login`으로 포털 ID/PW를 먼저 검증한다.
+- 로그인 검증 실패 시 광고를 보여주지 않는다.
+- 로그인 검증 성공 시 backend는 `portal_verification_token`을 반환한다.
+- 클라이언트는 `POST /portal/link`를 호출해 job 생성을 요청하고, 202 응답을 받으면 바로 광고를 보여준다.
+- 광고 시간과 스크래핑 job 실행 시간을 겹친다.
+- `POST /portal/link`는 `portal_verification_token`을 검증한 뒤 job 생성과 outbox 발행을 진행한다.
+- token 검증 실패 시 스크래핑 job을 만들지 않는다.
+- `/portal/link` 호출 시 포털 ID/PW는 다시 전송하지만, 사용자가 다시 입력하지는 않는다.
+
+## 남은 확인 사항
+
+- 스크래퍼 쪽에 `POST /login` 경량 엔드포인트가 필요하다.
+- 스크래퍼 `POST /login`은 포털 로그인과 `sso_security_check` 세션 핸드오프 성공을 검증 기준으로 삼는다.
+- 스크래퍼 `POST /login`은 ID/PW 오류 401, 계정 잠금 423, 시스템 오류 5xx를 반환해야 한다.

--- a/docs/specs/20260616-portal-login-split/context-notes.md
+++ b/docs/specs/20260616-portal-login-split/context-notes.md
@@ -1,0 +1,22 @@
+# 포털 연동 로그인 선검증 Context Notes
+
+## 2026-06-16
+
+- 현재 루트 worktree는 `feat/263`이고 사용자 변경 파일이 남아 있어 `/private/tmp/haksa-feat-267`에 격리 worktree를 만들었다.
+- `feat/267`은 최신 `origin/dev` 기준으로 생성했다.
+- 현재 `POST /portal/link`는 포털 자격 증명을 받아 스크래핑 job을 만들고 202를 반환한다.
+- 로그인 검증 실패가 job 실행 경로에 묶이는 UX 문제를 줄이기 위해 `POST /portal/link` 내부에서 로그인 선검증을 수행하는 방향으로 진행한다.
+- 스크래퍼 또는 Lambda 쪽 `POST /login` 경량 검증 경로가 필요하며, 이번 backend 변경은 그 경로를 전제로 한다.
+- baseline으로 `PortalLinkJobServiceUnitTests`와 `PortalLinkControllerApiIntegrationTest`를 실행했고 통과했다.
+- RED 테스트로 `PortalLinkJobServiceUnitTests`에 로그인 선검증 순서와 검증 실패 시 job 미생성 케이스를 추가했고, `PortalLinkJobService` constructor가 `PortalLoginVerifier`를 받지 않아 컴파일 실패하는 것을 확인했다.
+- `PortalLinkJobService`가 요청 검증 후 `PortalLoginVerifier.verify(...)`를 먼저 호출하고, 성공한 경우에만 user 조회와 job 생성을 진행하도록 변경했다.
+- `PortalClient.validateLogin`은 `crawler.base-url + /login`으로 POST 요청을 보내며, 401은 기존 `PORTAL_LOGIN_FAILED`로 매핑한다.
+- 관련 테스트 묶음은 통과했다.
+- 광고 UX가 추가되면서 단일 `/portal/link` 선검증 구조는 실패 사용자에게 광고가 노출될 수 있어 부적합하다고 판단했다.
+- 최종 흐름은 `POST /portal/login`으로 ID/PW를 먼저 검증하고, 성공 시 `portal_verification_token`을 반환하는 구조다.
+- 클라이언트는 `POST /portal/link`를 호출해 202 응답을 받은 직후 광고를 보여준다.
+- `POST /portal/link`는 포털 ID/PW와 `portal_verification_token`을 함께 받고, token 검증 성공 시에만 job을 만든다.
+- token은 서버 저장소 없이 HMAC 서명 기반 stateless token으로 발급한다.
+- token에는 비밀번호 원문을 넣지 않고 credential fingerprint만 포함한다.
+- `/portal/login`, token service, `/portal/link` token 검증, OpenAPI 테스트를 추가했고 관련 테스트 묶음은 통과했다.
+- `./gradlew test`와 `git diff --check`가 통과했다.

--- a/docs/specs/20260616-portal-login-split/context-notes.md
+++ b/docs/specs/20260616-portal-login-split/context-notes.md
@@ -16,7 +16,8 @@
 - 최종 흐름은 `POST /portal/login`으로 ID/PW를 먼저 검증하고, 성공 시 `portal_verification_token`을 반환하는 구조다.
 - 클라이언트는 `POST /portal/link`를 호출해 202 응답을 받은 직후 광고를 보여준다.
 - `POST /portal/link`는 포털 ID/PW와 `portal_verification_token`을 함께 받고, token 검증 성공 시에만 job을 만든다.
-- token은 서버 저장소 없이 HMAC 서명 기반 stateless token으로 발급한다.
-- token에는 비밀번호 원문을 넣지 않고 credential fingerprint만 포함한다.
+- token은 서버 저장소 없이 `jjwt` 기반 HMAC 서명 JWT로 발급한다.
+- token payload에는 비밀번호 원문이나 비밀번호 기반 fingerprint를 넣지 않는다.
+- 비밀번호 일치 여부는 `/portal/link`에서 다시 제출된 비밀번호로 token 서명을 재계산해 확인한다.
 - `/portal/login`, token service, `/portal/link` token 검증, OpenAPI 테스트를 추가했고 관련 테스트 묶음은 통과했다.
 - `./gradlew test`와 `git diff --check`가 통과했다.

--- a/docs/specs/20260616-portal-login-split/plan.md
+++ b/docs/specs/20260616-portal-login-split/plan.md
@@ -1,0 +1,23 @@
+# 포털 로그인 검증 분리 Plan
+
+1. 현재 포털 연동 controller, DTO, docs, OpenAPI 테스트 구조를 확인한다.
+2. `POST /portal/login` controller 테스트와 `PortalLoginService` 실패 테스트를 작성한다.
+3. `PortalLoginVerificationTokenService`의 발급, 검증, 만료 실패 테스트를 작성한다.
+4. `PortalLinkJobService`가 job 생성 전에 token을 검증하는 실패 테스트를 작성한다.
+5. `PortalLoginVerifier`와 `PortalClient.validateLogin`을 유지해 스크래퍼 `/login` 호출 경계를 둔다.
+6. `PortalLoginService`, `PortalLoginVerificationTokenService`, `PortalLoginController`를 추가한다.
+7. `PortalLinkJobService`를 token 검증 기반으로 변경한다.
+8. OpenAPI와 static API 문서를 갱신한다.
+9. 관련 테스트를 통과시킨 뒤 전체 테스트를 실행한다.
+
+## 검증 명령
+
+- `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLoginServiceUnitTests`.
+- `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLoginVerificationTokenServiceUnitTests`.
+- `./gradlew test --tests com.chukchuk.haksa.application.portal.PortalLinkJobServiceUnitTests`.
+- `./gradlew test --tests com.chukchuk.haksa.infrastructure.portal.client.PortalClientTests`.
+- `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLoginControllerApiIntegrationTest`.
+- `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkControllerApiIntegrationTest`.
+- `./gradlew test --tests com.chukchuk.haksa.domain.portal.controller.PortalLinkOpenApiTest`.
+- `./gradlew test --tests com.chukchuk.haksa.global.config.OpenApiResponseContractTest`.
+- API와 공개 계약 변경이므로 최종적으로 `./gradlew test`를 실행한다.

--- a/docs/specs/20260616-portal-login-split/spec.md
+++ b/docs/specs/20260616-portal-login-split/spec.md
@@ -1,0 +1,117 @@
+# 포털 로그인 검증 분리 Spec
+
+## 배경
+
+현재 포털 연동 시작 API는 `POST /portal/link` 하나로 포털 ID/PW 입력, 스크래핑 job 생성, outbox 발행까지 처리한다.
+이 구조에서는 포털 ID/PW 검증 실패도 스크래핑 실행 경로에 종속된다.
+
+ECS, EC2 기반 상시 실행 구조에서는 스크래핑 서버가 이미 떠 있어 실패 피드백이 비교적 빠르게 돌아왔다.
+하지만 요청 기반 Lambda 구조에서는 cold start와 스크래핑 초기화 비용 때문에 포털 인증 실패를 확인하는 데 30~60초 가까이 걸릴 수 있다.
+또한 포털 연동 과정에 광고가 추가되면, 로그인 실패 사용자에게도 광고가 먼저 노출될 수 있다.
+
+## 문제
+
+- 사용자가 포털 ID/PW를 잘못 입력해도 스크래핑 job 경로를 기다려야 한다.
+- 인증 실패가 job 생성 이후 polling 결과로 드러나면 첫 연동 UX가 불필요하게 느려진다.
+- 포털 로그인 실패 사용자에게 광고를 보여주면 “실패할 요청인데 광고부터 봤다”는 경험이 된다.
+- 광고 시간과 스크래핑 시간을 겹치려면 로그인 검증과 job 생성을 분리하되, job 생성은 광고 시작 전에 끝나야 한다.
+
+## 목표
+
+- 클라이언트는 먼저 `POST /portal/login`으로 포털 ID/PW를 검증한다.
+- 포털 ID/PW 검증 실패 시 광고를 보여주지 않고 즉시 실패 응답을 반환한다.
+- 검증 성공 시 `portal_verification_token`을 반환한다.
+- 클라이언트는 `POST /portal/link`를 호출해 스크래핑 job을 생성하고, 202 응답 직후 광고를 보여준다.
+- `POST /portal/link`는 `portal_verification_token`을 검증한 경우에만 job 생성과 outbox 발행을 수행한다.
+
+## 범위
+
+### 포함
+
+- `POST /portal/login` 추가.
+- 로그인 검증 성공 시 짧은 TTL의 `portal_verification_token` 발급.
+- `POST /portal/link` 요청에 `portal_verification_token` 필드 추가.
+- token 검증 실패 시 `ScrapeJob`과 `ScrapeJobOutbox`가 생성되지 않도록 보장.
+- 스크래퍼의 경량 로그인 검증 엔드포인트 호출 경계 추가.
+- service, token, controller, 스크래퍼 client 테스트 추가.
+
+### 제외
+
+- Lambda cold start 자체를 제거하는 인프라 변경.
+- 스크래퍼 워커의 내부 로그인 구현 변경.
+- 기존 스크래핑 job callback 처리 변경.
+- 기존 polling endpoint 변경.
+- 광고 SDK 연동과 광고 완료 증빙 검증.
+
+## API 계약
+
+### `POST /portal/login`
+
+인증된 사용자가 포털 ID/PW를 입력하면 backend가 스크래퍼의 경량 로그인 검증 경로를 호출한다.
+검증에 성공하면 `portal_verification_token`을 반환한다.
+이 API는 스크래핑 job을 생성하지 않는다.
+
+```json
+{
+  "portal_type": "suwon",
+  "username": "17019013",
+  "password": "pw"
+}
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "portal_verification_token": "token"
+  },
+  "message": "요청 성공"
+}
+```
+
+### `POST /portal/link`
+
+인증된 사용자가 포털 ID/PW와 `portal_verification_token`을 함께 보내면 backend가 token을 검증한다.
+검증에 성공한 경우에만 스크래핑 job을 생성하고 기존과 동일하게 202 응답을 반환한다.
+클라이언트는 202 응답을 받은 직후 광고를 보여주고, 광고가 끝나면 기존 polling 흐름으로 job 상태를 확인한다.
+
+```json
+{
+  "portal_type": "suwon",
+  "username": "17019013",
+  "password": "pw",
+  "portal_verification_token": "token"
+}
+```
+
+실패 응답은 기존 에러 코드 정책을 따른다.
+
+- 잘못된 입력은 `INVALID_ARGUMENT`.
+- 지원하지 않는 포털 타입은 `UNSUPPORTED_PORTAL_TYPE`.
+- 포털 ID/PW 불일치는 `POST /portal/login`에서 `PORTAL_LOGIN_FAILED`.
+- 계정 잠금은 `POST /portal/login`에서 `PORTAL_ACCOUNT_LOCKED`.
+- token 누락, 만료, 불일치는 `INVALID_ARGUMENT`.
+
+## 구현 방향
+
+현재 backend에는 포털 인증만 수행하는 외부 클라이언트가 없다.
+따라서 `PortalLoginVerifier` 인터페이스를 application 계층에 두고, 실제 구현은 infrastructure 계층에서 스크래퍼의 경량 로그인 검증 엔드포인트에 연결한다.
+
+이번 변경의 backend 책임은 다음 경계로 제한한다.
+
+- `PortalLoginService`가 `PortalLoginVerifier`를 호출하고 `PortalLoginVerificationTokenService`로 token을 발급한다.
+- token은 서버 저장 없이 HMAC 서명 기반 stateless token으로 발급한다.
+- token에는 비밀번호 원문을 넣지 않고, 사용자와 포털 타입, username hash, credential fingerprint, 만료 시각만 서명 대상에 포함한다.
+- `PortalLinkJobService`는 job 생성 전에 token을 검증한다.
+- token 검증 실패 시 job을 생성하지 않는 흐름을 보장한다.
+- 실제 포털 검증 구현체는 스크래퍼 검증 경로에 맞춰 연결할 수 있도록 인터페이스로 분리한다.
+
+## 테스트 기준
+
+- `POST /portal/login`은 포털 로그인 검증 후 `portal_verification_token`을 반환한다.
+- 로그인 검증 실패 예외가 발생하면 token을 발급하지 않는다.
+- 발급한 token은 같은 사용자와 같은 자격 증명에서만 검증된다.
+- 만료되거나 다른 비밀번호로 제출된 token은 거부된다.
+- `POST /portal/link`는 token 검증을 job 생성보다 먼저 실행한다.
+- token 검증 실패 시 `ScrapeJob`이나 `ScrapeJobOutbox`를 생성하지 않는다.
+- `PortalClient`는 스크래퍼의 `/login` 엔드포인트를 호출하고 401을 `PORTAL_LOGIN_FAILED`로 매핑한다.

--- a/docs/specs/20260616-portal-login-split/spec.md
+++ b/docs/specs/20260616-portal-login-split/spec.md
@@ -100,8 +100,9 @@ ECS, EC2 기반 상시 실행 구조에서는 스크래핑 서버가 이미 떠 
 이번 변경의 backend 책임은 다음 경계로 제한한다.
 
 - `PortalLoginService`가 `PortalLoginVerifier`를 호출하고 `PortalLoginVerificationTokenService`로 token을 발급한다.
-- token은 서버 저장 없이 HMAC 서명 기반 stateless token으로 발급한다.
-- token에는 비밀번호 원문을 넣지 않고, 사용자와 포털 타입, username hash, credential fingerprint, 만료 시각만 서명 대상에 포함한다.
+- token은 서버 저장 없이 `jjwt` 기반 HMAC 서명 JWT로 발급한다.
+- token payload에는 사용자와 포털 타입, username hash, 만료 시각만 포함한다.
+- 비밀번호는 token payload에 넣지 않고, token 서명 입력에만 사용해 `/portal/link`에서 다시 제출된 비밀번호가 로그인 검증 당시 값과 같은지 확인한다.
 - `PortalLinkJobService`는 job 생성 전에 token을 검증한다.
 - token 검증 실패 시 job을 생성하지 않는 흐름을 보장한다.
 - 실제 포털 검증 구현체는 스크래퍼 검증 경로에 맞춰 연결할 수 있도록 인터페이스로 분리한다.

--- a/docs/specs/20260616-portal-login-split/tasks.md
+++ b/docs/specs/20260616-portal-login-split/tasks.md
@@ -1,0 +1,17 @@
+# 포털 로그인 검증 분리 Tasks
+
+- [x] 현재 포털 controller와 테스트 패턴 확인.
+- [x] `POST /portal/login` controller 실패 테스트 작성.
+- [x] `PortalLoginServiceUnitTests` 실패 테스트 작성.
+- [x] `PortalLoginVerificationTokenServiceUnitTests` 실패 테스트 작성.
+- [x] `PortalLinkJobServiceUnitTests` token 검증 실패 테스트로 변경.
+- [x] 포털 로그인 verifier 인터페이스와 `PortalClient.validateLogin` 유지.
+- [x] `PortalLoginService` 추가.
+- [x] `PortalLoginVerificationTokenService` 추가.
+- [x] `PortalLoginController` 추가.
+- [x] `PortalLinkJobService` token 검증 연결.
+- [x] 생성 OpenAPI 테스트 갱신.
+- [x] static OpenAPI 문서 갱신.
+- [x] 관련 테스트 통과 확인.
+- [x] 전체 테스트 통과 확인.
+- [x] 논리 단위 커밋 생성.

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLinkJobService.java
@@ -28,9 +28,11 @@ public class PortalLinkJobService {
     private final ScrapeJobOutboxDispatcher scrapeJobOutboxDispatcher;
     private final UserService userService;
     private final ObjectMapper objectMapper;
+    private final PortalLoginVerificationTokenService tokenService;
 
     public PortalLinkDto.AcceptedResponse acceptJob(UUID userId, String idempotencyKey, PortalLinkDto.LinkRequest request) {
         validateRequest(idempotencyKey, request);
+        tokenService.verify(userId, request.portal_type(), request.username(), request.password(), request.portal_verification_token());
 
         User user = userService.getUserById(userId);
         ScrapeJobOperationType operationType = Boolean.TRUE.equals(user.getPortalConnected())
@@ -90,6 +92,9 @@ public class PortalLinkJobService {
             throw new CommonException(ErrorCode.INVALID_ARGUMENT);
         }
         if (request.username() == null || request.username().isBlank() || request.password() == null || request.password().isBlank()) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT);
+        }
+        if (request.portal_verification_token() == null || request.portal_verification_token().isBlank()) {
             throw new CommonException(ErrorCode.INVALID_ARGUMENT);
         }
         if (!"suwon".equals(normalize(request.portal_type()))) {

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginService.java
@@ -1,0 +1,38 @@
+// 포털 로그인 검증 후 연동용 검증 token을 발급하는 서비스
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PortalLoginService {
+
+    private final PortalLoginVerifier portalLoginVerifier;
+    private final PortalLoginVerificationTokenService tokenService;
+
+    public PortalLinkDto.LoginResponse login(UUID userId, PortalLinkDto.LoginRequest request) {
+        validateRequest(request);
+        portalLoginVerifier.verify(request.portal_type(), request.username(), request.password());
+        String token = tokenService.issue(userId, request.portal_type(), request.username(), request.password());
+        return new PortalLinkDto.LoginResponse(token);
+    }
+
+    private void validateRequest(PortalLinkDto.LoginRequest request) {
+        if (request.username() == null || request.username().isBlank() || request.password() == null || request.password().isBlank()) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT);
+        }
+        if (!"suwon".equals(normalize(request.portal_type()))) {
+            throw new CommonException(ErrorCode.UNSUPPORTED_PORTAL_TYPE);
+        }
+    }
+
+    private String normalize(String portalType) {
+        return portalType == null ? "" : portalType.trim().toLowerCase();
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
@@ -13,8 +13,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.security.Key;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -104,8 +105,8 @@ public class PortalLoginVerificationTokenService {
     private byte[] hashBytes(String value) {
         try {
             return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
-        } catch (Exception exception) {
-            throw new CommonException(ErrorCode.INVALID_ARGUMENT, exception);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 algorithm not available", exception);
         }
     }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
@@ -3,25 +3,30 @@ package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.Key;
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Base64;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HexFormat;
 import java.util.UUID;
 
 @Service
 public class PortalLoginVerificationTokenService {
 
-    private static final String VERSION = "v1";
-    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final String PORTAL_TYPE_CLAIM = "portal_type";
+    private static final String USERNAME_HASH_CLAIM = "username_hash";
 
     private final String secret;
     private final Duration ttl;
@@ -45,8 +50,16 @@ public class PortalLoginVerificationTokenService {
     }
 
     public String issue(UUID userId, String portalType, String username, String password) {
-        String canonical = canonicalPayload(userId, portalType, username, password);
-        return encode(canonical) + "." + encode(hmac(canonical));
+        Instant now = clock.instant();
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim(PORTAL_TYPE_CLAIM, normalize(portalType))
+                .claim(USERNAME_HASH_CLAIM, hash(normalizeUsername(username)))
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(ttl)))
+                .setId(UUID.randomUUID().toString())
+                .signWith(signingKey(portalType, username, password), SignatureAlgorithm.HS256)
+                .compact();
     }
 
     public void verify(UUID userId, String portalType, String username, String password, String token) {
@@ -54,102 +67,45 @@ public class PortalLoginVerificationTokenService {
             throw invalidToken();
         }
 
-        String[] parts = token.split("\\.", -1);
-        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
-            throw invalidToken();
-        }
-
-        String canonical = decodeToString(parts[0]);
-        byte[] expectedSignature = hmac(canonical);
-        byte[] actualSignature = decodeToBytes(parts[1]);
-        if (!MessageDigest.isEqual(expectedSignature, actualSignature)) {
-            throw invalidToken();
-        }
-
-        String[] fields = canonical.split("\\|", -1);
-        if (fields.length != 7) {
-            throw invalidToken();
-        }
-        if (!VERSION.equals(fields[0])) {
-            throw invalidToken();
-        }
-        if (!userId.toString().equals(fields[1])) {
-            throw invalidToken();
-        }
-        if (!normalize(portalType).equals(fields[2])) {
-            throw invalidToken();
-        }
-        if (!hash(normalizeUsername(username)).equals(fields[3])) {
-            throw invalidToken();
-        }
-        if (!credentialFingerprint(portalType, username, password).equals(fields[4])) {
-            throw invalidToken();
-        }
-        if (clock.instant().getEpochSecond() > parseExpiresAt(fields[5])) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(signingKey(portalType, username, password))
+                    .setClock(() -> Date.from(clock.instant()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            if (!userId.toString().equals(claims.getSubject())) {
+                throw invalidToken();
+            }
+            if (!normalize(portalType).equals(claims.get(PORTAL_TYPE_CLAIM, String.class))) {
+                throw invalidToken();
+            }
+            if (!hash(normalizeUsername(username)).equals(claims.get(USERNAME_HASH_CLAIM, String.class))) {
+                throw invalidToken();
+            }
+        } catch (JwtException | IllegalArgumentException exception) {
             throw invalidToken();
         }
     }
 
-    private String canonicalPayload(UUID userId, String portalType, String username, String password) {
-        long expiresAt = clock.instant().plus(ttl).getEpochSecond();
-        return String.join("|",
-                VERSION,
-                userId.toString(),
+    private Key signingKey(String portalType, String username, String password) {
+        return Keys.hmacShaKeyFor(hashBytes(String.join("\n",
+                secret,
                 normalize(portalType),
-                hash(normalizeUsername(username)),
-                credentialFingerprint(portalType, username, password),
-                String.valueOf(expiresAt),
-                UUID.randomUUID().toString()
-        );
-    }
-
-    private String credentialFingerprint(String portalType, String username, String password) {
-        return hash(String.join("\n", normalize(portalType), normalizeUsername(username), password));
-    }
-
-    private long parseExpiresAt(String value) {
-        try {
-            return Long.parseLong(value);
-        } catch (NumberFormatException exception) {
-            throw invalidToken();
-        }
-    }
-
-    private byte[] hmac(String value) {
-        try {
-            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
-            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
-            return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
-        } catch (Exception exception) {
-            throw new CommonException(ErrorCode.INVALID_ARGUMENT, exception);
-        }
+                normalizeUsername(username),
+                password == null ? "" : password
+        )));
     }
 
     private String hash(String value) {
+        return HexFormat.of().formatHex(hashBytes(value));
+    }
+
+    private byte[] hashBytes(String value) {
         try {
-            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+            return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
         } catch (Exception exception) {
             throw new CommonException(ErrorCode.INVALID_ARGUMENT, exception);
-        }
-    }
-
-    private String encode(String value) {
-        return encode(value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private String encode(byte[] value) {
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(value);
-    }
-
-    private String decodeToString(String value) {
-        return new String(decodeToBytes(value), StandardCharsets.UTF_8);
-    }
-
-    private byte[] decodeToBytes(String value) {
-        try {
-            return Base64.getUrlDecoder().decode(value);
-        } catch (IllegalArgumentException exception) {
-            throw invalidToken();
         }
     }
 

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenService.java
@@ -1,0 +1,167 @@
+// 포털 로그인 검증 token을 stateless 방식으로 발급하고 검증하는 서비스
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.UUID;
+
+@Service
+public class PortalLoginVerificationTokenService {
+
+    private static final String VERSION = "v1";
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    private final String secret;
+    private final Duration ttl;
+    private final Clock clock;
+
+    @Autowired
+    public PortalLoginVerificationTokenService(
+            @Value("${portal.login-verification.secret}") String secret,
+            @Value("${portal.login-verification.ttl-seconds:300}") long ttlSeconds
+    ) {
+        this(secret, Duration.ofSeconds(ttlSeconds), Clock.systemUTC());
+    }
+
+    PortalLoginVerificationTokenService(String secret, Duration ttl, Clock clock) {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException("Portal login verification secret must not be blank");
+        }
+        this.secret = secret;
+        this.ttl = ttl;
+        this.clock = clock;
+    }
+
+    public String issue(UUID userId, String portalType, String username, String password) {
+        String canonical = canonicalPayload(userId, portalType, username, password);
+        return encode(canonical) + "." + encode(hmac(canonical));
+    }
+
+    public void verify(UUID userId, String portalType, String username, String password, String token) {
+        if (token == null || token.isBlank()) {
+            throw invalidToken();
+        }
+
+        String[] parts = token.split("\\.", -1);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw invalidToken();
+        }
+
+        String canonical = decodeToString(parts[0]);
+        byte[] expectedSignature = hmac(canonical);
+        byte[] actualSignature = decodeToBytes(parts[1]);
+        if (!MessageDigest.isEqual(expectedSignature, actualSignature)) {
+            throw invalidToken();
+        }
+
+        String[] fields = canonical.split("\\|", -1);
+        if (fields.length != 7) {
+            throw invalidToken();
+        }
+        if (!VERSION.equals(fields[0])) {
+            throw invalidToken();
+        }
+        if (!userId.toString().equals(fields[1])) {
+            throw invalidToken();
+        }
+        if (!normalize(portalType).equals(fields[2])) {
+            throw invalidToken();
+        }
+        if (!hash(normalizeUsername(username)).equals(fields[3])) {
+            throw invalidToken();
+        }
+        if (!credentialFingerprint(portalType, username, password).equals(fields[4])) {
+            throw invalidToken();
+        }
+        if (clock.instant().getEpochSecond() > parseExpiresAt(fields[5])) {
+            throw invalidToken();
+        }
+    }
+
+    private String canonicalPayload(UUID userId, String portalType, String username, String password) {
+        long expiresAt = clock.instant().plus(ttl).getEpochSecond();
+        return String.join("|",
+                VERSION,
+                userId.toString(),
+                normalize(portalType),
+                hash(normalizeUsername(username)),
+                credentialFingerprint(portalType, username, password),
+                String.valueOf(expiresAt),
+                UUID.randomUUID().toString()
+        );
+    }
+
+    private String credentialFingerprint(String portalType, String username, String password) {
+        return hash(String.join("\n", normalize(portalType), normalizeUsername(username), password));
+    }
+
+    private long parseExpiresAt(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException exception) {
+            throw invalidToken();
+        }
+    }
+
+    private byte[] hmac(String value) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+            return mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception exception) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT, exception);
+        }
+    }
+
+    private String hash(String value) {
+        try {
+            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT, exception);
+        }
+    }
+
+    private String encode(String value) {
+        return encode(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String encode(byte[] value) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value);
+    }
+
+    private String decodeToString(String value) {
+        return new String(decodeToBytes(value), StandardCharsets.UTF_8);
+    }
+
+    private byte[] decodeToBytes(String value) {
+        try {
+            return Base64.getUrlDecoder().decode(value);
+        } catch (IllegalArgumentException exception) {
+            throw invalidToken();
+        }
+    }
+
+    private String normalize(String portalType) {
+        return portalType == null ? "" : portalType.trim().toLowerCase();
+    }
+
+    private String normalizeUsername(String username) {
+        return username == null ? "" : username.trim();
+    }
+
+    private CommonException invalidToken() {
+        return new CommonException(ErrorCode.INVALID_ARGUMENT);
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerifier.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalLoginVerifier.java
@@ -1,0 +1,7 @@
+// 포털 로그인 검증을 외부 구현과 분리하는 인터페이스
+package com.chukchuk.haksa.application.portal;
+
+public interface PortalLoginVerifier {
+
+    void verify(String portalType, String username, String password);
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalLoginController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/PortalLoginController.java
@@ -1,0 +1,33 @@
+// 포털 로그인 검증 요청을 처리하는 컨트롤러
+package com.chukchuk.haksa.domain.portal.controller;
+
+import com.chukchuk.haksa.application.portal.PortalLoginService;
+import com.chukchuk.haksa.domain.portal.controller.docs.PortalLoginControllerDocs;
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import com.chukchuk.haksa.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/portal")
+@RequiredArgsConstructor
+public class PortalLoginController implements PortalLoginControllerDocs {
+
+    private final PortalLoginService portalLoginService;
+
+    @PostMapping("/login")
+    public ResponseEntity<SuccessResponse<PortalLinkDto.LoginResponse>> verifyPortalLogin(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PortalLinkDto.LoginRequest request
+    ) {
+        PortalLinkDto.LoginResponse response = portalLoginService.login(userDetails.getId(), request);
+        return ResponseEntity.ok(SuccessResponse.of(response));
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLoginControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/controller/docs/PortalLoginControllerDocs.java
@@ -1,13 +1,12 @@
+// 포털 로그인 검증 API의 Swagger 문서 계약
 package com.chukchuk.haksa.domain.portal.controller.docs;
 
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
-import com.chukchuk.haksa.domain.portal.wrapper.PortalLinkAcceptedApiResponse;
+import com.chukchuk.haksa.domain.portal.wrapper.PortalLoginApiResponse;
 import com.chukchuk.haksa.global.common.response.SuccessResponse;
 import com.chukchuk.haksa.global.common.response.wrapper.ErrorResponseWrapper;
 import com.chukchuk.haksa.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,35 +17,31 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Portal Link", description = "비동기 포털 연동 job 생성 및 폴링 안내")
-public interface PortalLinkCommandControllerDocs {
+public interface PortalLoginControllerDocs {
 
     @Operation(
-            summary = "포털 연동 job 생성",
-            description = "포털 로그인 verification token을 검증한 뒤 비동기 스크래핑 job을 생성하고 polling endpoint를 반환합니다.",
+            summary = "포털 로그인 검증",
+            description = "포털 ID/PW를 검증하고 포털 연동 job 생성에 사용할 verification token을 반환합니다.",
             responses = {
-                    @ApiResponse(responseCode = "202", description = "요청 수락",
+                    @ApiResponse(responseCode = "200", description = "로그인 검증 성공",
                             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                    schema = @Schema(implementation = PortalLinkAcceptedApiResponse.class))),
+                                    schema = @Schema(implementation = PortalLoginApiResponse.class))),
                     @ApiResponse(responseCode = "400", description = "잘못된 입력 (INVALID_ARGUMENT)",
                             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @ApiResponse(responseCode = "401", description = "인증 실패",
+                    @ApiResponse(responseCode = "401", description = "자격 증명 오류 (PORTAL_LOGIN_FAILED)",
                             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = ErrorResponseWrapper.class))),
-                    @ApiResponse(responseCode = "409", description = "중복 요청 (SCRAPE_JOB_DUPLICATED)",
+                    @ApiResponse(responseCode = "423", description = "포털 계정 잠금 (PORTAL_ACCOUNT_LOCKED)",
                             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = ErrorResponseWrapper.class)))
             }
     )
     @SecurityRequirement(name = "bearerAuth")
-    ResponseEntity<SuccessResponse<PortalLinkDto.AcceptedResponse>> createPortalLinkJob(
+    ResponseEntity<SuccessResponse<PortalLinkDto.LoginResponse>> verifyPortalLogin(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestHeader("Idempotency-Key")
-            @Parameter(name = "Idempotency-Key", description = "동일 요청 deduplication 용 키", in = ParameterIn.HEADER, required = true)
-            String idempotencyKey,
-            @Valid @RequestBody PortalLinkDto.LinkRequest request
+            @Valid @RequestBody PortalLinkDto.LoginRequest request
     );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/dto/PortalLinkDto.java
@@ -9,6 +9,27 @@ import java.time.Instant;
 
 public class PortalLinkDto {
 
+    @Schema(description = "포털 로그인 검증 요청")
+    public record LoginRequest(
+            @NotBlank
+            @JsonProperty("portal_type")
+            @Schema(description = "포털 타입", example = "suwon")
+            String portal_type,
+            @NotBlank
+            @Schema(description = "포털 아이디", example = "17019013")
+            String username,
+            @NotBlank
+            @Schema(description = "포털 비밀번호", example = "pw")
+            String password
+    ) {}
+
+    @Schema(description = "포털 로그인 검증 응답")
+    public record LoginResponse(
+            @JsonProperty("portal_verification_token")
+            @Schema(description = "포털 로그인 검증 token", example = "token")
+            String portal_verification_token
+    ) {}
+
     @Schema(description = "포털 연동 job 생성 요청")
     public record LinkRequest(
             @NotBlank
@@ -20,7 +41,11 @@ public class PortalLinkDto {
             String username,
             @NotBlank
             @Schema(description = "포털 비밀번호", example = "pw")
-            String password
+            String password,
+            @NotBlank
+            @JsonProperty("portal_verification_token")
+            @Schema(description = "포털 로그인 검증 token", example = "token")
+            String portal_verification_token
     ) {}
 
     @Schema(description = "스크래핑 job 수락 응답")

--- a/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLoginApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/portal/wrapper/PortalLoginApiResponse.java
@@ -1,0 +1,14 @@
+// 포털 로그인 검증 성공 응답의 Swagger 문서용 래퍼
+package com.chukchuk.haksa.domain.portal.wrapper;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PortalLoginApiResponse", description = "포털 로그인 검증 응답")
+public class PortalLoginApiResponse extends SuccessResponse<PortalLinkDto.LoginResponse> {
+
+    public PortalLoginApiResponse() {
+        super(new PortalLinkDto.LoginResponse("portal-verification-token"), "요청 성공");
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
@@ -17,10 +17,14 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 
+import java.time.Duration;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PortalClient {
+    private static final Duration LOGIN_REQUEST_TIMEOUT = Duration.ofSeconds(90);
+
     @Value("${crawler.base-url}")
     private String baseUrl;
 
@@ -37,7 +41,7 @@ public class PortalClient {
                     .bodyValue(new LoginRequest(username, password))
                     .retrieve()
                     .toBodilessEntity()
-                    .block();
+                    .block(LOGIN_REQUEST_TIMEOUT);
 
         } catch (WebClientResponseException e) {
             logHttpError(uri, t0, e);

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.infrastructure.portal.client;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.logging.annotation.LogTime;
 import com.chukchuk.haksa.infrastructure.portal.dto.raw.RawPortalData;
+import com.chukchuk.haksa.infrastructure.portal.exception.PortalLoginException;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,30 @@ public class PortalClient {
     private String baseUrl;
 
     private final RestTemplate restTemplate;
+
+    public void validateLogin(String username, String password) {
+        String uri = "/login";
+        long t0 = LogTime.start();
+
+        try {
+            webClient.post()
+                    .uri(baseUrl + uri)
+                    .header("Content-Type", "application/json")
+                    .bodyValue(new LoginRequest(username, password))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+
+        } catch (WebClientResponseException e) {
+            logHttpError(uri, t0, e);
+            throw new PortalLoginException(mapHttpStatus(e.getStatusCode()), e);
+
+        } catch (Exception e) {
+            long tookMs = LogTime.elapsedMs(t0);
+            log.warn("[EXT] method=POST uri={} unexpected_error took_ms={}", uri, tookMs, e);
+            throw new PortalLoginException(ErrorCode.PORTAL_SCRAPE_FAILED, e);
+        }
+    }
 
     public RawPortalData scrapeAll(String username, String password) {
         String uri = "/scrape";

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClient.java
@@ -3,7 +3,6 @@ package com.chukchuk.haksa.infrastructure.portal.client;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.logging.annotation.LogTime;
 import com.chukchuk.haksa.infrastructure.portal.dto.raw.RawPortalData;
-import com.chukchuk.haksa.infrastructure.portal.exception.PortalLoginException;
 import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -29,28 +29,28 @@ public class PortalClient {
     private String baseUrl;
 
     private final RestTemplate restTemplate;
+    private final RestTemplate loginRestTemplate = new RestTemplate(loginRequestFactory());
 
     public void validateLogin(String username, String password) {
         String uri = "/login";
         long t0 = LogTime.start();
 
         try {
-            webClient.post()
-                    .uri(baseUrl + uri)
-                    .header("Content-Type", "application/json")
-                    .bodyValue(new LoginRequest(username, password))
-                    .retrieve()
-                    .toBodilessEntity()
-                    .block(LOGIN_REQUEST_TIMEOUT);
+            RequestEntity<LoginRequest> request = RequestEntity
+                    .post(URI.create(baseUrl + uri))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new LoginRequest(username, password));
 
-        } catch (WebClientResponseException e) {
+            loginRestTemplate.exchange(request, Void.class);
+
+        } catch (RestClientResponseException e) {
             logHttpError(uri, t0, e);
-            throw new PortalLoginException(mapHttpStatus(e.getStatusCode()), e);
+            throw new PortalScrapeException(mapHttpStatus(e.getStatusCode()), e);
 
         } catch (Exception e) {
             long tookMs = LogTime.elapsedMs(t0);
             log.warn("[EXT] method=POST uri={} unexpected_error took_ms={}", uri, tookMs, e);
-            throw new PortalLoginException(ErrorCode.PORTAL_SCRAPE_FAILED, e);
+            throw new PortalScrapeException(ErrorCode.PORTAL_SCRAPE_FAILED, e);
         }
     }
 
@@ -81,6 +81,12 @@ public class PortalClient {
     }
 
     private record LoginRequest(String username, String password) {}
+
+    private static SimpleClientHttpRequestFactory loginRequestFactory() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setReadTimeout((int) LOGIN_REQUEST_TIMEOUT.toMillis());
+        return requestFactory;
+    }
 
     private void logHttpError(String uri, long t0, RestClientResponseException e) {
         long tookMs = LogTime.elapsedMs(t0);

--- a/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientLoginVerifier.java
+++ b/src/main/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientLoginVerifier.java
@@ -1,0 +1,18 @@
+// PortalClient를 통해 포털 로그인 검증 요청을 수행하는 verifier 구현체
+package com.chukchuk.haksa.infrastructure.portal.client;
+
+import com.chukchuk.haksa.application.portal.PortalLoginVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PortalClientLoginVerifier implements PortalLoginVerifier {
+
+    private final PortalClient portalClient;
+
+    @Override
+    public void verify(String portalType, String username, String password) {
+        portalClient.validateLogin(username, password);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,10 @@ logging:
       - ^/internal/.*
       - /docs
 
+portal:
+  login-verification:
+    secret: ${PORTAL_LOGIN_VERIFICATION_SECRET:${JWT_SECRET}}
+    ttl-seconds: ${PORTAL_LOGIN_VERIFICATION_TTL_SECONDS:300}
 lecture-evaluation:
   target-year: ${LECTURE_EVALUATION_TARGET_YEAR:2026}
   target-semester: ${LECTURE_EVALUATION_TARGET_SEMESTER:10}

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLinkJobServiceUnitTests.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -22,8 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,12 +42,15 @@ class PortalLinkJobServiceUnitTests {
     @Mock
     private UserService userService;
 
+    @Mock
+    private PortalLoginVerificationTokenService tokenService;
+
     @Test
     @DisplayName("새 요청은 job/outbox 저장 후 같은 요청에서 동기 publish 한다")
     void acceptLinkJob_dispatchesSynchronously() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
-        PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", false, true);
 
         when(userService.getUserById(userId)).thenReturn(disconnectedUser(userId));
@@ -63,15 +70,51 @@ class PortalLinkJobServiceUnitTests {
 
         assertThat(response.job_id()).isEqualTo("job-1");
         assertThat(response.status()).isEqualTo("accepted");
+        verify(tokenService).verify(userId, "suwon", "17019013", "pw", "verification-token");
         verify(scrapeJobOutboxDispatcher).dispatchOnce("outbox-1");
+    }
+
+    @Test
+    @DisplayName("포털 로그인 검증 token을 먼저 검증한 뒤 job을 생성한다")
+    void acceptLinkJob_verifiesPortalLoginTokenBeforeCreatingJob() {
+        UUID userId = UUID.randomUUID();
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("pw");
+        PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", true, false);
+
+        when(userService.getUserById(userId)).thenReturn(disconnectedUser(userId));
+        when(portalLinkJobTxService.createOrLoadJob(eq(userId), eq("idem-1"), eq("suwon"), eq(ScrapeJobOperationType.LINK), any(), any(), eq("17019013"), eq("pw"), any()))
+                .thenReturn(preparedJob);
+
+        service.acceptJob(userId, "idem-1", request);
+
+        InOrder inOrder = inOrder(tokenService, userService, portalLinkJobTxService);
+        inOrder.verify(tokenService).verify(userId, "suwon", "17019013", "pw", "verification-token");
+        inOrder.verify(userService).getUserById(userId);
+        inOrder.verify(portalLinkJobTxService).createOrLoadJob(eq(userId), eq("idem-1"), eq("suwon"), eq(ScrapeJobOperationType.LINK), any(), any(), eq("17019013"), eq("pw"), any());
+    }
+
+    @Test
+    @DisplayName("포털 로그인 검증 token 검증에 실패하면 job을 생성하지 않는다")
+    void acceptLinkJob_doesNotCreateJobWhenPortalLoginTokenIsInvalid() {
+        UUID userId = UUID.randomUUID();
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("wrong");
+        doThrow(new CommonException(ErrorCode.INVALID_ARGUMENT))
+                .when(tokenService).verify(userId, "suwon", "17019013", "wrong", "verification-token");
+
+        assertThatThrownBy(() -> service.acceptJob(userId, "idem-1", request))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT.code()));
+        verifyNoInteractions(userService, portalLinkJobTxService, scrapeJobOutboxDispatcher);
     }
 
     @Test
     @DisplayName("이미 RUNNING 이상인 동일 요청은 기존 job을 재사용하고 publish 하지 않는다")
     void acceptLinkJob_reusesExistingJobWithoutDispatch() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
-        PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", true, false);
 
         when(userService.getUserById(userId)).thenReturn(disconnectedUser(userId));
@@ -88,8 +131,8 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("동기 publish 후 SENT/RUNNING이 아니면 enqueue 실패로 처리한다")
     void acceptLinkJob_throwsWhenDispatchStateIsNotSent() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
-        PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", false, true);
 
         when(userService.getUserById(userId)).thenReturn(disconnectedUser(userId));
@@ -114,8 +157,8 @@ class PortalLinkJobServiceUnitTests {
     @DisplayName("동시성으로 최초 저장이 충돌하면 기존 job을 다시 조회해 같은 요청 흐름에서 publish 한다")
     void acceptLinkJob_resolvesConcurrentDuplicateAndDispatches() {
         UUID userId = UUID.randomUUID();
-        PortalLinkJobService service = new PortalLinkJobService(portalLinkJobTxService, scrapeJobOutboxDispatcher, userService, new ObjectMapper().findAndRegisterModules());
-        PortalLinkDto.LinkRequest request = new PortalLinkDto.LinkRequest("suwon", "17019013", "pw");
+        PortalLinkJobService service = service();
+        PortalLinkDto.LinkRequest request = linkRequest("pw");
         PortalLinkJobTxService.PreparedJob preparedJob = new PortalLinkJobTxService.PreparedJob("job-1", "outbox-1", true, true);
 
         when(userService.getUserById(userId)).thenReturn(disconnectedUser(userId));
@@ -136,6 +179,20 @@ class PortalLinkJobServiceUnitTests {
 
         assertThat(response.job_id()).isEqualTo("job-1");
         verify(scrapeJobOutboxDispatcher).dispatchOnce("outbox-1");
+    }
+
+    private PortalLinkJobService service() {
+        return new PortalLinkJobService(
+                portalLinkJobTxService,
+                scrapeJobOutboxDispatcher,
+                userService,
+                new ObjectMapper().findAndRegisterModules(),
+                tokenService
+        );
+    }
+
+    private static PortalLinkDto.LinkRequest linkRequest(String password) {
+        return new PortalLinkDto.LinkRequest("suwon", "17019013", password, "verification-token");
     }
 
     private static User disconnectedUser(UUID userId) {

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginServiceUnitTests.java
@@ -1,0 +1,63 @@
+// 포털 로그인 검증 서비스의 token 발급 흐름을 검증하는 테스트
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PortalLoginServiceUnitTests {
+
+    @Mock
+    private PortalLoginVerifier portalLoginVerifier;
+
+    @Mock
+    private PortalLoginVerificationTokenService tokenService;
+
+    @Test
+    @DisplayName("포털 로그인 검증에 성공하면 verification token을 발급한다")
+    void login_issuesVerificationTokenAfterPortalLoginSuccess() {
+        UUID userId = UUID.randomUUID();
+        PortalLoginService service = new PortalLoginService(portalLoginVerifier, tokenService);
+        PortalLinkDto.LoginRequest request = new PortalLinkDto.LoginRequest("suwon", "17019013", "pw");
+        when(tokenService.issue(userId, "suwon", "17019013", "pw")).thenReturn("verification-token");
+
+        PortalLinkDto.LoginResponse response = service.login(userId, request);
+
+        assertThat(response.portal_verification_token()).isEqualTo("verification-token");
+        InOrder inOrder = inOrder(portalLoginVerifier, tokenService);
+        inOrder.verify(portalLoginVerifier).verify("suwon", "17019013", "pw");
+        inOrder.verify(tokenService).issue(userId, "suwon", "17019013", "pw");
+    }
+
+    @Test
+    @DisplayName("포털 로그인 검증에 실패하면 verification token을 발급하지 않는다")
+    void login_doesNotIssueVerificationTokenWhenPortalLoginFails() {
+        UUID userId = UUID.randomUUID();
+        PortalLoginService service = new PortalLoginService(portalLoginVerifier, tokenService);
+        PortalLinkDto.LoginRequest request = new PortalLinkDto.LoginRequest("suwon", "17019013", "wrong");
+        doThrow(new CommonException(ErrorCode.PORTAL_LOGIN_FAILED))
+                .when(portalLoginVerifier).verify("suwon", "17019013", "wrong");
+
+        assertThatThrownBy(() -> service.login(userId, request))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.PORTAL_LOGIN_FAILED.code()));
+        verify(tokenService, never()).issue(userId, "suwon", "17019013", "wrong");
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenServiceUnitTests.java
@@ -6,10 +6,14 @@ import com.chukchuk.haksa.global.exception.type.CommonException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.HexFormat;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +48,20 @@ class PortalLoginVerificationTokenServiceUnitTests {
     }
 
     @Test
+    @DisplayName("verification token payload에는 비밀번호 기반 fingerprint를 포함하지 않는다")
+    void issue_doesNotExposePasswordDerivedFingerprintInPayload() throws Exception {
+        UUID userId = UUID.randomUUID();
+        PortalLoginVerificationTokenService service = serviceAt(NOW);
+
+        String token = service.issue(userId, "suwon", "17019013", "pw");
+        String payload = decodePayload(token);
+
+        assertThat(payload).contains("\"portal_type\":\"suwon\"");
+        assertThat(payload).contains("\"username_hash\"");
+        assertThat(payload).doesNotContain(sha256("suwon\n17019013\npw"));
+    }
+
+    @Test
     @DisplayName("만료된 verification token은 거부한다")
     void verify_rejectsExpiredToken() {
         UUID userId = UUID.randomUUID();
@@ -58,5 +76,16 @@ class PortalLoginVerificationTokenServiceUnitTests {
 
     private PortalLoginVerificationTokenService serviceAt(Instant instant) {
         return new PortalLoginVerificationTokenService(SECRET, Duration.ofMinutes(5), Clock.fixed(instant, ZoneOffset.UTC));
+    }
+
+    private String decodePayload(String token) {
+        String[] parts = token.split("\\.", -1);
+        assertThat(parts).hasSize(3);
+        String encodedPayload = parts[1];
+        return new String(Base64.getUrlDecoder().decode(encodedPayload), StandardCharsets.UTF_8);
+    }
+
+    private String sha256(String value) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/application/portal/PortalLoginVerificationTokenServiceUnitTests.java
@@ -1,0 +1,62 @@
+// 포털 로그인 검증 token의 발급과 검증 규칙을 검증하는 테스트
+package com.chukchuk.haksa.application.portal;
+
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PortalLoginVerificationTokenServiceUnitTests {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+    private static final Instant NOW = Instant.parse("2026-06-16T10:00:00Z");
+
+    @Test
+    @DisplayName("발급한 verification token은 같은 사용자와 같은 자격 증명에서 검증된다")
+    void verify_acceptsMatchingUserAndCredential() {
+        UUID userId = UUID.randomUUID();
+        PortalLoginVerificationTokenService service = serviceAt(NOW);
+
+        String token = service.issue(userId, "suwon", "17019013", "pw");
+
+        service.verify(userId, "suwon", "17019013", "pw", token);
+    }
+
+    @Test
+    @DisplayName("다른 비밀번호로 제출한 verification token은 거부한다")
+    void verify_rejectsDifferentPassword() {
+        UUID userId = UUID.randomUUID();
+        PortalLoginVerificationTokenService service = serviceAt(NOW);
+        String token = service.issue(userId, "suwon", "17019013", "pw");
+
+        assertThatThrownBy(() -> service.verify(userId, "suwon", "17019013", "wrong", token))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT.code()));
+    }
+
+    @Test
+    @DisplayName("만료된 verification token은 거부한다")
+    void verify_rejectsExpiredToken() {
+        UUID userId = UUID.randomUUID();
+        PortalLoginVerificationTokenService issuer = serviceAt(NOW);
+        String token = issuer.issue(userId, "suwon", "17019013", "pw");
+        PortalLoginVerificationTokenService verifier = serviceAt(NOW.plusSeconds(301));
+
+        assertThatThrownBy(() -> verifier.verify(userId, "suwon", "17019013", "pw", token))
+                .isInstanceOf(CommonException.class)
+                .satisfies(ex -> assertThat(((CommonException) ex).getCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT.code()));
+    }
+
+    private PortalLoginVerificationTokenService serviceAt(Instant instant) {
+        return new PortalLoginVerificationTokenService(SECRET, Duration.ofMinutes(5), Clock.fixed(instant, ZoneOffset.UTC));
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLinkOpenApiTest.java
@@ -33,6 +33,14 @@ class PortalLinkOpenApiTest {
 
         assertSuccessResponseSchema(
                 apiDocs,
+                "/portal/login",
+                "post",
+                "200",
+                "PortalLoginApiResponse",
+                "LoginResponse"
+        );
+        assertSuccessResponseSchema(
+                apiDocs,
                 "/portal/link",
                 "post",
                 "202",

--- a/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLoginControllerApiIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/portal/controller/PortalLoginControllerApiIntegrationTest.java
@@ -1,6 +1,7 @@
+// 포털 로그인 검증 API의 HTTP 계약을 검증하는 테스트
 package com.chukchuk.haksa.domain.portal.controller;
 
-import com.chukchuk.haksa.application.portal.PortalLinkJobService;
+import com.chukchuk.haksa.application.portal.PortalLoginService;
 import com.chukchuk.haksa.domain.portal.dto.PortalLinkDto;
 import com.chukchuk.haksa.support.ApiControllerWebMvcTestSupport;
 import org.junit.jupiter.api.DisplayName;
@@ -21,38 +22,35 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(PortalLinkController.class)
+@WebMvcTest(PortalLoginController.class)
 @AutoConfigureMockMvc(addFilters = false)
-class PortalLinkControllerApiIntegrationTest extends ApiControllerWebMvcTestSupport {
+class PortalLoginControllerApiIntegrationTest extends ApiControllerWebMvcTestSupport {
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
-    private PortalLinkJobService portalLinkJobService;
+    private PortalLoginService portalLoginService;
 
     @Test
-    @DisplayName("portal link 요청 성공 시 accepted 응답을 반환한다")
-    void createPortalLinkJob_success() throws Exception {
+    @DisplayName("포털 로그인 검증 성공 시 verification token을 반환한다")
+    void verifyPortalLogin_success() throws Exception {
         UUID userId = UUID.randomUUID();
         authenticate(userId);
-        when(portalLinkJobService.acceptJob(eq(userId), eq("idem-1"), any(PortalLinkDto.LinkRequest.class)))
-                .thenReturn(new PortalLinkDto.AcceptedResponse("job-1", "accepted", "/portal/link/jobs/job-1"));
+        when(portalLoginService.login(eq(userId), any(PortalLinkDto.LoginRequest.class)))
+                .thenReturn(new PortalLinkDto.LoginResponse("verification-token"));
 
-        mockMvc.perform(post("/portal/link")
-                        .header("Idempotency-Key", "idem-1")
+        mockMvc.perform(post("/portal/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
                                   "portal_type":"suwon",
                                   "username":"17019013",
-                                  "password":"pw",
-                                  "portal_verification_token":"verification-token"
+                                  "password":"pw"
                                 }
                                 """))
-                .andExpect(status().isAccepted())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.job_id").value("job-1"))
-                .andExpect(jsonPath("$.data.status").value("accepted"));
+                .andExpect(jsonPath("$.data.portal_verification_token").value("verification-token"));
     }
 }

--- a/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
@@ -40,6 +40,7 @@ class OpenApiResponseContractTest {
     );
 
     private static final List<OperationRef> PROTECTED_OPERATIONS = List.of(
+            new OperationRef("/portal/login", "post"),
             new OperationRef("/portal/link", "post"),
             new OperationRef("/portal/link/jobs/{jobId}", "get"),
             new OperationRef("/portal/link/jobs/{jobId}/summary", "get"),

--- a/src/test/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientTests.java
+++ b/src/test/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientTests.java
@@ -1,0 +1,66 @@
+// PortalClient의 포털 로그인 검증 HTTP 호출과 오류 매핑을 검증하는 테스트
+package com.chukchuk.haksa.infrastructure.portal.client;
+
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.infrastructure.portal.exception.PortalLoginException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PortalClientTests {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void validateLogin_postsCredentialToLoginEndpoint() throws Exception {
+        AtomicReference<String> requestBody = new AtomicReference<>();
+        PortalClient client = clientWithServer(204, requestBody);
+
+        client.validateLogin("17019013", "pw");
+
+        assertThat(requestBody.get()).contains("\"username\":\"17019013\"");
+        assertThat(requestBody.get()).contains("\"password\":\"pw\"");
+    }
+
+    @Test
+    void validateLogin_mapsUnauthorizedToPortalLoginFailed() throws Exception {
+        PortalClient client = clientWithServer(401, new AtomicReference<>());
+
+        assertThatThrownBy(() -> client.validateLogin("17019013", "wrong"))
+                .isInstanceOf(PortalLoginException.class)
+                .satisfies(ex -> assertThat(((PortalLoginException) ex).getCode()).isEqualTo(ErrorCode.PORTAL_LOGIN_FAILED.code()));
+    }
+
+    private PortalClient clientWithServer(int status, AtomicReference<String> requestBody) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/login", exchange -> respond(exchange, status, requestBody));
+        server.start();
+
+        PortalClient client = new PortalClient();
+        ReflectionTestUtils.setField(client, "baseUrl", "http://localhost:" + server.getAddress().getPort());
+        return client;
+    }
+
+    private void respond(HttpExchange exchange, int status, AtomicReference<String> requestBody) throws IOException {
+        requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+        exchange.sendResponseHeaders(status, -1);
+        exchange.close();
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientTests.java
+++ b/src/test/java/com/chukchuk/haksa/infrastructure/portal/client/PortalClientTests.java
@@ -2,12 +2,13 @@
 package com.chukchuk.haksa.infrastructure.portal.client;
 
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
-import com.chukchuk.haksa.infrastructure.portal.exception.PortalLoginException;
+import com.chukchuk.haksa.infrastructure.portal.exception.PortalScrapeException;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -44,8 +45,8 @@ class PortalClientTests {
         PortalClient client = clientWithServer(401, new AtomicReference<>());
 
         assertThatThrownBy(() -> client.validateLogin("17019013", "wrong"))
-                .isInstanceOf(PortalLoginException.class)
-                .satisfies(ex -> assertThat(((PortalLoginException) ex).getCode()).isEqualTo(ErrorCode.PORTAL_LOGIN_FAILED.code()));
+                .isInstanceOf(PortalScrapeException.class)
+                .satisfies(ex -> assertThat(((PortalScrapeException) ex).getCode()).isEqualTo(ErrorCode.PORTAL_LOGIN_FAILED.code()));
     }
 
     private PortalClient clientWithServer(int status, AtomicReference<String> requestBody) throws IOException {
@@ -53,7 +54,7 @@ class PortalClientTests {
         server.createContext("/login", exchange -> respond(exchange, status, requestBody));
         server.start();
 
-        PortalClient client = new PortalClient();
+        PortalClient client = new PortalClient(new RestTemplate());
         ReflectionTestUtils.setField(client, "baseUrl", "http://localhost:" + server.getAddress().getPort());
         return client;
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,6 +19,11 @@ security:
 crawler:
   base-url: https://example.com
 
+portal:
+  login-verification:
+    secret: test-portal-login-verification-secret
+    ttl-seconds: 300
+
 scraping:
   mode: async
   job:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,6 +35,11 @@ security:
 crawler:
   base-url: http://localhost:8081
 
+portal:
+  login-verification:
+    secret: test-portal-login-verification-secret
+    ttl-seconds: 300
+
 sentry:
   enable: false
 


### PR DESCRIPTION
## 작업 내용

- 스크래퍼 로그인 검증 전용 클라이언트를 추가했습니다.
- `POST /portal/login` API를 추가해 포털 ID/PW 검증과 연동 요청을 분리했습니다.
- `POST /portal/link`에서 로그인 검증 토큰을 확인한 뒤에만 스크래핑 job을 생성하도록 변경했습니다.
- OpenAPI 문서와 포털 로그인 검증 분리 스펙 문서를 갱신했습니다.

## 배경

포털 연동 버튼 클릭 후 광고를 노출하는 흐름에서 로그인 실패 사용자에게도 광고가 먼저 보이는 문제를 피하기 위해, 로그인 검증과 실제 연동 job 생성을 분리했습니다.

## 검증

- `git diff --check HEAD`
- `./gradlew test --rerun-tasks`

### 🔗 Related Issue

Closes #267



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 포털 로그인 검증 API를 별도로 제공하고, 성공 시 검증 토큰을 발급합니다.
  * 포털 연동 요청은 유효한 검증 토큰이 있을 때만 처리됩니다.
  * 로그인 성공 시 광고 표시와 기존 연동 진행 흐름을 이어갈 수 있습니다.

* **문서**
  * 포털 로그인 및 연동 API의 OpenAPI 문서와 사용 절차를 업데이트했습니다.

* **버그 수정**
  * 인증 실패, 만료·불일치 토큰 요청이 작업 생성으로 이어지지 않도록 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->