### PR TITLE
281 feat: 강의평가 상태 테스트 API 추가

### DIFF
--- a/docs/specs/20260626-issue-281-lecture-evaluation-test-api/plan.md
+++ b/docs/specs/20260626-issue-281-lecture-evaluation-test-api/plan.md
@@ -1,0 +1,140 @@
+# Issue 281 Implementation Plan
+
+## 목표
+
+dev/test profile에서 고정 프론트 테스트 계정의 강의평가 상태를 인증 없이 재구성하는 5개 POST API를 추가한다.
+
+## 선택한 접근
+
+`AdminTestController`에 강의평가 테스트 전용 endpoint를 추가하고, 실제 상태 재구성은 신규 `AdminTestLectureEvaluationService`에 분리한다. 기존 `LectureEvaluationService#submit`과 `#skip`은 사용자 요청 검증과 일괄 제출 흐름에 맞춰져 있어 전체 삭제 후 재구성, `empty-semester`, 실제 강의 재사용 seed에는 맞지 않으므로 재사용하지 않는다.
+
+## 수정 파일
+
+- Modify: `src/main/java/com/chukchuk/haksa/domain/admin/controller/AdminTestController.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/admin/controller/docs/AdminTestControllerDocs.java`.
+- Create: `src/main/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationService.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/academic/record/model/SemesterAcademicRecord.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationRepository.java`.
+- Modify: `src/main/java/com/chukchuk/haksa/global/security/SecurityConfig.java`.
+- Modify: `src/main/resources/public/openapi.yaml`.
+- Modify: `src/test/java/com/chukchuk/haksa/domain/admin/controller/AdminTestControllerApiIntegrationTest.java`.
+- Create: `src/test/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationServiceUnitTests.java`.
+- Modify: `src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java`.
+- Modify: `src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java`.
+
+## Task 1: 서비스 단위 테스트를 먼저 추가한다
+
+- `AdminTestLectureEvaluationServiceUnitTests`를 생성한다.
+- `empty-semester`가 대상 학기의 평가 데이터, 수강 데이터, 학기 row를 삭제하고 캐시를 삭제하는지 검증한다.
+- `not-released`가 실제 교수 연결 `CourseOffering`을 재사용해 IP 수강 과목과 `NOT_RELEASED` 학기 row를 만드는지 검증한다.
+- `pending`이 완료 성적 수강 과목과 `PENDING` 학기 row를 만들고 평가 데이터는 만들지 않는지 검증한다.
+- `skipped`가 완료 성적 수강 과목과 `SKIPPED` 학기 row를 만들고 평가 데이터는 만들지 않는지 검증한다.
+- `completed`가 완료 성적 수강 과목, `COMPLETED` 학기 row, 과목별 평가와 태그를 만드는지 검증한다.
+- 후보 `CourseOffering`이 없으면 `CommonException(ErrorCode.INVALID_ARGUMENT)`로 실패하고 임의 강의/교수를 생성하지 않는지 검증한다.
+
+검증 명령:
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationServiceUnitTests'
+```
+
+예상 RED:
+
+- 신규 서비스와 repository 메서드가 없어서 컴파일 또는 테스트 실패.
+
+## Task 2: 상태 재구성 서비스를 구현한다
+
+- `AdminTestLectureEvaluationService`를 `@Service`, `@Transactional`로 추가한다.
+- 상수로 target `userId`, `studentId`, `year`, `semester`를 둔다.
+- 고정 사용자를 조회하고 연결 학생 ID가 target `studentId`와 일치하는지 확인한다.
+- 모든 상태 API는 순행/역행 여부와 관계없이 기존 target 학기 데이터를 먼저 삭제한 뒤 목표 상태를 재구성한다.
+- 공통 정리 순서:
+  - `CourseEvaluationRepository`에서 target 학생/학기 평가를 삭제한다.
+  - `StudentCourseRepository`에서 target 학생/학기 수강 과목을 삭제한다.
+  - `SemesterAcademicRecordRepository`에서 target 학생/학기 row를 삭제한다.
+- `empty-semester`는 공통 정리 후 추가 row를 만들지 않고 종료한다.
+- seed가 필요한 상태는 `CourseOfferingRepository`에서 target 학기 교수 연결 실제 강의 후보를 조회한다.
+- seed 과목 수는 최소 1개로 시작하되, repository는 안정적인 정렬로 후보를 가져온다.
+- `not-released`는 `GradeType.IP`, 나머지 성적 공개 상태는 `GradeType.A_PLUS`로 `StudentCourse`를 생성한다.
+- `SemesterAcademicRecord`에는 테스트용 최소 성적 요약 값을 넣고 상태를 강제 세팅한다.
+- `completed`는 각 수강 과목의 course/professor로 `CourseEvaluation`을 만들고 대표 태그를 함께 저장한다.
+- 모든 public 메서드 끝에서 `AcademicCache#deleteAllByStudentId`를 호출한다.
+
+검증 명령:
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationServiceUnitTests'
+```
+
+예상 GREEN:
+
+- 서비스 단위 테스트 통과.
+
+## Task 3: 컨트롤러 API와 문서 인터페이스를 추가한다
+
+- `AdminTestController`에 5개 `@PostMapping("/test-lecture-evaluations/...")` 메서드를 추가한다.
+- `AdminTestControllerDocs`에 같은 메서드와 `@Operation` 설명을 추가한다.
+- 각 endpoint는 body 없이 신규 서비스 메서드를 호출하고 `MessageOnlyResponse`를 반환한다.
+- 컨트롤러 테스트에서 5개 endpoint가 서비스 메서드 호출과 성공 메시지를 반환하는지 검증한다.
+
+검증 명령:
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.domain.admin.controller.AdminTestControllerApiIntegrationTest'
+```
+
+## Task 4: security public endpoint를 반영한다
+
+- `SecurityConfig.PUBLIC_ENDPOINTS`에 `/api/admin/test-lecture-evaluations/**`를 추가한다.
+- `JwtAuthenticationFilterTests`의 public admin test endpoint fixture에 POST endpoint를 추가한다.
+- 토큰 없이 POST 호출이 인증 오류 없이 통과하는지 검증한다.
+
+검증 명령:
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests'
+```
+
+## Task 5: OpenAPI static 문서를 갱신한다
+
+- `src/main/resources/public/openapi.yaml`에 5개 path를 추가한다.
+- 모든 path는 `Admin Test` tag, `post`, `200` 성공 응답, `400` 실패 응답을 문서화한다.
+- `OpenApiResponseContractTest`에 신규 path 존재 검증을 추가한다.
+
+검증 명령:
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.global.config.OpenApiResponseContractTest'
+```
+
+## Task 6: 통합 검증과 커밋
+
+- 관련 테스트를 한 번 더 묶어서 실행한다.
+
+```bash
+./gradlew test --tests 'com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationServiceUnitTests' --tests 'com.chukchuk.haksa.domain.admin.controller.AdminTestControllerApiIntegrationTest' --tests 'com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests' --tests 'com.chukchuk.haksa.global.config.OpenApiResponseContractTest'
+```
+
+- 전체 테스트를 실행한다.
+
+```bash
+./gradlew test
+```
+
+- 통과 후 관련 파일만 stage 한다.
+- 커밋 메시지는 repo 규칙에 맞춰 한국어로 작성한다.
+
+```bash
+git commit -m "281 feat: 강의평가 상태 테스트 API 추가"
+```
+
+## 검토 포인트
+
+- `empty-semester`를 `NOT_RELEASED`로 오해하지 않도록 API명과 문서 표현을 유지한다.
+- 실제 강의/교수 재사용 조건을 완화하지 않는다.
+- 순행/역행과 관계없이 target 학기 평가 데이터, 수강 데이터, 학기 row를 먼저 삭제한다.
+- `CourseEvaluation` unique key 충돌을 피하기 위해 completed 생성 전 target 학기 평가 데이터를 항상 삭제한다.
+- dev/test profile 컨트롤러라는 기존 `Admin Test` 경계를 유지한다.

