### PR TITLE
301 fix: 개인 이수 학점 기준 통일

### DIFF
--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
@@ -42,7 +42,7 @@ public class StudentCourseDto {
                     course.getOffering().getCourse().getCourseCode(),
                     course.getOffering().getFacultyDivisionName(),
                     course.getOffering().getRawFacultyDivisionName(),
-                    course.getOffering().getPoints(),
+                    course.getPoints() != null ? course.getPoints() : 0,
                     course.getOffering().getProfessor() != null ? course.getOffering().getProfessor().getProfessorName() : "미지정",
                     course.getGrade() != null ? course.getGrade().getValue().getValue() : "F",
                     course.getPoints() != null ? course.getPoints() : 0,

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
@@ -232,7 +232,7 @@ public class GraduationQueryRepository {
             SELECT DISTINCT ON (c.course_code, co.faculty_division_name)
                 sc.offering_id,
                 TRIM(co.faculty_division_name) AS area_type,
-                co.points,
+                sc.points,
                 sc.grade,
                 c.course_name,
                 co.semester,

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDtoTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDtoTests.java
@@ -58,6 +58,17 @@ class StudentCourseDtoTests {
     }
 
     @Test
+    @DisplayName("수강 과목 응답은 개인 이수 학점을 반환한다")
+    void from_returnsStudentSpecificPoints() {
+        StudentCourse studentCourse = studentCourse(offering(FacultyDivision.전핵, null));
+        when(studentCourse.getPoints()).thenReturn(21);
+
+        StudentCourseDto.CourseDetailDto result = StudentCourseDto.CourseDetailDto.from(studentCourse);
+
+        assertThat(result.credits()).isEqualTo(21);
+    }
+
+    @Test
     @DisplayName("선교 과목 응답은 liberalAreaCode 를 반환한다")
     void from_whenMissionCourseHasAreaCode_returnsLiberalAreaCode() {
         CourseOffering offering = offering(FacultyDivision.선교, areaCode(7));

--- a/src/test/java/com/chukchuk/haksa/domain/academic/record/service/StudentCourseServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/academic/record/service/StudentCourseServiceUnitTests.java
@@ -38,7 +38,6 @@ class StudentCourseServiceUnitTests {
         when(course.getOffering().getCourse().getCourseName()).thenReturn("자료구조");
         when(course.getOffering().getCourse().getCourseCode()).thenReturn("CSE101");
         when(course.getOffering().getFacultyDivisionName()).thenReturn(FacultyDivision.전핵);
-        when(course.getOffering().getPoints()).thenReturn(3);
         when(course.getOffering().getProfessor().getProfessorName()).thenReturn("홍길동");
         when(course.getGrade().getValue().getValue()).thenReturn("A+");
         when(course.getPoints()).thenReturn(3);
@@ -71,7 +70,6 @@ class StudentCourseServiceUnitTests {
         when(course.getOffering().getCourse().getCourseName()).thenReturn("교양영어");
         when(course.getOffering().getCourse().getCourseCode()).thenReturn("ENG101");
         when(course.getOffering().getFacultyDivisionName()).thenReturn(FacultyDivision.중핵);
-        when(course.getOffering().getPoints()).thenReturn(2);
         when(course.getOffering().getProfessor()).thenReturn(null);
         when(course.getGrade()).thenReturn(null);
         when(course.getPoints()).thenReturn(null);

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryMapperTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepositoryMapperTest.java
@@ -4,13 +4,22 @@ import com.chukchuk.haksa.domain.cache.AcademicCache;
 import com.chukchuk.haksa.domain.graduation.dto.CourseDto;
 import com.chukchuk.haksa.domain.graduation.dto.CourseInternalDto;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GraduationQueryRepositoryMapperTest {
@@ -20,6 +29,9 @@ class GraduationQueryRepositoryMapperTest {
 
     @Mock
     private AcademicCache academicCache;
+
+    @Mock
+    private Query query;
 
     private GraduationQueryRepository newRepository() {
         return new GraduationQueryRepository(em, academicCache);
@@ -96,5 +108,20 @@ class GraduationQueryRepositoryMapperTest {
         CourseDto dto = repository.toCourseResponseDto(internal);
 
         assertThat(dto.getLiberalAreaCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("최근 유효 과목 조회는 개인 이수 학점을 사용한다")
+    void getLatestValidCourses_usesStudentSpecificPoints() {
+        UUID studentId = UUID.randomUUID();
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.setParameter(eq("studentId"), eq(studentId))).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of());
+
+        newRepository().getLatestValidCourses(studentId);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(em).createNativeQuery(sqlCaptor.capture());
+        assertThat(sqlCaptor.getValue()).contains("sc.points,").doesNotContain("co.points,");
     }
 }


### PR DESCRIPTION
### 변경 사항
- 수강내역의 학점을 `student_courses.points`로 반환합니다.
- 졸업진단이 공유 강좌 학점이 아닌 개인 이수 학점을 사용합니다.
- 개인 학점 회귀 테스트를 추가했습니다.

### 배경
편입 인정 학점처럼 학생마다 다른 학점이 공유 `course_offerings.points`에 반영되면 다른 학생의 졸업진단에 영향을 줄 수 있습니다.

### 검증
- `./gradlew test`

### 🔗 Related Issue

Closes #301

- #301