### PR TITLE
304 docs: 개발 문서와 Wiki 갱신 규칙 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 
 ## Documentation Maintenance
 - Keep `README.md` as the project entry point and the GitHub Wiki as the detailed developer and operations guide.
+- The Wiki is the separate `https://github.com/cchaksa/cchaksa-backend.wiki.git` repository and uses `master` as its default branch.
 - Before completing a task, decide whether changes to public APIs, authentication, database schema, domain rules, architecture, deployment, operations, or incident response require a Wiki update.
 - Add or supersede an ADR when an architecture decision, its constraints, or its operational consequences change.
 - Internal refactors and test-only changes normally do not require a Wiki update. State why no Wiki update was needed in the final response.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@
 - Keep this file short and durable. Put task-specific decisions in the relevant issue, PR, spec, or final response instead.
 - Update `AGENTS.md` only when a durable project-wide rule changes, and call that out explicitly.
 
+## Documentation Maintenance
+- Keep `README.md` as the project entry point and the GitHub Wiki as the detailed developer and operations guide.
+- Before completing a task, decide whether changes to public APIs, authentication, database schema, domain rules, architecture, deployment, operations, or incident response require a Wiki update.
+- Add or supersede an ADR when an architecture decision, its constraints, or its operational consequences change.
+- Internal refactors and test-only changes normally do not require a Wiki update. State why no Wiki update was needed in the final response.
+- When a Wiki update is required, update the separate Wiki repository, verify its links and sensitive-data safety, push it, and confirm the public page renders.
+- Follow the human-facing documentation and commit procedure in the Wiki `Development Guide`; do not duplicate its long-form content here.
+
 ## Communication
 - When the user writes in Korean, respond in Korean unless the task requires another language.
 - Korean sentences should end with `.`, `?`, or `!`, not a closing colon.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 4. [기술 스택](#기술-스택)
 5. [아키텍처](#아키텍처)
 6. [ERD](#erd)
-7. [커밋 컨벤션](#커밋-컨벤션)
+7. [개발 문서](#개발-문서)
 8. [관련 블로그 게시글](#관련-블로그-게시글)
 
 ---
@@ -151,42 +151,13 @@ flowchart LR
 
 ---
 
-## 커밋 컨벤션
+## 개발 문서
 
-### 기본 구조
-```
-type: subject
+- [Backend Wiki](https://github.com/cchaksa/cchaksa-backend/wiki): 로컬 실행, 아키텍처, API·인증, 배포, 운영, 트러블슈팅.
+- [Development Guide](https://github.com/cchaksa/cchaksa-backend/wiki/Development-Guide): 브랜치, 커밋, 테스트, PR, Wiki 갱신 절차.
+- [Architecture Decision Records](https://github.com/cchaksa/cchaksa-backend/wiki/Architecture-Decision-Records): 주요 기술 결정과 재검토 조건.
 
-body (선택)
-```
-
-### type 종류
-```
-feat: 기능 추가
-fix: 버그 수정
-refactor: 코드 리팩토링
-comment: 주석 추가/수정
-docs: 문서 수정
-test: 테스트 코드 작성 또는 수정
-chore: 빌드/패키지 설정 변경
-rename: 파일/폴더명 변경
-remove: 파일 삭제
-style: 코드 포맷팅
-!BREAKING CHANGE!: 기존 API 사용에 영향을 주는 변경 (예: 응답 포맷 변경 등)
-```
-
-### 커밋 예시
-```
-feat: 로그인 기능 구현
-
-Email 중복확인 API 개발
-
----
-
-fix: 사용자 정보 누락 버그 해결
-
-사용자 서비스 코드 수정
-```
+AI Agent의 실행 규칙은 저장소의 [`AGENTS.md`](AGENTS.md)에서 관리합니다. 사람용 상세 절차는 Wiki에서 관리하며 README에 중복해서 작성하지 않습니다.
 
 ---
 


### PR DESCRIPTION
## 변경 사항

- `AGENTS.md`에 문서별 책임과 Wiki 갱신 판단·게시 규칙을 추가했습니다.
- Wiki 저장소 주소와 기본 브랜치 `master`를 명시했습니다.
- README의 오래된 커밋 컨벤션을 제거하고 개발 문서 진입점으로 정리했습니다.
- Wiki [Development Guide](https://github.com/cchaksa/cchaksa-backend/wiki/Development-Guide)에 커밋 type, PR 규칙, 문서 책임, Wiki 갱신 판단표와 게시 절차를 추가했습니다.

## 변경 이유

README의 `type: subject` 예시와 실제 `{issue-number} {type}: {message}` 규칙이 달랐습니다. 또한 코드 변경 시 Wiki 갱신 여부와 게시 완료 조건이 명확하지 않아 작업마다 문서가 누락될 수 있었습니다.

이번 `AGENTS.md` 변경은 프로젝트 전체에 지속 적용되는 규칙입니다. 상세 사람용 절차는 Wiki에서 관리하고 에이전트 규칙은 짧게 유지합니다.

## 검증

- `./gradlew test` 성공.
- 메인 저장소와 Wiki `git diff --check` 성공.
- Wiki 내부 링크 16개 문서 검증 성공.
- README의 공개 Wiki 링크 3개 HTTP 200 확인.
- 민감정보 패턴 검사 통과.
- 공개 Development Guide의 본문과 목차 렌더링 확인.

Closes #304