### PR TITLE
283 hotfix: 외국어 인증 추가로 인한 회원 탈퇴 오류 수정

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,1 +1,1 @@
-model = 'gpt-5-codex'
+model = "gpt-5.5"

--- a/docs/specs/20260627-issue-283-user-delete-graduation-progress/checklist.md
+++ b/docs/specs/20260627-issue-283-user-delete-graduation-progress/checklist.md
@@ -1,0 +1,8 @@
+# Checklist
+
+- [x] `student_graduation_progress`가 있는 학생 탈퇴 실패를 재현하는 통합 테스트를 추가한다.
+- [x] 실패 테스트가 기존 코드에서 실패하는지 확인한다.
+- [x] `StudentGraduationProgressRepository.deleteByStudentId(UUID studentId)`를 추가한다.
+- [x] `StudentDeletionService`가 학생 삭제 전에 졸업 진행 데이터를 삭제하도록 수정한다.
+- [x] 탈퇴 통합 테스트와 졸업 진행 관련 테스트를 실행한다.
+- [x] 변경사항을 커밋한다.

--- a/docs/specs/20260627-issue-283-user-delete-graduation-progress/context-notes.md
+++ b/docs/specs/20260627-issue-283-user-delete-graduation-progress/context-notes.md
@@ -1,0 +1,9 @@
+# Context Notes
+
+- 운영 DB에서 `19012037` 학생의 `student_graduation_progress` 행이 1개 확인됐다.
+- 운영 DB의 `students` 참조 FK는 `semester_academic_records`, `student_academic_records`, `student_courses`, `student_graduation_progress` 네 개다.
+- 기존 `StudentDeletionService`는 앞의 세 테이블만 삭제하고 `student_graduation_progress`는 삭제하지 않는다.
+- 이번 변경은 회원 탈퇴 경로만 수정한다. `StudentService.resetBy(...)`는 학업 데이터 초기화 용도라 범위에서 제외한다.
+- `.codex/config.toml`의 기존 변경은 이번 작업과 무관하므로 건드리지 않는다.
+- RED 확인 결과 `UserServiceIntegrationTest`의 기존 탈퇴 테스트가 `student_graduation_progress` FK 제약 위반으로 실패했다.
+- GREEN 확인 결과 `UserServiceIntegrationTest`와 `StudentGraduationProgressServiceTests`가 통과했다.