--- a/docs/specs/20260626-issue-281-lecture-evaluation-test-api/spec-lite.md
+++ b/docs/specs/20260626-issue-281-lecture-evaluation-test-api/spec-lite.md
@@ -1,0 +1,79 @@
+# Issue 281: dev 전용 강의평가 상태 테스트 API
+
+## 목적
+
+프론트엔드 개발자가 dev 환경에서 강의평가 화면의 주요 상태를 안정적으로 재현할 수 있도록, 고정 테스트 계정의 강의평가 관련 데이터를 인증 없이 원하는 상태로 재구성하는 API를 제공한다.
+
+## 배경
+
+기존 `Admin Test` API는 실제 관리자 기능이라기보다 프론트 개발과 QA를 위한 dev 전용 테스트 데이터 조작 API다. 이번 작업도 같은 성격이며, 운영 profile에서는 컨트롤러가 로드되지 않아야 한다.
+
+대상 고정 계정은 다음 값으로 고정한다.
+
+- `user_id`: `faf9c30a-9674-4624-8855-6d0be23c749b`.
+- `student_id`: `47f72b79-a3f0-4834-869b-8ba3a0cf3474`.
+- `year`: `2026`.
+- `semester`: `10`.
+
+## 도메인 정리
+
+- `semester_academic_records`는 포털 학기 성적 요약이 있을 때 생성된다.
+- 해당 학기 과목이 아예 없는 상태는 일반적으로 `semester_academic_records` row도 없는 상태다.
+- 따라서 "과목 없음" 테스트는 `NOT_RELEASED`가 아니라 `GET /api/lecture-evaluations/required` 응답의 `evaluationStatus=null`, `grades=[]`를 재현하는 `empty-semester` 상태로 정의한다.
+- `NOT_RELEASED`는 해당 학기의 `semester_academic_records` row와 `student_courses` row가 존재하고, 대상 학기 수강 과목 성적이 모두 `IP`인 상태다.
+- `PENDING`은 해당 학기 row와 성적 공개 완료 수강 과목이 있고, 강의평가 데이터는 아직 없는 상태다.
+- `SKIPPED`는 `PENDING`과 같은 성적 조건에 더해 `lecture_evaluation_status=SKIPPED`이고, 해당 학기 강의평가 데이터는 없는 상태다.
+- `COMPLETED`는 `PENDING`과 같은 성적 조건에 더해 `lecture_evaluation_status=COMPLETED`이고, 과목별 `course_evaluations`와 `course_evaluation_tags`가 있는 상태다.
+
+## API 기본안
+
+모든 API는 `POST`이고 요청 body는 받지 않는다.
+
+- `POST /api/admin/test-lecture-evaluations/empty-semester`.
+- `POST /api/admin/test-lecture-evaluations/not-released`.
+- `POST /api/admin/test-lecture-evaluations/pending`.
+- `POST /api/admin/test-lecture-evaluations/skipped`.
+- `POST /api/admin/test-lecture-evaluations/completed`.
+
+응답은 기존 `Admin Test` API와 동일하게 `SuccessResponse<MessageOnlyResponse>`를 사용한다.
+
+## 데이터 구성 규칙
+
+- 모든 API는 순행/역행 여부와 관계없이 호출 시 먼저 대상 학생의 target 학기 평가 데이터, 수강 데이터, 학기 row를 삭제한 뒤 목표 상태에 필요한 레코드를 재구성한다.
+- `empty-semester`는 재구성 없이 삭제 상태를 유지해 강의평가 상태 조회가 `evaluationStatus=null`, `grades=[]`가 되게 한다.
+- `not-released`, `pending`, `skipped`, `completed`는 삭제 후 대상 학기의 `semester_academic_records`와 `student_courses`를 새로 구성한다.
+- 테스트 수강 과목은 새 가짜 `Course`, `Professor`, `CourseOffering`을 만들지 않고, DB에 이미 존재하는 실제 `CourseOffering` 중 `year=2026`, `semester=10`, `course_id IS NOT NULL`, `professor_id IS NOT NULL` 조건을 만족하는 row를 재사용한다.
+- 조건에 맞는 실제 `CourseOffering`이 없으면 임의 데이터를 만들지 않고 실패 응답을 반환한다.
+- `not-released`는 재사용한 수강 과목 성적을 `IP`로 저장한다.
+- `pending`, `skipped`, `completed`는 재사용한 수강 과목 성적을 `A+` 같은 완료 성적으로 저장한다.
+- `completed`는 재사용한 각 과목의 `course_id`, `professor_id` 기준으로 `course_evaluations`와 `course_evaluation_tags`를 생성한다.
+- 호출 후 대상 학생 학업 캐시는 삭제한다.
+
+## 구현 범위
+
+- 신규 dev/test 전용 서비스와 API 메서드를 추가한다.
+- 필요한 repository 삭제/조회 메서드를 추가한다.
+- security public endpoint에 신규 API를 추가한다.
+- static OpenAPI 문서에 신규 API와 응답을 반영한다.
+- 관련 controller, service, security, OpenAPI 테스트를 추가한다.
+
+## 제외
+
+- 운영 profile 활성화.
+- 별도 관리자 권한 체계.
+- 임의 테스트 강의 또는 임의 테스트 교수 생성.
+- 강의평가 통계, 조회, 수정 API.
+- 프론트엔드 화면 구현.
+
+## 완료 조건
+
+- 5개 API가 dev/test profile에서만 로드된다.
+- 5개 API가 인증 없이 호출 가능하다.
+- `empty-semester` 호출 후 `GET /api/lecture-evaluations/required`는 `evaluationStatus=null`, `grades=[]`가 되는 데이터 상태를 만든다.
+- `not-released` 호출 후 target 학기 row와 IP 수강 과목이 존재하고 `lecture_evaluation_status=NOT_RELEASED`가 된다.
+- `pending` 호출 후 target 학기 row와 완료 성적 수강 과목이 존재하고 평가 데이터 없이 `lecture_evaluation_status=PENDING`이 된다.
+- `skipped` 호출 후 target 학기 row와 완료 성적 수강 과목이 존재하고 평가 데이터 없이 `lecture_evaluation_status=SKIPPED`가 된다.
+- `completed` 호출 후 target 학기 row, 완료 성적 수강 과목, 과목별 평가 데이터와 태그가 존재하고 `lecture_evaluation_status=COMPLETED`가 된다.
+- 실제 존재하는 교수 연결 `CourseOffering`이 없으면 임의 데이터를 만들지 않고 실패한다.
+- 관련 API가 `src/main/resources/public/openapi.yaml`에 반영된다.
+- 관련 테스트와 전체 `./gradlew test`가 통과한다.

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/model/SemesterAcademicRecord.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/model/SemesterAcademicRecord.java
@@ -150,6 +150,10 @@ public class SemesterAcademicRecord extends BaseEntity {
         this.lectureEvaluationStatus = LectureEvaluationStatus.COMPLETED;
     }
 
