### PR TITLE
hotfix: 선교 영역 공백 정규화 보정

### DIFF
--- a/docs/specs/20260623-liberal-area-count/checklist.md
+++ b/docs/specs/20260623-liberal-area-count/checklist.md
@@ -4,6 +4,7 @@
 - [x] 선교 `completedElectiveCourses`가 `liberalAreaCode` 고유 개수만 세는 회귀 테스트를 추가한다.
 - [x] `liberalAreaCode == null`인 선교 과목이 오류 없이 카운트에서 제외되는지 테스트한다.
 - [x] 선교 외 영역은 기존 offering 기준 카운트를 유지한다.
+- [x] 선교 요건 `areaType`에 공백이 있어도 동일하게 계산되도록 보정한다.
 - [x] focused test를 통과시킨다.
 - [x] 전체 `./gradlew test`를 통과시킨다.
 - [ ] 커밋 후 원격 hotfix 브랜치로 push한다.

--- a/docs/specs/20260623-liberal-area-count/context-notes.md
+++ b/docs/specs/20260623-liberal-area-count/context-notes.md
@@ -6,3 +6,4 @@
 - 정책 결정: 선교 영역은 `liberalAreaCode` 고유 개수로 카운트한다. null 세부영역은 중복 여부를 판단할 수 없으므로 영역 충족 카운트에서는 제외하고 과목 목록에는 유지한다.
 - focused test `./gradlew test --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryEtcTests`는 구현 전 `completedElectiveCourses` 기대값 불일치로 실패했고, 구현 후 통과했다.
 - 전체 `./gradlew test`도 통과했다.
+- PR #276 봇 리뷰에서 `areaType` 공백 방어가 필요하다는 코멘트가 있었다. 실제 조회 경로에서는 helper 비교뿐 아니라 `coursesByArea` lookup에도 같은 정규화가 필요하므로 요건 `areaType`을 loop 초입에서 trim해 lookup, count, DTO 변환에 일관되게 사용한다.

--- a/docs/specs/20260623-liberal-area-count/spec-lite.md
+++ b/docs/specs/20260623-liberal-area-count/spec-lite.md
@@ -9,6 +9,7 @@
 - `선교` 영역의 `completedElectiveCourses`만 `liberalAreaCode` 고유 개수 기준으로 계산한다.
 - `liberalAreaCode`가 `null`인 선교 과목은 카운트에서 제외하되, 과목 목록 응답에는 유지한다.
 - 선교가 아닌 영역은 기존 `offeringId` 고유 개수 계산을 유지한다.
+- 요건 `areaType`에 앞뒤 공백이 있어도 계산 기준이 달라지지 않게 한다.
 
 ## Verification
 

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
@@ -103,17 +103,18 @@ public class GraduationQueryRepository {
         List<AreaProgressDto> result = new ArrayList<>();
 
         for (AreaRequirementDto req : areaRequirements) {
-            List<CourseInternalDto> taken = coursesByArea.getOrDefault(req.areaType(), Collections.emptyList());
+            String areaType = normalizeAreaType(req.areaType());
+            List<CourseInternalDto> taken = coursesByArea.getOrDefault(areaType, Collections.emptyList());
 
             int earnedCredits = taken.stream().mapToInt(CourseInternalDto::getCredits).sum();
-            int completedElectiveCourses = countCompletedElectiveCourses(req.areaType(), taken);
+            int completedElectiveCourses = countCompletedElectiveCourses(areaType, taken);
 
             List<CourseDto> courseDtos = taken.stream()
                     .map(this::toCourseResponseDto)
                     .toList();
 
             AreaProgressDto dto = new AreaProgressDto(
-                    parseDivision(req.areaType()),
+                    parseDivision(areaType),
                     req.requiredCredits(),
                     earnedCredits,
                     req.requiredElectiveCourses(),
@@ -192,17 +193,18 @@ public class GraduationQueryRepository {
         // 이수 현황 계산
         List<AreaProgressDto> result = new ArrayList<>();
         for (AreaRequirementDto req : mergedRequirements) {
-            List<CourseInternalDto> taken = coursesByArea.getOrDefault(req.areaType(), Collections.emptyList());
+            String areaType = normalizeAreaType(req.areaType());
+            List<CourseInternalDto> taken = coursesByArea.getOrDefault(areaType, Collections.emptyList());
 
             int earnedCredits = taken.stream().mapToInt(CourseInternalDto::getCredits).sum();
-            int completedElectiveCourses = countCompletedElectiveCourses(req.areaType(), taken);
+            int completedElectiveCourses = countCompletedElectiveCourses(areaType, taken);
 
             List<CourseDto> courseDtos = taken.stream()
                     .map(this::toCourseResponseDto)
                     .toList();
 
             AreaProgressDto dto = new AreaProgressDto(
-                    parseDivision(req.areaType()),
+                    parseDivision(areaType),
                     req.requiredCredits(),
                     earnedCredits,
                     req.requiredElectiveCourses(),
@@ -324,6 +326,10 @@ public class GraduationQueryRepository {
         return FacultyDivision.valueOf(raw.trim());
     }
 
+    private String normalizeAreaType(String raw) {
+        return raw == null ? null : raw.trim();
+    }
+
     private void appendEtcAreaIfPresent(List<AreaProgressDto> target, Map<String, List<CourseInternalDto>> coursesByArea) {
         if (target.stream().anyMatch(dto -> dto.getAreaType() == FacultyDivision.기타)) {
             return;
@@ -374,7 +380,8 @@ public class GraduationQueryRepository {
     }
 
     private int countCompletedElectiveCourses(String areaType, List<CourseInternalDto> courses) {
-        if (FacultyDivision.선교.name().equals(areaType)) {
+        String normalizedAreaType = normalizeAreaType(areaType);
+        if (FacultyDivision.선교.name().equals(normalizedAreaType)) {
             return (int) courses.stream()
                     .map(CourseInternalDto::getLiberalAreaCode)
                     .filter(Objects::nonNull)

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryEtcTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryEtcTests.java
@@ -42,7 +42,7 @@ class GraduationQueryRepositoryEtcTests {
     }
 
     @Test
-    @DisplayName("선교 completedElectiveCourses 는 null 을 제외한 세부 영역 고유 개수로 계산한다")
+    @DisplayName("선교 completedElectiveCourses 는 요건 공백을 무시하고 세부 영역 고유 개수로 계산한다")
     void getStudentAreaProgress_countsMissionDistinctLiberalAreas() {
         GraduationQueryRepository missionRepository = new TestMissionGraduationQueryRepository();
 
@@ -93,7 +93,7 @@ class GraduationQueryRepositoryEtcTests {
 
         @Override
         public List<AreaRequirementDto> getAreaRequirementsWithCache(Long deptId, Integer admissionYear) {
-            return List.of(new AreaRequirementDto("선교", 18, 6, 7));
+            return List.of(new AreaRequirementDto("선교 ", 18, 6, 7));
         }
 
         @Override


### PR DESCRIPTION
## Summary
- PR #276 리뷰에서 지적된 areaType 공백 케이스를 main hotfix 위에 반영합니다.
- 요건 areaType을 trim한 값으로 coursesByArea lookup, completedElectiveCourses 계산, DTO areaType 변환을 일관되게 수행합니다.
- 회귀 테스트는 요건 areaType이 `선교 `인 케이스를 검증합니다.

## Test
- ./gradlew test --tests com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepositoryEtcTests
- ./gradlew test