--- a/docs/specs/20260627-issue-283-user-delete-graduation-progress/spec-lite.md
+++ b/docs/specs/20260627-issue-283-user-delete-graduation-progress/spec-lite.md
@@ -1,0 +1,27 @@
+# 회원 탈퇴 시 졸업 진행 데이터 삭제 누락 수정
+
+## 배경
+
+회원 탈퇴 시 `students` 삭제 전에 학생을 참조하는 하위 데이터를 삭제한다.
+운영 DB 확인 결과 `student_graduation_progress.student_id`가 `students.student_id`를 FK로 참조하지만, 현재 탈퇴 로직은 해당 테이블을 삭제하지 않는다.
+
+## 목표
+
+회원 탈퇴 시 `student_graduation_progress` 행도 같은 트랜잭션에서 삭제해 졸업 진행 데이터가 있는 사용자의 탈퇴 실패를 방지한다.
+
+## 범위
+
+- `StudentGraduationProgressRepository`에 학생 ID 기준 삭제 메서드를 추가한다.
+- `StudentDeletionService`에서 학생 삭제 전에 졸업 진행 데이터를 삭제한다.
+- 회원 탈퇴 통합 테스트에 졸업 진행 데이터가 있는 학생 케이스를 포함한다.
+
+## 제외
+
+- API 응답 형식 변경.
+- DB schema 또는 Flyway migration 변경.
+- 학생 학업 데이터 초기화인 `StudentService.resetBy(...)` 동작 변경.
+
+## 검증
+
+- `./gradlew test --tests "*UserServiceIntegrationTest"`
+- `./gradlew test --tests "*StudentGraduationProgressServiceTests" --tests "*UserServiceIntegrationTest"`

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/StudentGraduationProgressRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/StudentGraduationProgressRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 
 public interface StudentGraduationProgressRepository extends JpaRepository<StudentGraduationProgress, UUID> {
     Optional<StudentGraduationProgress> findByStudentId(UUID studentId);
+
+    void deleteByStudentId(UUID studentId);
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.student.service;
 import com.chukchuk.haksa.domain.academic.record.repository.SemesterAcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentAcademicRecordRepository;
 import com.chukchuk.haksa.domain.academic.record.repository.StudentCourseRepository;
+import com.chukchuk.haksa.domain.graduation.repository.StudentGraduationProgressRepository;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.domain.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class StudentDeletionService {
     private final StudentAcademicRecordRepository studentAcademicRecordRepository;
     private final SemesterAcademicRecordRepository semesterAcademicRecordRepository;
     private final StudentCourseRepository studentCourseRepository;
+    private final StudentGraduationProgressRepository studentGraduationProgressRepository;
     private final StudentRepository studentRepository;
 
     @Transactional
@@ -34,6 +36,7 @@ public class StudentDeletionService {
             studentCourseRepository.deleteByStudentId(studentId);
             semesterAcademicRecordRepository.deleteByStudentId(studentId);
             studentAcademicRecordRepository.deleteByStudentId(studentId);
+            studentGraduationProgressRepository.deleteByStudentId(studentId);
         }
         studentRepository.delete(student);
     }

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
@@ -14,6 +14,8 @@ import com.chukchuk.haksa.domain.course.repository.CourseOfferingRepository;
 import com.chukchuk.haksa.domain.course.repository.CourseRepository;
 import com.chukchuk.haksa.domain.department.model.Department;
 import com.chukchuk.haksa.domain.department.repository.DepartmentRepository;
+import com.chukchuk.haksa.domain.graduation.model.StudentGraduationProgress;
+import com.chukchuk.haksa.domain.graduation.repository.StudentGraduationProgressRepository;
 import com.chukchuk.haksa.domain.student.model.Grade;
 import com.chukchuk.haksa.domain.student.model.GradeType;
 import com.chukchuk.haksa.domain.student.model.Student;
@@ -65,6 +67,8 @@ class UserServiceIntegrationTest {
     private CourseRepository courseRepository;
     @Autowired
     private CourseOfferingRepository courseOfferingRepository;
+    @SpyBean
+    private StudentGraduationProgressRepository studentGraduationProgressRepository;
 
     @MockBean
     private AcademicCache academicCache;
@@ -99,6 +103,7 @@ class UserServiceIntegrationTest {
         assertThat(studentAcademicRecordRepository.findByStudentId(studentId)).isEmpty();
         assertThat(semesterAcademicRecordRepository.findByStudentId(studentId)).isEmpty();
         assertThat(studentCourseRepository.findAll()).isEmpty();
+        assertThat(studentGraduationProgressRepository.findByStudentId(studentId)).isEmpty();
 
         verify(academicCache).deleteAllByStudentId(studentId);
         verify(authTokenCache).evictByUserId(user.getId().toString());
@@ -125,6 +130,7 @@ class UserServiceIntegrationTest {
         verify(authTokenCache).evictByUserId(user.getId().toString());
         verify(studentRepository, never()).delete(any());
         verify(studentAcademicRecordRepository, never()).deleteByStudentId(any());
+        verify(studentGraduationProgressRepository, never()).deleteByStudentId(any());
     }
 
     private Student createStudent(User user) {
@@ -202,5 +208,9 @@ class UserServiceIntegrationTest {
         );
         student.addStudentCourse(studentCourse);
         studentCourseRepository.save(studentCourse);
+
+        studentGraduationProgressRepository.save(
+                StudentGraduationProgress.createForLanguageCert(student, true)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- 회원 탈퇴 시 `student_graduation_progress`가 남아 `students` 삭제가 FK 제약에 걸리던 문제를 수정했습니다.
- `StudentDeletionService`에서 학생 삭제 전에 졸업 진행 데이터를 함께 삭제하도록 변경했습니다.
- 졸업 진행 데이터가 있는 사용자 탈퇴 통합 테스트를 추가했습니다.

## Root Cause

외국어 인증 동기화 이후 `student_graduation_progress`에 학생별 졸업 진행 row가 생성되지만, 기존 탈퇴 로직은 학적/학기/수강 데이터만 삭제하고 해당 row를 삭제하지 않았습니다.

## Test Plan

- [x] `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*UserServiceIntegrationTest"`
- [x] `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test --tests "*StudentGraduationProgressServiceTests" --tests "*UserServiceIntegrationTest"`
- [x] `JAVA_HOME=/Users/keemhoeyune/Library/Java/JavaVirtualMachines/temurin-17.0.18/Contents/Home ./gradlew test`

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes) 
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue

Closes #283

close #283