+    public void setLectureEvaluationStatusForTest(LectureEvaluationStatus status) {
+        this.lectureEvaluationStatus = status;
+    }
+
     public boolean isLectureEvaluationPending() {
         return this.lectureEvaluationStatus == LectureEvaluationStatus.PENDING;
     }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
@@ -33,7 +33,7 @@ public interface SemesterAcademicRecordRepository extends JpaRepository<Semester
 
     void deleteByStudentId(UUID studentId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         DELETE FROM SemesterAcademicRecord sar
         WHERE sar.student.id = :studentId

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/SemesterAcademicRecordRepository.java
@@ -2,6 +2,7 @@ package com.chukchuk.haksa.domain.academic.record.repository;
 
 import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -31,4 +32,17 @@ public interface SemesterAcademicRecordRepository extends JpaRepository<Semester
     List<SemesterAcademicRecord> findByStudentIdOrderByYearDescSemesterDesc(UUID studentId);
 
     void deleteByStudentId(UUID studentId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        DELETE FROM SemesterAcademicRecord sar
+        WHERE sar.student.id = :studentId
+          AND sar.year = :year
+          AND sar.semester = :semester
+    """)
+    void deleteByStudentIdAndYearAndSemester(
+            @Param("studentId") UUID studentId,
+            @Param("year") Integer year,
+            @Param("semester") Integer semester
+    );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
@@ -37,7 +37,7 @@ public interface StudentCourseRepository extends JpaRepository<StudentCourse, Lo
     @Query("DELETE FROM StudentCourse sc WHERE sc.student.id = :studentId AND sc.id IN :ids")
     void deleteOwnedByStudentIdAndIdIn(@Param("studentId") UUID studentId, @Param("ids") List<Long> ids);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         DELETE FROM StudentCourse sc
         WHERE sc.student.id = :studentId

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/repository/StudentCourseRepository.java
@@ -36,4 +36,17 @@ public interface StudentCourseRepository extends JpaRepository<StudentCourse, Lo
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM StudentCourse sc WHERE sc.student.id = :studentId AND sc.id IN :ids")
     void deleteOwnedByStudentIdAndIdIn(@Param("studentId") UUID studentId, @Param("ids") List<Long> ids);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        DELETE FROM StudentCourse sc
+        WHERE sc.student.id = :studentId
+          AND sc.offering.year = :year
+          AND sc.offering.semester = :semester
+    """)
+    void deleteByStudentIdAndYearAndSemester(
+            @Param("studentId") UUID studentId,
+            @Param("year") Integer year,
+            @Param("semester") Integer semester
+    );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/admin/controller/AdminTestController.java
+++ b/src/main/java/com/chukchuk/haksa/domain/admin/controller/AdminTestController.java
@@ -4,6 +4,7 @@ package com.chukchuk.haksa.domain.admin.controller;
 import com.chukchuk.haksa.domain.admin.controller.docs.AdminTestControllerDocs;
 import com.chukchuk.haksa.domain.admin.dto.AdminTestDto;
 import com.chukchuk.haksa.domain.admin.service.AdminTestAccountService;
+import com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationService;
 import com.chukchuk.haksa.domain.admin.service.AdminTestMutationService;
 import com.chukchuk.haksa.domain.admin.service.AdminTestOptionService;
 import com.chukchuk.haksa.domain.course.model.FacultyDivision;
@@ -34,6 +35,7 @@ public class AdminTestController implements AdminTestControllerDocs {
     private final AdminTestAccountService accountService;
     private final AdminTestOptionService optionService;
     private final AdminTestMutationService mutationService;
+    private final AdminTestLectureEvaluationService lectureEvaluationService;
 
     @Override
     @PostMapping("/test-users")
@@ -112,5 +114,40 @@ public class AdminTestController implements AdminTestControllerDocs {
             @Valid @RequestBody AdminTestDto.CreateTestCourseRequest request
     ) {
         return ResponseEntity.ok(SuccessResponse.of(mutationService.createTestCourse(userDetails.getId(), request)));
+    }
+
+    @Override
+    @PostMapping("/test-lecture-evaluations/empty-semester")
+    public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationEmptySemester() {
+        lectureEvaluationService.setEmptySemester();
+        return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("강의평가 테스트 상태가 empty-semester로 변경되었습니다.")));
+    }
+
+    @Override
+    @PostMapping("/test-lecture-evaluations/not-released")
+    public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationNotReleased() {
+        lectureEvaluationService.setNotReleased();
+        return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("강의평가 테스트 상태가 NOT_RELEASED로 변경되었습니다.")));
+    }
+
+    @Override
+    @PostMapping("/test-lecture-evaluations/pending")
+    public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationPending() {
+        lectureEvaluationService.setPending();
+        return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("강의평가 테스트 상태가 PENDING으로 변경되었습니다.")));
+    }
+
+    @Override
+    @PostMapping("/test-lecture-evaluations/skipped")
+    public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationSkipped() {
+        lectureEvaluationService.setSkipped();
+        return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("강의평가 테스트 상태가 SKIPPED로 변경되었습니다.")));
+    }
+
+    @Override
+    @PostMapping("/test-lecture-evaluations/completed")
+    public ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationCompleted() {
+        lectureEvaluationService.setCompleted();
+        return ResponseEntity.ok(SuccessResponse.of(new MessageOnlyResponse("강의평가 테스트 상태가 COMPLETED로 변경되었습니다.")));
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/admin/controller/docs/AdminTestControllerDocs.java
+++ b/src/main/java/com/chukchuk/haksa/domain/admin/controller/docs/AdminTestControllerDocs.java
@@ -57,4 +57,19 @@ public interface AdminTestControllerDocs {
             CustomUserDetails userDetails,
             AdminTestDto.CreateTestCourseRequest request
     );
+
+    @Operation(summary = "dev 강의평가 empty-semester 상태 세팅", description = "고정 프론트 테스트 계정의 target 학기 평가/수강/학기 row를 삭제합니다.")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationEmptySemester();
+
+    @Operation(summary = "dev 강의평가 NOT_RELEASED 상태 세팅", description = "고정 프론트 테스트 계정의 target 학기를 성적 미공개 상태로 재구성합니다.")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationNotReleased();
+
+    @Operation(summary = "dev 강의평가 PENDING 상태 세팅", description = "고정 프론트 테스트 계정의 target 학기를 강의평가 대기 상태로 재구성합니다.")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationPending();
+
+    @Operation(summary = "dev 강의평가 SKIPPED 상태 세팅", description = "고정 프론트 테스트 계정의 target 학기를 강의평가 건너뛰기 상태로 재구성합니다.")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationSkipped();
+
+    @Operation(summary = "dev 강의평가 COMPLETED 상태 세팅", description = "고정 프론트 테스트 계정의 target 학기를 강의평가 완료 상태로 재구성합니다.")
+    ResponseEntity<SuccessResponse<MessageOnlyResponse>> setLectureEvaluationCompleted();
 }

