### PR TITLE
298 fix: OTLP trace exporter 자동 설정 제외

### DIFF
--- a/docs/specs/20260702-otlp-tracing-default/checklist.md
+++ b/docs/specs/20260702-otlp-tracing-default/checklist.md
@@ -1,0 +1,6 @@
+# Checklist
+
+- [x] Sentry 이슈와 현재 설정 확인.
+- [x] OTLP tracing auto-configuration 제외.
+- [x] 최소 검증 실행.
+- [x] 변경 사항 커밋.

--- a/docs/specs/20260702-otlp-tracing-default/context-notes.md
+++ b/docs/specs/20260702-otlp-tracing-default/context-notes.md
@@ -1,0 +1,6 @@
+# Context Notes
+
+- `JAVA-SPRING-BOOT-4C`는 OTLP trace exporter가 `localhost:4318`로 연결을 시도하면서 발생한다.
+- Spring Boot 3.2.5 설정 메타데이터에는 `management.tracing.export.otlp.enabled`가 없다.
+- `OtlpHttpSpanExporter`는 `OtlpAutoConfiguration`에서 구성되므로 해당 auto-configuration만 제외한다.
+- `management.tracing.enabled` 기본값은 `true`로 유지해 trace/span ID 생성은 보존한다.

--- a/docs/specs/20260702-otlp-tracing-default/spec-lite.md
+++ b/docs/specs/20260702-otlp-tracing-default/spec-lite.md
@@ -1,0 +1,21 @@
+# OTLP trace exporter 자동 설정 제외
+
+## 배경
+
+Sentry `JAVA-SPRING-BOOT-4C`에서 OTLP exporter가 `localhost:4318`로 span export를 시도하다가 연결 실패가 반복된다.
+
+## 목표
+
+tracing 자체는 유지하되, OTLP collector가 없는 환경에서 trace export가 발생하지 않게 한다.
+
+## 계획
+
+1. Spring Boot 3.2.5에서 별도 export enabled 설정이 없으므로 OTLP tracing auto-configuration만 제외한다.
+2. local override와 metrics export 기본 비활성 설정은 유지한다.
+3. 설정 파일 검증과 테스트로 기본값이 안전한지 확인한다.
+
+## 완료 기준
+
+- `MANAGEMENT_TRACING_ENABLED`가 없으면 tracing은 활성화된다.
+- OTLP trace exporter는 자동 구성되지 않는다.
+- Sentry `JAVA-SPRING-BOOT-4C` 재발 여부를 배포 후 확인할 수 있다.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
     group:
       develop-shadow:
         - dev
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpAutoConfiguration
   jackson:
     time-zone: Asia/Seoul
     date-format: yyyy-MM-dd HH:mm:ss
@@ -128,7 +131,7 @@ management:
         url: ${MANAGEMENT_OTLP_METRICS_EXPORT_URL:http://localhost:4318/v1/metrics}
   # 기존 tracing 설정 유지
   tracing:
-    enabled: true
+    enabled: ${MANAGEMENT_TRACING_ENABLED:true}
 
 logging:
   exclude:


### PR DESCRIPTION
## 작업 내용

- tracing 자체는 유지하고 OTLP tracing auto-configuration만 제외했습니다.
- Spring Boot 3.2.5에는 OTLP trace exporter만 끄는 설정 키가 없어 `OtlpAutoConfiguration`을 제외했습니다.
- `traceId`/`spanId` 생성은 유지하면서 `localhost:4318` trace export 시도를 막습니다.
- 관련 Sentry 이슈: `JAVA-SPRING-BOOT-4C`
- Closes #298

## 검증

- `./gradlew test` 통과