### PR TITLE
hotfix: 선교 세부영역 이수 개수 계산 수정

### DIFF
--- a/docs/specs/20260623-liberal-area-count/checklist.md
+++ b/docs/specs/20260623-liberal-area-count/checklist.md
@@ -1,0 +1,10 @@
+# Checklist
+
+- [x] main 기준 hotfix 브랜치에서 작업한다.
+- [x] 선교 `completedElectiveCourses`가 `liberalAreaCode` 고유 개수만 세는 회귀 테스트를 추가한다.
+- [x] `liberalAreaCode == null`인 선교 과목이 오류 없이 카운트에서 제외되는지 테스트한다.
+- [x] 선교 외 영역은 기존 offering 기준 카운트를 유지한다.
+- [x] focused test를 통과시킨다.
+- [x] 전체 `./gradlew test`를 통과시킨다.
+- [ ] 커밋 후 원격 hotfix 브랜치로 push한다.
+- [ ] dev 반영 경로를 확인한다.

--- a/docs/specs/20260623-liberal-area-count/checklist.md
+++ b/docs/specs/20260623-liberal-area-count/checklist.md
@@ -6,5 +6,5 @@
 - [x] 선교 외 영역은 기존 offering 기준 카운트를 유지한다.
 - [x] focused test를 통과시킨다.
 - [x] 전체 `./gradlew test`를 통과시킨다.
-- [ ] 커밋 후 원격 hotfix 브랜치로 push한다.
-- [ ] dev 반영 경로를 확인한다.
+- [x] 커밋 후 원격 hotfix 브랜치로 push한다.
+- [x] dev 반영 경로를 확인한다.

--- a/docs/specs/20260623-liberal-area-count/context-notes.md
+++ b/docs/specs/20260623-liberal-area-count/context-notes.md
@@ -1,0 +1,8 @@
+# Context Notes
+
+- 2026-06-23: 사용자 제보 스크린샷에서 선택교양이 `7개영역 / 6개영역`으로 보이나 실제 고유 세부영역은 6개로 확인됨.
+- 현재 `GraduationQueryRepository`는 `completedElectiveCourses`를 `offeringId` 고유 개수로 계산한다.
+- `liberalAreaCode`는 `course_offerings.area_code`에서 조회되며 선교 과목 응답에만 노출된다.
+- 정책 결정: 선교 영역은 `liberalAreaCode` 고유 개수로 카운트한다. null 세부영역은 중복 여부를 판단할 수 없으므로 영역 충족 카운트에서는 제외하고 과목 목록에는 유지한다.
+- focused test `./gradlew test --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryEtcTests`는 구현 전 `completedElectiveCourses` 기대값 불일치로 실패했고, 구현 후 통과했다.
+- 전체 `./gradlew test`도 통과했다.

--- a/docs/specs/20260623-liberal-area-count/context-notes.md
+++ b/docs/specs/20260623-liberal-area-count/context-notes.md
@@ -6,3 +6,4 @@
 - 정책 결정: 선교 영역은 `liberalAreaCode` 고유 개수로 카운트한다. null 세부영역은 중복 여부를 판단할 수 없으므로 영역 충족 카운트에서는 제외하고 과목 목록에는 유지한다.
 - focused test `./gradlew test --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryEtcTests`는 구현 전 `completedElectiveCourses` 기대값 불일치로 실패했고, 구현 후 통과했다.
 - 전체 `./gradlew test`도 통과했다.
+- main 대상 PR은 `hotfix/liberal-area-count`, dev 대상 PR은 `hotfix/liberal-area-count-dev`로 분리했다.

--- a/docs/specs/20260623-liberal-area-count/spec-lite.md
+++ b/docs/specs/20260623-liberal-area-count/spec-lite.md
@@ -1,0 +1,16 @@
+# Spec Lite
+
+## Problem
+
+선교 영역 진행도에서 `completedElectiveCourses`가 세부 교양 영역 수가 아니라 수강 과목 offering 수로 계산된다. 같은 `liberalAreaCode` 과목을 여러 개 들어도 UI에서는 하나의 영역으로 보여야 한다.
+
+## Scope
+
+- `선교` 영역의 `completedElectiveCourses`만 `liberalAreaCode` 고유 개수 기준으로 계산한다.
+- `liberalAreaCode`가 `null`인 선교 과목은 카운트에서 제외하되, 과목 목록 응답에는 유지한다.
+- 선교가 아닌 영역은 기존 `offeringId` 고유 개수 계산을 유지한다.
+
+## Verification
+
+- 선교 중복 세부영역과 null 세부영역을 포함한 repository 단위 테스트를 추가한다.
+- focused Gradle test를 실행한다.

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
@@ -106,10 +106,7 @@ public class GraduationQueryRepository {
             List<CourseInternalDto> taken = coursesByArea.getOrDefault(req.areaType(), Collections.emptyList());
 
             int earnedCredits = taken.stream().mapToInt(CourseInternalDto::getCredits).sum();
-            int completedElectiveCourses = (int) taken.stream()
-                    .map(CourseInternalDto::getOfferingId)
-                    .distinct()
-                    .count();
+            int completedElectiveCourses = countCompletedElectiveCourses(req.areaType(), taken);
 
             List<CourseDto> courseDtos = taken.stream()
                     .map(this::toCourseResponseDto)
@@ -198,10 +195,7 @@ public class GraduationQueryRepository {
             List<CourseInternalDto> taken = coursesByArea.getOrDefault(req.areaType(), Collections.emptyList());
 
             int earnedCredits = taken.stream().mapToInt(CourseInternalDto::getCredits).sum();
-            int completedElectiveCourses = (int) taken.stream()
-                    .map(CourseInternalDto::getOfferingId)
-                    .distinct()
-                    .count();
+            int completedElectiveCourses = countCompletedElectiveCourses(req.areaType(), taken);
 
             List<CourseDto> courseDtos = taken.stream()
                     .map(this::toCourseResponseDto)
@@ -377,6 +371,20 @@ public class GraduationQueryRepository {
                     }
                     return area.trim();
                 }));