--- a/src/main/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -116,7 +117,7 @@ public class AdminTestLectureEvaluationService {
     ) {
         int attemptedCredits = offerings.stream()
                 .map(CourseOffering::getPoints)
-                .filter(points -> points != null)
+                .filter(Objects::nonNull)
                 .mapToInt(Integer::intValue)
                 .sum();
         SemesterAcademicRecord record = new SemesterAcademicRecord(

--- a/src/main/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationService.java
@@ -1,0 +1,165 @@
+package com.chukchuk.haksa.domain.admin.service;
+
+import com.chukchuk.haksa.domain.academic.record.model.LectureEvaluationStatus;
+import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
+import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.cache.AcademicCache;
+import com.chukchuk.haksa.domain.course.model.CourseOffering;
+import com.chukchuk.haksa.domain.course.repository.CourseOfferingRepository;
+import com.chukchuk.haksa.domain.lectureevaluations.model.CourseEvaluation;
+import com.chukchuk.haksa.domain.lectureevaluations.model.LectureEvaluationTag;
+import com.chukchuk.haksa.domain.lectureevaluations.repository.CourseEvaluationRepository;
+import com.chukchuk.haksa.domain.lectureevaluations.repository.CourseEvaluationTagRepository;
+import com.chukchuk.haksa.domain.student.model.Grade;
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.user.model.User;
+import com.chukchuk.haksa.domain.user.repository.UserRepository;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminTestLectureEvaluationService {
+
+    private static final UUID TARGET_USER_ID = UUID.fromString("faf9c30a-9674-4624-8855-6d0be23c749b");
+    private static final UUID TARGET_STUDENT_ID = UUID.fromString("47f72b79-a3f0-4834-869b-8ba3a0cf3474");
+    private static final int TARGET_YEAR = 2026;
+    private static final int TARGET_SEMESTER = 10;
+
+    private final UserRepository userRepository;
+    private final SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+    private final StudentCourseRepository studentCourseRepository;
+    private final CourseOfferingRepository courseOfferingRepository;
+    private final CourseEvaluationRepository courseEvaluationRepository;
+    private final CourseEvaluationTagRepository courseEvaluationTagRepository;
+    private final AcademicCache academicCache;
+
+    public void setEmptySemester() {
+        Student student = getTargetStudent();
+        clearTargetSemester(student.getId());
+        academicCache.deleteAllByStudentId(student.getId());
+    }
+
+    public void setNotReleased() {
+        rebuildSemester(LectureEvaluationStatus.NOT_RELEASED, GradeType.IP, false);
+    }
+
+    public void setPending() {
+        rebuildSemester(LectureEvaluationStatus.PENDING, GradeType.A_PLUS, false);
+    }
+
+    public void setSkipped() {
+        rebuildSemester(LectureEvaluationStatus.SKIPPED, GradeType.A_PLUS, false);
+    }
+
+    public void setCompleted() {
+        rebuildSemester(LectureEvaluationStatus.COMPLETED, GradeType.A_PLUS, true);
+    }
+
+    private void rebuildSemester(LectureEvaluationStatus status, GradeType gradeType, boolean createEvaluations) {
+        Student student = getTargetStudent();
+        clearTargetSemester(student.getId());
+
+        List<CourseOffering> offerings = findReusableOfferings();
+        semesterAcademicRecordRepository.save(newSemesterRecord(student, status, offerings));
+        studentCourseRepository.saveAll(toStudentCourses(student, offerings, gradeType));
+        if (createEvaluations) {
+            courseEvaluationRepository.saveAll(toCourseEvaluations(student, offerings));
+        }
+        academicCache.deleteAllByStudentId(student.getId());
+    }
+
+    private Student getTargetStudent() {
+        User user = userRepository.findById(TARGET_USER_ID)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+        Student student = user.getStudent();
+        if (student == null || !TARGET_STUDENT_ID.equals(student.getId())) {
+            throw new CommonException(ErrorCode.USER_NOT_CONNECTED);
+        }
+        return student;
+    }
+
+    private void clearTargetSemester(UUID studentId) {
+        courseEvaluationTagRepository.deleteByStudentIdAndYearAndSemester(studentId, TARGET_YEAR, TARGET_SEMESTER);
+        courseEvaluationRepository.deleteByStudentIdAndYearAndSemester(studentId, TARGET_YEAR, TARGET_SEMESTER);
+        studentCourseRepository.deleteByStudentIdAndYearAndSemester(studentId, TARGET_YEAR, TARGET_SEMESTER);
+        semesterAcademicRecordRepository.deleteByStudentIdAndYearAndSemester(studentId, TARGET_YEAR, TARGET_SEMESTER);
+    }
+
+    private List<CourseOffering> findReusableOfferings() {
+        List<CourseOffering> offerings = courseOfferingRepository.findReusableLectureEvaluationTestOfferings(
+                TARGET_YEAR,
+                TARGET_SEMESTER
+        );
+        if (offerings.isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_ARGUMENT);
+        }
+        return offerings;
+    }
+
+    private SemesterAcademicRecord newSemesterRecord(
+            Student student,
+            LectureEvaluationStatus status,
+            List<CourseOffering> offerings
+    ) {
+        int attemptedCredits = offerings.stream()
+                .map(CourseOffering::getPoints)
+                .filter(points -> points != null)
+                .mapToInt(Integer::intValue)
+                .sum();
+        SemesterAcademicRecord record = new SemesterAcademicRecord(
+                student,
+                TARGET_YEAR,
+                TARGET_SEMESTER,
+                attemptedCredits,
+                status == LectureEvaluationStatus.NOT_RELEASED ? 0 : attemptedCredits,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                null,
+                null
+        );
+        record.setLectureEvaluationStatusForTest(status);
+        return record;
+    }
+
+    private List<StudentCourse> toStudentCourses(Student student, List<CourseOffering> offerings, GradeType gradeType) {
+        return offerings.stream()
+                .map(offering -> new StudentCourse(
+                        student,
+                        offering,
+                        new Grade(gradeType),
+                        offering.getPoints(),
+                        false,
+                        gradeType == GradeType.IP ? null : 95,
+                        false
+                ))
+                .toList();
+    }
+
+    private List<CourseEvaluation> toCourseEvaluations(Student student, List<CourseOffering> offerings) {
+        return offerings.stream()
+                .map(offering -> new CourseEvaluation(
+                        student,
+                        offering.getCourse(),
+                        offering.getProfessor(),
+                        TARGET_YEAR,
+                        TARGET_SEMESTER,
+                        "프론트 테스트용 강의평가입니다.",
+                        List.of(LectureEvaluationTag.INTERESTING_LECTURE)
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
@@ -70,8 +70,6 @@ public interface CourseOfferingRepository extends JpaRepository<CourseOffering, 
         WHERE o.deletedAt IS NULL
           AND o.year = :year
           AND o.semester = :semester
-          AND o.course IS NOT NULL
-          AND o.professor IS NOT NULL
         ORDER BY c.courseName ASC, p.professorName ASC, o.id ASC
     """)
     List<CourseOffering> findReusableLectureEvaluationTestOfferings(Integer year, Integer semester);

--- a/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
@@ -60,4 +60,19 @@ public interface CourseOfferingRepository extends JpaRepository<CourseOffering, 
             Integer semester,
             String departmentName
     );
+
+    @Query("""
+        SELECT o FROM CourseOffering o
+        JOIN FETCH o.course c
+        JOIN FETCH o.professor p
+        LEFT JOIN FETCH o.department d
+        LEFT JOIN FETCH o.liberalArtsAreaCode lac
+        WHERE o.deletedAt IS NULL
+          AND o.year = :year
+          AND o.semester = :semester
+          AND o.course IS NOT NULL
+          AND o.professor IS NOT NULL
+        ORDER BY c.courseName ASC, p.professorName ASC, o.id ASC
+    """)
+    List<CourseOffering> findReusableLectureEvaluationTestOfferings(Integer year, Integer semester);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Repository
 public interface CourseEvaluationRepository extends JpaRepository<CourseEvaluation, Long> {
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         DELETE FROM CourseEvaluation ce
         WHERE ce.student.id = :studentId

--- a/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationRepository.java
@@ -2,8 +2,26 @@ package com.chukchuk.haksa.domain.lectureevaluations.repository;
 
 import com.chukchuk.haksa.domain.lectureevaluations.model.CourseEvaluation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
 
 @Repository
 public interface CourseEvaluationRepository extends JpaRepository<CourseEvaluation, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        DELETE FROM CourseEvaluation ce
+        WHERE ce.student.id = :studentId
+          AND ce.year = :year
+          AND ce.semester = :semester
+    """)
+    void deleteByStudentIdAndYearAndSemester(
+            @Param("studentId") UUID studentId,
+            @Param("year") Integer year,
+            @Param("semester") Integer semester
+    );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationTagRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationTagRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Repository
 public interface CourseEvaluationTagRepository extends JpaRepository<CourseEvaluationTag, Long> {
 
-    @Modifying(clearAutomatically = true)
+    @Modifying
     @Query("""
         DELETE FROM CourseEvaluationTag tag
         WHERE tag.courseEvaluation.id IN (

--- a/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationTagRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/lectureevaluations/repository/CourseEvaluationTagRepository.java
@@ -2,8 +2,30 @@ package com.chukchuk.haksa.domain.lectureevaluations.repository;
 
 import com.chukchuk.haksa.domain.lectureevaluations.model.CourseEvaluationTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
 
 @Repository
 public interface CourseEvaluationTagRepository extends JpaRepository<CourseEvaluationTag, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        DELETE FROM CourseEvaluationTag tag
+        WHERE tag.courseEvaluation.id IN (
+            SELECT ce.id
+            FROM CourseEvaluation ce
+            WHERE ce.student.id = :studentId
+              AND ce.year = :year
+              AND ce.semester = :semester
+        )
+    """)
+    void deleteByStudentIdAndYearAndSemester(
+            @Param("studentId") UUID studentId,
+            @Param("year") Integer year,
+            @Param("semester") Integer semester
+    );
 }

--- a/src/main/java/com/chukchuk/haksa/global/security/SecurityConfig.java
+++ b/src/main/java/com/chukchuk/haksa/global/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
             "/api/users/signin", "/api/users/signin/**", "/api/auth/refresh",
             "/api/admin/test-users",
             "/api/admin/test-options", "/api/admin/departments", "/api/admin/course-offerings",
+            "/api/admin/test-lecture-evaluations/**",
             "/internal/scrape-results",
             "/actuator/prometheus", "/actuator/health", "/actuator/info"
     };

--- a/src/main/resources/public/openapi.yaml
+++ b/src/main/resources/public/openapi.yaml
@@ -514,6 +514,106 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorDetail'
 
+  /api/admin/test-lecture-evaluations/empty-semester:
+    post:
+      tags:
+        - Admin Test
+      summary: dev 강의평가 empty-semester 상태 세팅
+      description: 고정 프론트 테스트 계정의 2026년 1학기(10) 평가 데이터, 수강 데이터, 학기 row를 삭제해 강의평가 조회 시 evaluationStatus=null, grades=[] 상태를 재현합니다.
+      responses:
+        '200':
+          description: 강의평가 테스트 상태 세팅 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageOnlyApiResponse'
+        '400':
+          description: 잘못된 요청 또는 대상 계정 상태 불일치
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
+  /api/admin/test-lecture-evaluations/not-released:
+    post:
+      tags:
+        - Admin Test
+      summary: dev 강의평가 NOT_RELEASED 상태 세팅
+      description: 고정 프론트 테스트 계정의 2026년 1학기(10)를 실제 교수 연결 강의와 IP 성적 수강 데이터가 있는 NOT_RELEASED 상태로 재구성합니다.
+      responses:
+        '200':
+          description: 강의평가 테스트 상태 세팅 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageOnlyApiResponse'
+        '400':
+          description: 재사용 가능한 실제 강의 후보 없음 또는 대상 계정 상태 불일치
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
+  /api/admin/test-lecture-evaluations/pending:
+    post:
+      tags:
+        - Admin Test
+      summary: dev 강의평가 PENDING 상태 세팅
+      description: 고정 프론트 테스트 계정의 2026년 1학기(10)를 실제 교수 연결 강의와 완료 성적 수강 데이터가 있고 평가 데이터는 없는 PENDING 상태로 재구성합니다.
+      responses:
+        '200':
+          description: 강의평가 테스트 상태 세팅 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageOnlyApiResponse'
+        '400':
+          description: 재사용 가능한 실제 강의 후보 없음 또는 대상 계정 상태 불일치
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
+  /api/admin/test-lecture-evaluations/skipped:
+    post:
+      tags:
+        - Admin Test
+      summary: dev 강의평가 SKIPPED 상태 세팅
+      description: 고정 프론트 테스트 계정의 2026년 1학기(10)를 실제 교수 연결 강의와 완료 성적 수강 데이터가 있고 평가 데이터는 없는 SKIPPED 상태로 재구성합니다.
+      responses:
+        '200':
+          description: 강의평가 테스트 상태 세팅 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageOnlyApiResponse'
+        '400':
+          description: 재사용 가능한 실제 강의 후보 없음 또는 대상 계정 상태 불일치
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
+  /api/admin/test-lecture-evaluations/completed:
+    post:
+      tags:
+        - Admin Test
+      summary: dev 강의평가 COMPLETED 상태 세팅
+      description: 고정 프론트 테스트 계정의 2026년 1학기(10)를 실제 교수 연결 강의, 완료 성적 수강 데이터, 과목별 평가와 태그가 있는 COMPLETED 상태로 재구성합니다.
+      responses:
+        '200':
+          description: 강의평가 테스트 상태 세팅 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageOnlyApiResponse'
+        '400':
+          description: 재사용 가능한 실제 강의 후보 없음 또는 대상 계정 상태 불일치
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetail'
+
   /portal/link/jobs/{jobId}/duration:
     get:
       tags:

--- a/src/test/java/com/chukchuk/haksa/domain/admin/controller/AdminTestControllerApiIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/admin/controller/AdminTestControllerApiIntegrationTest.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.admin.controller;
 
 import com.chukchuk.haksa.domain.admin.dto.AdminTestDto;
 import com.chukchuk.haksa.domain.admin.service.AdminTestAccountService;
+import com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationService;
 import com.chukchuk.haksa.domain.admin.service.AdminTestMutationService;
 import com.chukchuk.haksa.domain.admin.service.AdminTestOptionService;
 import com.chukchuk.haksa.domain.course.model.FacultyDivision;
@@ -24,6 +25,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -50,6 +52,9 @@ class AdminTestControllerApiIntegrationTest extends ApiControllerWebMvcTestSuppo
 
     @MockBean
     private AdminTestMutationService mutationService;
+
+    @MockBean
+    private AdminTestLectureEvaluationService lectureEvaluationService;
 
     @Test
     @DisplayName("테스트 계정 생성 성공 시 토큰과 테스트 식별자를 반환한다")
@@ -240,5 +245,60 @@ class AdminTestControllerApiIntegrationTest extends ApiControllerWebMvcTestSuppo
                 .andExpect(jsonPath("$.data.courseCode").value("test_CSE101"))
                 .andExpect(jsonPath("$.data.courseName").value("프론트 테스트 강의"))
                 .andExpect(jsonPath("$.data.area").value("전선"));
+    }
+
+    @Test
+    @DisplayName("강의평가 empty-semester 테스트 상태 세팅 성공 시 성공 메시지를 반환한다")
+    void setLectureEvaluationEmptySemester_success() throws Exception {
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/empty-semester"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("강의평가 테스트 상태가 empty-semester로 변경되었습니다."));
+
+        verify(lectureEvaluationService).setEmptySemester();
+    }
+
+    @Test
+    @DisplayName("강의평가 NOT_RELEASED 테스트 상태 세팅 성공 시 성공 메시지를 반환한다")
+    void setLectureEvaluationNotReleased_success() throws Exception {
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/not-released"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("강의평가 테스트 상태가 NOT_RELEASED로 변경되었습니다."));
+
+        verify(lectureEvaluationService).setNotReleased();
+    }
+
+    @Test
+    @DisplayName("강의평가 PENDING 테스트 상태 세팅 성공 시 성공 메시지를 반환한다")
+    void setLectureEvaluationPending_success() throws Exception {
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/pending"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("강의평가 테스트 상태가 PENDING으로 변경되었습니다."));
+
+        verify(lectureEvaluationService).setPending();
+    }
+
+    @Test
+    @DisplayName("강의평가 SKIPPED 테스트 상태 세팅 성공 시 성공 메시지를 반환한다")
+    void setLectureEvaluationSkipped_success() throws Exception {
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/skipped"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("강의평가 테스트 상태가 SKIPPED로 변경되었습니다."));
+
+        verify(lectureEvaluationService).setSkipped();
+    }
+
+    @Test
+    @DisplayName("강의평가 COMPLETED 테스트 상태 세팅 성공 시 성공 메시지를 반환한다")
+    void setLectureEvaluationCompleted_success() throws Exception {
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/completed"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("강의평가 테스트 상태가 COMPLETED로 변경되었습니다."));
+
+        verify(lectureEvaluationService).setCompleted();
     }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/admin/service/AdminTestLectureEvaluationServiceUnitTests.java
@@ -1,0 +1,274 @@
+package com.chukchuk.haksa.domain.admin.service;
+
+import com.chukchuk.haksa.domain.academic.record.model.LectureEvaluationStatus;
+import com.chukchuk.haksa.domain.academic.record.model.SemesterAcademicRecord;
+import com.chukchuk.haksa.domain.academic.record.model.StudentCourse;
+import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
+import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.cache.AcademicCache;
+import com.chukchuk.haksa.domain.course.model.Course;
+import com.chukchuk.haksa.domain.course.model.CourseOffering;
+import com.chukchuk.haksa.domain.course.model.EvaluationType;
+import com.chukchuk.haksa.domain.course.model.FacultyDivision;
+import com.chukchuk.haksa.domain.course.repository.CourseOfferingRepository;
+import com.chukchuk.haksa.domain.department.model.Department;
+import com.chukchuk.haksa.domain.lectureevaluations.model.CourseEvaluation;
+import com.chukchuk.haksa.domain.lectureevaluations.repository.CourseEvaluationRepository;
+import com.chukchuk.haksa.domain.lectureevaluations.repository.CourseEvaluationTagRepository;
+import com.chukchuk.haksa.domain.professor.model.Professor;
+import com.chukchuk.haksa.domain.student.model.GradeType;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.student.model.StudentStatus;
+import com.chukchuk.haksa.domain.user.model.User;
+import com.chukchuk.haksa.domain.user.repository.UserRepository;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTestLectureEvaluationServiceUnitTests {
+
+    private static final UUID TARGET_USER_ID = UUID.fromString("faf9c30a-9674-4624-8855-6d0be23c749b");
+    private static final UUID TARGET_STUDENT_ID = UUID.fromString("47f72b79-a3f0-4834-869b-8ba3a0cf3474");
+    private static final int TARGET_YEAR = 2026;
+    private static final int TARGET_SEMESTER = 10;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SemesterAcademicRecordRepository semesterAcademicRecordRepository;
+
+    @Mock
+    private StudentCourseRepository studentCourseRepository;
+
+    @Mock
+    private CourseOfferingRepository courseOfferingRepository;
+
+    @Mock
+    private CourseEvaluationRepository courseEvaluationRepository;
+
+    @Mock
+    private CourseEvaluationTagRepository courseEvaluationTagRepository;
+
+    @Mock
+    private AcademicCache academicCache;
+
+    @InjectMocks
+    private AdminTestLectureEvaluationService service;
+
+    @Test
+    @DisplayName("empty-semester는 대상 학기 데이터를 모두 삭제하고 추가 row를 만들지 않는다")
+    void setEmptySemester_deletesTargetSemesterDataOnly() {
+        Student student = targetStudent();
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+
+        service.setEmptySemester();
+
+        InOrder inOrder = inOrder(
+                courseEvaluationTagRepository,
+                courseEvaluationRepository,
+                studentCourseRepository,
+                semesterAcademicRecordRepository
+        );
+        inOrder.verify(courseEvaluationTagRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(courseEvaluationRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(studentCourseRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(semesterAcademicRecordRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        verify(semesterAcademicRecordRepository, never()).save(any());
+        verify(studentCourseRepository, never()).saveAll(any());
+        verify(academicCache).deleteAllByStudentId(TARGET_STUDENT_ID);
+    }
+
+    @Test
+    @DisplayName("not-released는 실제 교수 연결 강의를 IP 수강 과목으로 재구성한다")
+    void setNotReleased_rebuildsIpCoursesAndNotReleasedSemester() {
+        Student student = targetStudent();
+        CourseOffering offering = offering(1L, 11L, "자료구조", "김교수");
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+        when(courseOfferingRepository.findReusableLectureEvaluationTestOfferings(TARGET_YEAR, TARGET_SEMESTER))
+                .thenReturn(List.of(offering));
+
+        service.setNotReleased();
+
+        assertRebuiltSemester(LectureEvaluationStatus.NOT_RELEASED);
+        ArgumentCaptor<List<StudentCourse>> coursesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(studentCourseRepository).saveAll(coursesCaptor.capture());
+        assertThat(coursesCaptor.getValue()).hasSize(1);
+        assertThat(coursesCaptor.getValue().get(0).getOffering()).isSameAs(offering);
+        assertThat(coursesCaptor.getValue().get(0).getGrade().getValue()).isEqualTo(GradeType.IP);
+        verify(courseEvaluationRepository, never()).saveAll(any());
+        verify(academicCache).deleteAllByStudentId(TARGET_STUDENT_ID);
+    }
+
+    @Test
+    @DisplayName("pending은 완료 성적 수강 과목과 PENDING 학기 row만 재구성한다")
+    void setPending_rebuildsCompletedCoursesAndPendingSemesterWithoutEvaluations() {
+        Student student = targetStudent();
+        CourseOffering offering = offering(1L, 11L, "자료구조", "김교수");
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+        when(courseOfferingRepository.findReusableLectureEvaluationTestOfferings(TARGET_YEAR, TARGET_SEMESTER))
+                .thenReturn(List.of(offering));
+
+        service.setPending();
+
+        assertRebuiltSemester(LectureEvaluationStatus.PENDING);
+        ArgumentCaptor<List<StudentCourse>> coursesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(studentCourseRepository).saveAll(coursesCaptor.capture());
+        assertThat(coursesCaptor.getValue().get(0).getGrade().getValue()).isEqualTo(GradeType.A_PLUS);
+        verify(courseEvaluationRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("skipped는 완료 성적 수강 과목과 SKIPPED 학기 row만 재구성한다")
+    void setSkipped_rebuildsCompletedCoursesAndSkippedSemesterWithoutEvaluations() {
+        Student student = targetStudent();
+        CourseOffering offering = offering(1L, 11L, "자료구조", "김교수");
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+        when(courseOfferingRepository.findReusableLectureEvaluationTestOfferings(TARGET_YEAR, TARGET_SEMESTER))
+                .thenReturn(List.of(offering));
+
+        service.setSkipped();
+
+        assertRebuiltSemester(LectureEvaluationStatus.SKIPPED);
+        verify(courseEvaluationRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("completed는 완료 성적 수강 과목과 평가 데이터를 재구성한다")
+    void setCompleted_rebuildsCoursesSemesterAndEvaluations() {
+        Student student = targetStudent();
+        CourseOffering first = offering(1L, 11L, "자료구조", "김교수");
+        CourseOffering second = offering(2L, 12L, "운영체제", "이교수");
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+        when(courseOfferingRepository.findReusableLectureEvaluationTestOfferings(TARGET_YEAR, TARGET_SEMESTER))
+                .thenReturn(List.of(first, second));
+
+        service.setCompleted();
+
+        assertRebuiltSemester(LectureEvaluationStatus.COMPLETED);
+        ArgumentCaptor<List<CourseEvaluation>> evaluationsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(courseEvaluationRepository).saveAll(evaluationsCaptor.capture());
+        assertThat(evaluationsCaptor.getValue()).hasSize(2);
+        assertThat(evaluationsCaptor.getValue())
+                .allSatisfy(evaluation -> assertThat(evaluation.getTags()).isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("재사용할 실제 교수 연결 강의가 없으면 임의 데이터를 만들지 않고 실패한다")
+    void setPending_throwsWhenReusableOfferingMissing() {
+        Student student = targetStudent();
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(student.getUser()));
+        when(courseOfferingRepository.findReusableLectureEvaluationTestOfferings(TARGET_YEAR, TARGET_SEMESTER))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.setPending())
+                .isInstanceOf(CommonException.class)
+                .hasMessage(ErrorCode.INVALID_ARGUMENT.message());
+
+        verify(studentCourseRepository, never()).saveAll(any());
+        verify(semesterAcademicRecordRepository, never()).save(any());
+        verify(courseEvaluationRepository, never()).saveAll(any());
+    }
+
+    private void assertRebuiltSemester(LectureEvaluationStatus expectedStatus) {
+        InOrder inOrder = inOrder(
+                courseEvaluationTagRepository,
+                courseEvaluationRepository,
+                studentCourseRepository,
+                semesterAcademicRecordRepository
+        );
+        inOrder.verify(courseEvaluationTagRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(courseEvaluationRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(studentCourseRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+        inOrder.verify(semesterAcademicRecordRepository)
+                .deleteByStudentIdAndYearAndSemester(TARGET_STUDENT_ID, TARGET_YEAR, TARGET_SEMESTER);
+
+        ArgumentCaptor<SemesterAcademicRecord> recordCaptor = ArgumentCaptor.forClass(SemesterAcademicRecord.class);
+        verify(semesterAcademicRecordRepository).save(recordCaptor.capture());
+        assertThat(recordCaptor.getValue().getStudent().getId()).isEqualTo(TARGET_STUDENT_ID);
+        assertThat(recordCaptor.getValue().getYear()).isEqualTo(TARGET_YEAR);
+        assertThat(recordCaptor.getValue().getSemester()).isEqualTo(TARGET_SEMESTER);
+        assertThat(recordCaptor.getValue().getLectureEvaluationStatus()).isEqualTo(expectedStatus);
+    }
+
+    private Student targetStudent() {
+        User user = User.builder()
+                .id(TARGET_USER_ID)
+                .email("front-dev@example.com")
+                .profileNickname("front-dev")
+                .build();
+        Student student = Student.builder()
+                .studentCode("20261234")
+                .name("프론트테스트")
+                .department(new Department("CSE", "컴퓨터학과"))
+                .major(new Department("CSE", "컴퓨터학과"))
+                .secondaryMajor(null)
+                .admissionYear(2024)
+                .semesterEnrolled(1)
+                .isTransferStudent(false)
+                .isGraduated(false)
+                .status(StudentStatus.재학)
+                .gradeLevel(1)
+                .completedSemesters(0)
+                .admissionType("신입")
+                .user(user)
+                .build();
+        ReflectionTestUtils.setField(student, "id", TARGET_STUDENT_ID);
+        user.setStudent(student);
+        return student;
+    }
+
+    private CourseOffering offering(Long courseId, Long professorId, String courseName, String professorName) {
+        Course course = new Course("CSE" + courseId, courseName);
+        ReflectionTestUtils.setField(course, "id", courseId);
+        Professor professor = new Professor(professorName);
+        ReflectionTestUtils.setField(professor, "id", professorId);
+        CourseOffering offering = new CourseOffering(
+                20261,
+                false,
+                TARGET_YEAR,
+                TARGET_SEMESTER,
+                "컴퓨터학과",
+                "01",
+                null,
+                null,
+                3,
+                EvaluationType.UNKNOWN,
+                FacultyDivision.전선,
+                course,
+                professor,
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(offering, "id", courseId * 100);
+        return offering;
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/OpenApiResponseContractTest.java
@@ -36,6 +36,11 @@ class OpenApiResponseContractTest {
             new OperationRef("/api/admin/test-options", "get"),
             new OperationRef("/api/admin/departments", "get"),
             new OperationRef("/api/admin/course-offerings", "get"),
+            new OperationRef("/api/admin/test-lecture-evaluations/empty-semester", "post"),
+            new OperationRef("/api/admin/test-lecture-evaluations/not-released", "post"),
+            new OperationRef("/api/admin/test-lecture-evaluations/pending", "post"),
+            new OperationRef("/api/admin/test-lecture-evaluations/skipped", "post"),
+            new OperationRef("/api/admin/test-lecture-evaluations/completed", "post"),
             new OperationRef("/internal/scrape-results", "post")
     );
 

--- a/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
+++ b/src/test/java/com/chukchuk/haksa/global/security/filter/JwtAuthenticationFilterTests.java
@@ -42,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -160,12 +161,20 @@ class JwtAuthenticationFilterTests {
 
         mockMvc.perform(get("/api/admin/course-offerings"))
                 .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/admin/test-lecture-evaluations/pending"))
+                .andExpect(status().isOk());
     }
 
     @RestController
     static class AdminReadEndpointController {
         @GetMapping({"/api/admin/test-options", "/api/admin/departments", "/api/admin/course-offerings"})
         String ok() {
+            return "ok";
+        }
+
+        @org.springframework.web.bind.annotation.PostMapping("/api/admin/test-lecture-evaluations/pending")
+        String postOk() {
             return "ok";
         }
     }


### PR DESCRIPTION
### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue

Closes #281

### 변경 배경

프론트엔드에서 강의평가 화면의 상태별 분기를 테스트하려면 dev 데이터가 특정 상태로 정확히 맞춰져야 합니다. 기존 `Admin Test` API는 계정/강의 데이터 조작은 가능했지만, `semester_academic_records`, `student_courses`, `course_evaluations`, `course_evaluation_tags`를 강의평가 상태별로 일관되게 재구성하는 API는 없었습니다.

### 주요 변경 사항

1. `POST /api/admin/test-lecture-evaluations/{state}` 형태의 dev/test 전용 무인증 API 5개를 추가했습니다.
   - `empty-semester`: 대상 학기 평가/수강/학기 row를 삭제해 `evaluationStatus=null`, `grades=[]` 상태를 재현합니다.
   - `not-released`: 실제 교수 연결 강의를 재사용해 IP 성적 수강 과목과 `NOT_RELEASED` 학기 row를 만듭니다.
   - `pending`: 완료 성적 수강 과목과 `PENDING` 학기 row를 만들고 평가 데이터는 비웁니다.
   - `skipped`: 완료 성적 수강 과목과 `SKIPPED` 학기 row를 만들고 평가 데이터는 비웁니다.
   - `completed`: 완료 성적 수강 과목, `COMPLETED` 학기 row, 과목별 평가/태그를 만듭니다.
2. 모든 상태 세팅은 순행/역행 여부와 관계없이 기존 target 학기 데이터를 먼저 삭제한 뒤 재구성하도록 했습니다.
3. 가짜 강의/교수는 생성하지 않고, `year=2026`, `semester=10`, `course_id`, `professor_id`가 있는 실제 `CourseOffering`만 재사용합니다.
4. `course_evaluation_tags` FK 충돌을 피하기 위해 태그 삭제 → 평가 삭제 → 수강 삭제 → 학기 row 삭제 순서로 정리합니다.
5. static OpenAPI와 security public endpoint, 관련 테스트를 함께 반영했습니다.

### 리뷰 포인트

1. `empty-semester`를 `NOT_RELEASED`와 분리한 모델링이 타당한지 확인 부탁드립니다. 코드 기준으로 과목이 없는 학기는 `semester_academic_records` row도 없는 상태가 자연스럽다고 보고 분리했습니다.
2. 테스트 API임에도 실제 `CourseOffering`/`Professor`를 재사용하도록 한 제약이 dev 데이터 운영 방식과 맞는지 봐주세요.
3. `SemesterAcademicRecord#setLectureEvaluationStatusForTest`처럼 테스트 API 전용 상태 강제 세팅 메서드를 엔티티에 둔 선택이 괜찮은지 확인 부탁드립니다.
4. bulk delete 쿼리 추가 범위와 삭제 순서가 FK/unique constraint 관점에서 충분한지 봐주세요.
5. 신규 무인증 endpoint가 `@Profile({"dev", "test"})` 컨트롤러와 `SecurityConfig.PUBLIC_ENDPOINTS` 양쪽에서 의도대로 제한되는지 확인 부탁드립니다.

### 검증

- `./gradlew test --tests 'com.chukchuk.haksa.domain.admin.service.AdminTestLectureEvaluationServiceUnitTests'`
- `./gradlew test --tests 'com.chukchuk.haksa.domain.admin.controller.AdminTestControllerApiIntegrationTest'`
- `./gradlew test --tests 'com.chukchuk.haksa.global.security.filter.JwtAuthenticationFilterTests'`
- `./gradlew test --tests 'com.chukchuk.haksa.global.config.OpenApiResponseContractTest'`
- `./gradlew test`

### 남은 주의점

- dev DB에 조건에 맞는 2026년 1학기(10) 교수 연결 `CourseOffering`이 없으면 상태 세팅 API는 임의 데이터를 만들지 않고 `INVALID_ARGUMENT`로 실패합니다.
- 이 API는 프론트 개발 편의용 dev/test endpoint이며 운영 profile 활성화는 범위 밖입니다.