+    }
+
+    private int countCompletedElectiveCourses(String areaType, List<CourseInternalDto> courses) {
+        if (FacultyDivision.선교.name().equals(areaType)) {
+            return (int) courses.stream()
+                    .map(CourseInternalDto::getLiberalAreaCode)
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .count();
+        }
+        return (int) courses.stream()
+                .map(CourseInternalDto::getOfferingId)
+                .distinct()
+                .count();
     }
 
     public CourseDto toCourseResponseDto(CourseInternalDto dto) {

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryEtcTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryEtcTests.java
@@ -24,16 +24,39 @@ class GraduationQueryRepositoryEtcTests {
     void getStudentAreaProgress_addsEtcAreaWithMagicNumbers() {
         List<AreaProgressDto> progress = repository.getStudentAreaProgress(UUID.randomUUID(), 1L, 2024);
 
+        AreaProgressDto majorArea = progress.stream()
+                .filter(dto -> dto.getAreaType() == FacultyDivision.전핵)
+                .findFirst()
+                .orElseThrow();
         AreaProgressDto etcArea = progress.stream()
                 .filter(dto -> dto.getAreaType() == FacultyDivision.기타)
                 .findFirst()
                 .orElseThrow();
 
+        assertThat(majorArea.getCompletedElectiveCourses()).isEqualTo(1);
         assertThat(etcArea.getRequiredCredits()).isZero();
         assertThat(etcArea.getEarnedCredits()).isEqualTo(3);
         assertThat(etcArea.getCourses())
                 .map(CourseDto::getCourseName)
                 .containsExactlyInAnyOrder("특별활동", "미지정활동");
+    }
+
+    @Test
+    @DisplayName("선교 completedElectiveCourses 는 null 을 제외한 세부 영역 고유 개수로 계산한다")
+    void getStudentAreaProgress_countsMissionDistinctLiberalAreas() {
+        GraduationQueryRepository missionRepository = new TestMissionGraduationQueryRepository();
+
+        List<AreaProgressDto> progress = missionRepository.getStudentAreaProgress(UUID.randomUUID(), 1L, 2024);
+
+        AreaProgressDto missionArea = progress.stream()
+                .filter(dto -> dto.getAreaType() == FacultyDivision.선교)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(missionArea.getCompletedElectiveCourses()).isEqualTo(2);
+        assertThat(missionArea.getCourses())
+                .map(CourseDto::getCourseName)
+                .containsExactlyInAnyOrder("세계차산업의이해", "일본사회의이해", "러시아문화", "영역미확인선교");
     }
 
     private static class TestGraduationQueryRepository extends GraduationQueryRepository {
@@ -59,6 +82,35 @@ class GraduationQueryRepositoryEtcTests {
                     3L, null, 2, "P", "미지정활동", 1, 2024, "UNK001", 0, null
             );
             return List.of(major, etc, undefined);
+        }
+    }
+
+    private static class TestMissionGraduationQueryRepository extends GraduationQueryRepository {
+
+        TestMissionGraduationQueryRepository() {
+            super(null, mock(AcademicCache.class));
+        }
+
+        @Override
+        public List<AreaRequirementDto> getAreaRequirementsWithCache(Long deptId, Integer admissionYear) {
+            return List.of(new AreaRequirementDto("선교", 18, 6, 7));
+        }
+
+        @Override
+        public List<CourseInternalDto> getLatestValidCourses(UUID studentId) {
+            CourseInternalDto area2First = new CourseInternalDto(
+                    1L, "선교", 3, "A0", "세계차산업의이해", 203, 2024, "CUL201", 90, 2
+            );
+            CourseInternalDto area2Second = new CourseInternalDto(
+                    2L, "선교", 3, "A+", "일본사회의이해", 10, 2024, "CUL202", 95, 2
+            );
+            CourseInternalDto area4 = new CourseInternalDto(
+                    3L, "선교", 3, "A0", "러시아문화", 10, 2026, "CUL401", 90, 4
+            );
+            CourseInternalDto unknownArea = new CourseInternalDto(
+                    4L, "선교", 3, "B+", "영역미확인선교", 20, 2025, "CUL999", 85, null
+            );
+            return List.of(area2First, area2Second, area4, unknownArea);
         }
     }
 }


### PR DESCRIPTION
## Summary
- main hotfix 커밋을 origin/dev 기준 브랜치에 cherry-pick했습니다.
- 선교 completedElectiveCourses를 liberalAreaCode 고유 개수로 계산합니다.
- null liberalAreaCode는 카운트에서 제외하고 과목 목록은 유지합니다.

## Test
- ./gradlew test --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryEtcTests
- ./gradlew test