### PR TITLE
310 feat: Sentry 예외 이벤트 가독성 및 분류 체계 개선

### DIFF
--- a/docs/superpowers/plans/2026-07-22-sentry-event-classification.md
+++ b/docs/superpowers/plans/2026-07-22-sentry-event-classification.md
@@ -1,0 +1,111 @@
+# Sentry Event Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep every actionable user event while making Sentry issues searchable, readable, and free from known same-request duplicate log events.
+
+**Architecture:** `GlobalExceptionHandler` remains the single capture point for handled web exceptions. A small Logback filter rejects only known duplicate web-request logs from the exception handler and Hibernate, while a Spring-managed Sentry callback normalizes handled domain exception titles without changing API responses or fingerprints.
+
+**Tech Stack:** Java 17, Spring Boot 3.2.5, Sentry Java 8.16.0, Logback, JUnit 5, AssertJ.
+
+## Global Constraints
+
+- Preserve every event for actionable errors such as `G02`; do not sample by user.
+- Never include raw student codes, email addresses, tokens, SQL, IPs, UUIDs, trace IDs, or span IDs in issue titles.
+- Keep user-specific values as searchable event tags, never as fingerprint values.
+- Keep dev and prod Sentry environments separate.
+- Follow test-first red-green cycles and split commits into small logical units near 30 changed lines when practical.
+
+---
+
+### Task 1: Normalize searchable Sentry tags
+
+**Files:**
+- Modify: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java`
+- Modify: `src/main/resources/logback-spring.xml`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java`
+- Test: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTests.java`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java`
+
+**Interfaces:**
+- Consumes: existing MDC values and `HashUtil.sha256Short(String)`.
+- Produces: `studentCodeHash`, `admissionYear`, `departmentId`, `secondaryDepartmentId`, `majorType`, and `traceId` Sentry tags.
+
+- [ ] Write failing tests that require hashed student identification and camelCase graduation tags.
+- [ ] Run `./gradlew test --tests '*SentryMdcTagBinderTest' --tests '*GraduationMajorResolverTests' --tests '*LogbackConfigTest'` and verify the new assertions fail.
+- [ ] Replace raw `student_code` MDC with `studentCodeHash` and normalize graduation tag names at the throw site.
+- [ ] Align the binder and both Logback Sentry appenders with the normalized tag list.
+- [ ] Re-run the focused tests and verify they pass.
+- [ ] Commit with `310 fix: Sentry 사용자 문맥 태그 정규화`.
+
+### Task 2: Filter expected client errors without hiding actionable errors
+
+**Files:**
+- Modify: `src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java`
+- Test: `src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java`
+
+**Interfaces:**
+- Consumes: `BaseException.getCode()` and request URI for contextual entity-not-found handling.
+- Produces: `shouldReportBaseException(BaseException)` and `shouldReportEntityNotFound(EntityNotFoundException, HttpServletRequest)` decisions.
+
+- [ ] Add failing tests that exclude lecture-evaluation client errors and stale refresh-token user lookups.
+- [ ] Add a regression assertion that `G02` and system scrape failures remain reportable.
+- [ ] Run `./gradlew test --tests '*GlobalExceptionHandlerTest'` and verify the new exclusions fail.
+- [ ] Extend expected error-code filtering to all `BaseException` subtypes and add URI-scoped `U01` filtering only for `/api/auth/refresh`.
+- [ ] Re-run the focused test and verify it passes.
+- [ ] Commit with `310 fix: 예상 가능한 Sentry 오류 제외`.
+
+### Task 3: Normalize issue titles while preserving exceptions
+
+**Files:**
+- Create: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallback.java`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallbackTest.java`
+- Modify: `src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java`
+
+**Interfaces:**
+- Consumes: event tags `error.code`, `error.title`, and the processed Sentry exception list.
+- Produces: a `SentryOptions.BeforeSendCallback` Spring bean that rewrites only the displayed outer exception type/value and retains its stack trace.
+
+- [ ] Write failing callback tests for `[G02] 졸업요건 데이터 없음`, non-domain exceptions, and missing exception lists.
+- [ ] Run `./gradlew test --tests '*SentryEventTitleCallbackTest'` and verify compilation or assertions fail because the callback does not exist.
+- [ ] Add the callback bean and set `error.title` plus `operation` tags at the handler capture boundary.
+- [ ] Keep fingerprints based on stable error type and code, never user tags.
+- [ ] Re-run title and handler tests and verify they pass.
+- [ ] Commit with `310 feat: Sentry 이슈 제목 정규화`.
+
+### Task 4: Remove known same-request Logback duplicates
+
+**Files:**
+- Create: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateLogFilter.java`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateLogFilterTest.java`
+- Modify: `src/main/java/com/chukchuk/haksa/global/logging/filter/MdcUserEnricherFilter.java`
+- Modify: `src/main/resources/logback-spring.xml`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java`
+
+**Interfaces:**
+- Consumes: MDC marker `sentryManagedRequest` and `ILoggingEvent.getLoggerName()`.
+- Produces: `DENY` only for managed web-request logs from `GlobalExceptionHandler` and `org.hibernate.*`; all other events return `NEUTRAL`.
+
+- [ ] Write failing filter tests for managed duplicate loggers, unmanaged/background logs, and unrelated application loggers.
+- [ ] Run `./gradlew test --tests '*SentryDuplicateLogFilterTest' --tests '*LogbackConfigTest'` and verify the new behavior fails.
+- [ ] Add and clean up the request-scoped MDC marker in `MdcUserEnricherFilter`.
+- [ ] Add the filter to dev and prod Sentry appenders.
+- [ ] Re-run focused tests and verify they pass.
+- [ ] Commit with `310 fix: 동일 요청 Sentry 로그 중복 차단`.
+
+### Task 5: Verify integrated behavior
+
+**Files:**
+- Modify only if verification exposes a requirement-linked defect.
+
+**Interfaces:**
+- Consumes: all changes from Tasks 1 through 4.
+- Produces: verified #310 acceptance criteria.
+
+- [ ] Run `./gradlew test --tests '*GlobalExceptionHandlerTest' --tests '*Sentry*Test' --tests '*LogbackConfigTest'`.
+- [ ] Run the full `./gradlew test` suite.
+- [ ] Inspect `git diff --check` and `git status --short`.
+- [ ] Confirm `G02` remains reportable, expected client errors are excluded, raw student code is absent from tags, and only known duplicate loggers are denied.
+- [ ] Review the final diff for unrelated changes and PII exposure.
+

--- a/docs/tasks/310/plan.md
+++ b/docs/tasks/310/plan.md
@@ -108,4 +108,3 @@
 - [ ] Inspect `git diff --check` and `git status --short`.
 - [ ] Confirm `G02` remains reportable, expected client errors are excluded, raw student code is absent from tags, and only known duplicate loggers are denied.
 - [ ] Review the final diff for unrelated changes and PII exposure.
-

--- a/docs/tasks/310/plan.md
+++ b/docs/tasks/310/plan.md
@@ -1,6 +1,6 @@
 # Sentry Event Classification Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Checked items record completed work.
 
 **Goal:** Keep every actionable user event while making Sentry issues searchable, readable, and free from known same-request duplicate log events.
 
@@ -25,19 +25,19 @@
 - Modify: `src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java`
 - Modify: `src/main/resources/logback-spring.xml`
 - Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java`
-- Test: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTests.java`
+- Test: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java`
 - Test: `src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java`
 
 **Interfaces:**
 - Consumes: existing MDC values and `HashUtil.sha256Short(String)`.
 - Produces: `studentCodeHash`, `admissionYear`, `departmentId`, `secondaryDepartmentId`, `majorType`, and `traceId` Sentry tags.
 
-- [ ] Write failing tests that require hashed student identification and camelCase graduation tags.
-- [ ] Run `./gradlew test --tests '*SentryMdcTagBinderTest' --tests '*GraduationMajorResolverTests' --tests '*LogbackConfigTest'` and verify the new assertions fail.
-- [ ] Replace raw `student_code` MDC with `studentCodeHash` and normalize graduation tag names at the throw site.
-- [ ] Align the binder and both Logback Sentry appenders with the normalized tag list.
-- [ ] Re-run the focused tests and verify they pass.
-- [ ] Commit with `310 fix: Sentry 사용자 문맥 태그 정규화`.
+- [x] Write failing tests that require hashed student identification and camelCase graduation tags.
+- [x] Run `./gradlew test --tests '*SentryMdcTagBinderTest' --tests '*GraduationMajorResolverTest' --tests '*LogbackConfigTest'` and verify the new assertions fail.
+- [x] Replace raw `student_code` MDC with `studentCodeHash` and normalize graduation tag names at the throw site.
+- [x] Align the binder and both Logback Sentry appenders with the normalized tag list.
+- [x] Re-run the focused tests and verify they pass.
+- [x] Commit with `310 fix: Sentry 사용자 문맥 태그 정규화`.
 
 ### Task 2: Filter expected client errors without hiding actionable errors
 
@@ -49,12 +49,12 @@
 - Consumes: `BaseException.getCode()` and request URI for contextual entity-not-found handling.
 - Produces: `shouldReportBaseException(BaseException)` and `shouldReportEntityNotFound(EntityNotFoundException, HttpServletRequest)` decisions.
 
-- [ ] Add failing tests that exclude lecture-evaluation client errors and stale refresh-token user lookups.
-- [ ] Add a regression assertion that `G02` and system scrape failures remain reportable.
-- [ ] Run `./gradlew test --tests '*GlobalExceptionHandlerTest'` and verify the new exclusions fail.
-- [ ] Extend expected error-code filtering to all `BaseException` subtypes and add URI-scoped `U01` filtering only for `/api/auth/refresh`.
-- [ ] Re-run the focused test and verify it passes.
-- [ ] Commit with `310 fix: 예상 가능한 Sentry 오류 제외`.
+- [x] Add failing tests that exclude lecture-evaluation client errors and stale refresh-token user lookups.
+- [x] Add a regression assertion that `G02` and system scrape failures remain reportable.
+- [x] Run `./gradlew test --tests '*GlobalExceptionHandlerTest'` and verify the new exclusions fail.
+- [x] Extend expected error-code filtering to all `BaseException` subtypes and add URI-scoped `U01` filtering only for `/api/auth/refresh`.
+- [x] Re-run the focused test and verify it passes.
+- [x] Commit with `310 fix: 예상 가능한 Sentry 오류 제외`.
 
 ### Task 3: Normalize issue titles while preserving exceptions
 
@@ -67,18 +67,18 @@
 - Consumes: event tags `error.code`, `error.title`, and the processed Sentry exception list.
 - Produces: a `SentryOptions.BeforeSendCallback` Spring bean that rewrites only the displayed outer exception type/value and retains its stack trace.
 
-- [ ] Write failing callback tests for `[G02] 졸업요건 데이터 없음`, non-domain exceptions, and missing exception lists.
-- [ ] Run `./gradlew test --tests '*SentryEventTitleCallbackTest'` and verify compilation or assertions fail because the callback does not exist.
-- [ ] Add the callback bean and set `error.title` plus `operation` tags at the handler capture boundary.
-- [ ] Keep fingerprints based on stable error type and code, never user tags.
-- [ ] Re-run title and handler tests and verify they pass.
-- [ ] Commit with `310 feat: Sentry 이슈 제목 정규화`.
+- [x] Write failing callback tests for `[G02] 졸업요건 데이터 없음`, non-domain exceptions, and missing exception lists.
+- [x] Run `./gradlew test --tests '*SentryEventTitleCallbackTest'` and verify compilation or assertions fail because the callback does not exist.
+- [x] Add the callback bean and set `error.title` plus `operation` tags at the handler capture boundary.
+- [x] Keep fingerprints based on stable error type and code, never user tags.
+- [x] Re-run title and handler tests and verify they pass.
+- [x] Commit with `310 feat: Sentry 이슈 제목 정규화`.
 
 ### Task 4: Remove known same-request Logback duplicates
 
 **Files:**
-- Create: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateLogFilter.java`
-- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateLogFilterTest.java`
+- Create: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilter.java`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilterTest.java`
 - Modify: `src/main/java/com/chukchuk/haksa/global/logging/filter/MdcUserEnricherFilter.java`
 - Modify: `src/main/resources/logback-spring.xml`
 - Test: `src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java`
@@ -87,12 +87,12 @@
 - Consumes: MDC marker `sentryManagedRequest` and `ILoggingEvent.getLoggerName()`.
 - Produces: `DENY` only for managed web-request logs from `GlobalExceptionHandler` and `org.hibernate.*`; all other events return `NEUTRAL`.
 
-- [ ] Write failing filter tests for managed duplicate loggers, unmanaged/background logs, and unrelated application loggers.
-- [ ] Run `./gradlew test --tests '*SentryDuplicateLogFilterTest' --tests '*LogbackConfigTest'` and verify the new behavior fails.
-- [ ] Add and clean up the request-scoped MDC marker in `MdcUserEnricherFilter`.
-- [ ] Add the filter to dev and prod Sentry appenders.
-- [ ] Re-run focused tests and verify they pass.
-- [ ] Commit with `310 fix: 동일 요청 Sentry 로그 중복 차단`.
+- [x] Write failing filter tests for managed duplicate loggers, unmanaged/background logs, and unrelated application loggers.
+- [x] Run `./gradlew test --tests '*SentryDuplicateEventFilterTest' --tests '*LogbackConfigTest'` and verify the new behavior fails.
+- [x] Add and clean up the request-scoped MDC marker in `MdcUserEnricherFilter`.
+- [x] Add the filter to dev and prod Sentry appenders.
+- [x] Re-run focused tests and verify they pass.
+- [x] Commit with `310 fix: 동일 요청 Sentry 로그 중복 차단`.
 
 ### Task 5: Verify integrated behavior
 
@@ -103,8 +103,8 @@
 - Consumes: all changes from Tasks 1 through 4.
 - Produces: verified #310 acceptance criteria.
 
-- [ ] Run `./gradlew test --tests '*GlobalExceptionHandlerTest' --tests '*Sentry*Test' --tests '*LogbackConfigTest'`.
-- [ ] Run the full `./gradlew test` suite.
-- [ ] Inspect `git diff --check` and `git status --short`.
-- [ ] Confirm `G02` remains reportable, expected client errors are excluded, raw student code is absent from tags, and only known duplicate loggers are denied.
-- [ ] Review the final diff for unrelated changes and PII exposure.
+- [x] Run `./gradlew test --tests '*GlobalExceptionHandlerTest' --tests '*Sentry*Test' --tests '*LogbackConfigTest'`.
+- [x] Run the full `./gradlew test --stacktrace --no-daemon` suite.
+- [x] Inspect `git diff --check` and `git status --short`.
+- [x] Confirm `G02` remains reportable, expected client errors are excluded, raw student code is absent from tags, and only known duplicate loggers are denied.
+- [x] Review the final diff for unrelated changes and PII exposure.

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
@@ -7,6 +7,7 @@ import com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepository
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
+import com.chukchuk.haksa.global.logging.util.HashUtil;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
@@ -131,12 +132,12 @@ public class GraduationMajorResolver {
             Long secondaryMajorId,
             int admissionYear
     ) {
-        MDC.put("student_code", student.getStudentCode());
-        MDC.put("admission_year", String.valueOf(admissionYear));
-        MDC.put("primary_department_id", String.valueOf(primaryMajorId));
-        MDC.put("secondary_department_id",
+        MDC.put("studentCodeHash", HashUtil.sha256Short(student.getStudentCode()));
+        MDC.put("admissionYear", String.valueOf(admissionYear));
+        MDC.put("departmentId", String.valueOf(primaryMajorId));
+        MDC.put("secondaryDepartmentId",
                 secondaryMajorId == null ? "NONE" : String.valueOf(secondaryMajorId));
-        MDC.put("major_type", secondaryMajorId == null ? "SINGLE" : "DUAL");
+        MDC.put("majorType", secondaryMajorId == null ? "SINGLE" : "DUAL");
 
         throw new CommonException(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND);
     }

--- a/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
@@ -37,7 +37,9 @@ public class GlobalExceptionHandler {
             ErrorCode.PORTAL_ACCOUNT_LOCKED.code(),
             ErrorCode.INVALID_CALLBACK_SIGNATURE.code(),
             ErrorCode.SCRAPE_INVALID_CALLBACK_REQUEST.code(),
-            ErrorCode.SCRAPE_INVALID_S3_KEY.code()
+            ErrorCode.SCRAPE_INVALID_S3_KEY.code(),
+            ErrorCode.LECTURE_EVALUATION_NOT_REQUIRED.code(),
+            ErrorCode.LECTURE_EVALUATION_COURSE_MISMATCH.code()
     );
 
     /** 비즈니스 예외(대부분 4xx)*/
@@ -93,15 +95,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleEntityNotFound(EntityNotFoundException ex, HttpServletRequest req) {
 
-        try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
-            Sentry.withScope(scope -> {
-                scope.setTag("error.type", "ENTITY_NOT_FOUND");
-                scope.setTag("error.code", ex.getCode());
-                scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
-                scope.setLevel(io.sentry.SentryLevel.WARNING);
-                SentryMdcTagBinder.bind(scope);
-                Sentry.captureException(ex);
-            });
+        if (shouldReportEntityNotFound(ex, req)) {
+            try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
+                Sentry.withScope(scope -> {
+                    scope.setTag("error.type", "ENTITY_NOT_FOUND");
+                    scope.setTag("error.code", ex.getCode());
+                    scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
+                    scope.setLevel(io.sentry.SentryLevel.WARNING);
+                    SentryMdcTagBinder.bind(scope);
+                    Sentry.captureException(ex);
+                });
+            }
         }
 
         return ResponseEntity.status(ex.getStatus())
@@ -162,5 +166,10 @@ public class GlobalExceptionHandler {
             return !EXPECTED_CLIENT_ERROR_CODES.contains(ex.getCode());
         }
         return true;
+    }
+
+    boolean shouldReportEntityNotFound(EntityNotFoundException ex, HttpServletRequest req) {
+        return !ErrorCode.USER_NOT_FOUND.code().equals(ex.getCode())
+                || !"/api/auth/refresh".equals(req.getRequestURI());
     }
 }

--- a/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.chukchuk.haksa.global.exception.handler;
 import com.chukchuk.haksa.global.common.response.ErrorResponse;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.BaseException;
-import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.global.logging.sanitize.LogSanitizer;
 import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
@@ -22,6 +21,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.List;
 import java.util.Set;
@@ -53,6 +53,7 @@ public class GlobalExceptionHandler {
                     scope.setTag("error.type", "BASE_EXCEPTION");
                     scope.setTag("error.code", ex.getCode());
                     scope.setTag(SentryEventTitleCallback.ERROR_TITLE_TAG, sentryTitle(ex));
+                    scope.setTag("operation", sentryOperation(req));
                     scope.setFingerprint(List.of("BASE_EXCEPTION", ex.getCode()));
                     scope.setLevel(io.sentry.SentryLevel.WARNING); // 4xx 의미 유지
 
@@ -103,6 +104,7 @@ public class GlobalExceptionHandler {
                     scope.setTag("error.type", "ENTITY_NOT_FOUND");
                     scope.setTag("error.code", ex.getCode());
                     scope.setTag(SentryEventTitleCallback.ERROR_TITLE_TAG, sentryTitle(ex));
+                    scope.setTag("operation", sentryOperation(req));
                     scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
                     scope.setLevel(io.sentry.SentryLevel.WARNING);
                     SentryMdcTagBinder.bind(scope);
@@ -120,6 +122,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleRuntime(RuntimeException ex, HttpServletRequest req) {
         try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
             Sentry.withScope(scope -> {
+                scope.setTag("operation", sentryOperation(req));
                 SentryMdcTagBinder.bind(scope);
                 Sentry.captureException(ex);
             });
@@ -134,6 +137,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAny(Exception ex, HttpServletRequest req) {
         try (SentryMdcContext.MdcScope ignored = SentryMdcContext.openFromRequest(req)) {
             Sentry.withScope(scope -> {
+                scope.setTag("operation", sentryOperation(req));
                 SentryMdcTagBinder.bind(scope);
                 Sentry.captureException(ex);
             });
@@ -168,11 +172,14 @@ public class GlobalExceptionHandler {
         return "[%s] %s".formatted(ex.getCode(), ex.getMessage());
     }
 
+    String sentryOperation(HttpServletRequest req) {
+        Object pattern = req.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        String route = pattern instanceof String value ? value : "UNKNOWN";
+        return "%s %s".formatted(nvl(req.getMethod()), route).trim();
+    }
+
     boolean shouldReportBaseException(BaseException ex) {
-        if (ex instanceof CommonException) {
-            return !EXPECTED_CLIENT_ERROR_CODES.contains(ex.getCode());
-        }
-        return true;
+        return !EXPECTED_CLIENT_ERROR_CODES.contains(ex.getCode());
     }
 
     boolean shouldReportEntityNotFound(EntityNotFoundException ex, HttpServletRequest req) {

--- a/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import com.chukchuk.haksa.global.logging.sanitize.LogSanitizer;
 import com.chukchuk.haksa.global.logging.sentry.SentryMdcContext;
+import com.chukchuk.haksa.global.logging.sentry.SentryEventTitleCallback;
 import com.chukchuk.haksa.global.logging.sentry.SentryMdcTagBinder;
 import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,6 +52,7 @@ public class GlobalExceptionHandler {
                 Sentry.withScope(scope -> {
                     scope.setTag("error.type", "BASE_EXCEPTION");
                     scope.setTag("error.code", ex.getCode());
+                    scope.setTag(SentryEventTitleCallback.ERROR_TITLE_TAG, sentryTitle(ex));
                     scope.setFingerprint(List.of("BASE_EXCEPTION", ex.getCode()));
                     scope.setLevel(io.sentry.SentryLevel.WARNING); // 4xx 의미 유지
 
@@ -100,6 +102,7 @@ public class GlobalExceptionHandler {
                 Sentry.withScope(scope -> {
                     scope.setTag("error.type", "ENTITY_NOT_FOUND");
                     scope.setTag("error.code", ex.getCode());
+                    scope.setTag(SentryEventTitleCallback.ERROR_TITLE_TAG, sentryTitle(ex));
                     scope.setFingerprint(List.of("ENTITY_NOT_FOUND", ex.getCode()));
                     scope.setLevel(io.sentry.SentryLevel.WARNING);
                     SentryMdcTagBinder.bind(scope);
@@ -160,6 +163,10 @@ public class GlobalExceptionHandler {
     }
 
     private String nvl(String s) { return s == null ? "" : s; }
+
+    private String sentryTitle(BaseException ex) {
+        return "[%s] %s".formatted(ex.getCode(), ex.getMessage());
+    }
 
     boolean shouldReportBaseException(BaseException ex) {
         if (ex instanceof CommonException) {

--- a/src/main/java/com/chukchuk/haksa/global/logging/filter/MdcUserEnricherFilter.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/filter/MdcUserEnricherFilter.java
@@ -1,5 +1,6 @@
 package com.chukchuk.haksa.global.logging.filter;
 
+import com.chukchuk.haksa.global.logging.sentry.SentryDuplicateEventFilter;
 import com.chukchuk.haksa.global.logging.util.HashUtil;
 import io.sentry.Sentry;
 import io.sentry.protocol.User;
@@ -30,6 +31,7 @@ public class MdcUserEnricherFilter extends OncePerRequestFilter {
 
             MDC.put("userId", userId);
             MDC.put("userIdHash", HashUtil.sha256Short(userId));
+            MDC.put(SentryDuplicateEventFilter.MANAGED_REQUEST_MDC_KEY, "true");
 
             String studentCode = resolveStudentCode();
             if (studentCode != null && !studentCode.isBlank()) {
@@ -48,6 +50,7 @@ public class MdcUserEnricherFilter extends OncePerRequestFilter {
             MDC.remove("userId");
             MDC.remove("userIdHash");
             MDC.remove("studentCodeHash");
+            MDC.remove(SentryDuplicateEventFilter.MANAGED_REQUEST_MDC_KEY);
             Sentry.setUser(null); // 반드시 해제
         }
     }

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilter.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilter.java
@@ -1,0 +1,30 @@
+// HTTP 요청에서 명시적 예외 캡처와 중복되는 Logback Sentry 이벤트를 제외하는 필터
+package com.chukchuk.haksa.global.logging.sentry;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import java.util.Map;
+
+public class SentryDuplicateEventFilter extends Filter<ILoggingEvent> {
+
+    public static final String MANAGED_REQUEST_MDC_KEY = "sentryManagedRequest";
+    private static final String EXCEPTION_HANDLER_LOGGER =
+            "com.chukchuk.haksa.global.exception.handler.GlobalExceptionHandler";
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        Map<String, String> mdc = event.getMDCPropertyMap();
+        if (mdc == null || !"true".equals(mdc.get(MANAGED_REQUEST_MDC_KEY))) {
+            return FilterReply.NEUTRAL;
+        }
+
+        String logger = event.getLoggerName();
+        if (EXCEPTION_HANDLER_LOGGER.equals(logger)
+                || (logger != null && logger.startsWith("org.hibernate."))) {
+            return FilterReply.DENY;
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallback.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallback.java
@@ -1,0 +1,30 @@
+// 도메인 예외의 Sentry 이슈 제목을 오류 코드 기반으로 정규화하는 콜백
+package com.chukchuk.haksa.global.logging.sentry;
+
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.SentryOptions;
+import io.sentry.protocol.SentryException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SentryEventTitleCallback implements SentryOptions.BeforeSendCallback {
+
+    public static final String ERROR_TITLE_TAG = "error.title";
+
+    @Override
+    public SentryEvent execute(SentryEvent event, Hint hint) {
+        String title = event.getTag(ERROR_TITLE_TAG);
+        List<SentryException> exceptions = event.getExceptions();
+        if (title == null || title.isBlank() || exceptions == null || exceptions.isEmpty()) {
+            return event;
+        }
+
+        SentryException outermost = exceptions.get(exceptions.size() - 1);
+        outermost.setType(title);
+        outermost.setValue(null);
+        return event;
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
@@ -19,11 +19,12 @@ public final class SentryMdcTagBinder {
             "outboxId",
             "operationType",
             "workerRequestId",
-            "student_code",
-            "admission_year",
-            "primary_department_id",
-            "secondary_department_id",
-            "major_type"
+            "studentCodeHash",
+            "admissionYear",
+            "departmentId",
+            "secondaryDepartmentId",
+            "majorType",
+            "traceId"
     );
 
     private SentryMdcTagBinder() {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,11 +34,12 @@
             <tag>outboxId</tag>
             <tag>operationType</tag>
             <tag>workerRequestId</tag>
-            <tag>student_code</tag>
-            <tag>admission_year</tag>
-            <tag>primary_department_id</tag>
-            <tag>secondary_department_id</tag>
-            <tag>major_type</tag>
+            <tag>studentCodeHash</tag>
+            <tag>admissionYear</tag>
+            <tag>departmentId</tag>
+            <tag>secondaryDepartmentId</tag>
+            <tag>majorType</tag>
+            <tag>traceId</tag>
         </mdcTags>
     </appender>
 
@@ -53,11 +54,12 @@
             <tag>outboxId</tag>
             <tag>operationType</tag>
             <tag>workerRequestId</tag>
-            <tag>student_code</tag>
-            <tag>admission_year</tag>
-            <tag>primary_department_id</tag>
-            <tag>secondary_department_id</tag>
-            <tag>major_type</tag>
+            <tag>studentCodeHash</tag>
+            <tag>admissionYear</tag>
+            <tag>departmentId</tag>
+            <tag>secondaryDepartmentId</tag>
+            <tag>majorType</tag>
+            <tag>traceId</tag>
         </mdcTags>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,6 +24,7 @@
     </appender>
 
     <appender name="SENTRY_DEV" class="io.sentry.logback.SentryAppender">
+        <filter class="com.chukchuk.haksa.global.logging.sentry.SentryDuplicateEventFilter"/>
         <minimumEventLevel>ERROR</minimumEventLevel>
         <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
         <sendDefaultPii>false</sendDefaultPii>
@@ -44,6 +45,7 @@
     </appender>
 
     <appender name="SENTRY_PROD" class="io.sentry.logback.SentryAppender">
+        <filter class="com.chukchuk.haksa.global.logging.sentry.SentryDuplicateEventFilter"/>
         <minimumEventLevel>ERROR</minimumEventLevel>
         <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
         <sendDefaultPii>false</sendDefaultPii>

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
@@ -1,0 +1,64 @@
+// 졸업요건 학과 판별 실패 시 Sentry 문맥을 검증하는 테스트
+package com.chukchuk.haksa.domain.graduation.policy;
+
+import com.chukchuk.haksa.domain.department.model.Department;
+import com.chukchuk.haksa.domain.department.repository.DepartmentRepository;
+import com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepository;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import com.chukchuk.haksa.global.logging.util.HashUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GraduationMajorResolverTest {
+
+    @Mock
+    private GraduationQueryRepository graduationQueryRepository;
+
+    @Mock
+    private DepartmentRepository departmentRepository;
+
+    @InjectMocks
+    private GraduationMajorResolver resolver;
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void 졸업요건이_없으면_학번_해시와_학과_문맥을_남긴다() {
+        Student student = org.mockito.Mockito.mock(Student.class);
+        Department department = org.mockito.Mockito.mock(Department.class);
+        when(student.getStudentCode()).thenReturn("17015080");
+        when(student.getDepartment()).thenReturn(department);
+        when(department.getId()).thenReturn(38L);
+        when(graduationQueryRepository.getAreaRequirementsWithCache(38L, 2017))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> resolver.resolve(student, 2017))
+                .isInstanceOf(CommonException.class)
+                .satisfies(error -> assertThat(((CommonException) error).getCode())
+                        .isEqualTo(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND.code()));
+
+        assertThat(MDC.get("studentCodeHash")).isEqualTo(HashUtil.sha256Short("17015080"));
+        assertThat(MDC.get("admissionYear")).isEqualTo("2017");
+        assertThat(MDC.get("departmentId")).isEqualTo("38");
+        assertThat(MDC.get("secondaryDepartmentId")).isEqualTo("NONE");
+        assertThat(MDC.get("majorType")).isEqualTo("SINGLE");
+        assertThat(MDC.get("student_code")).isNull();
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.HandlerMapping;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -49,6 +50,8 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void shouldReportSystemPortalExceptions() {
+        assertThat(handler.shouldReportBaseException(
+                new CommonException(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND))).isTrue();
         assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED))).isTrue();
         assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED))).isTrue();
         assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_SCHEMA_INVALID))).isTrue();
@@ -58,6 +61,16 @@ class GlobalExceptionHandlerTest {
     @Test
     void shouldReportNonCommonBaseExceptions() {
         assertThat(handler.shouldReportBaseException(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND))).isTrue();
+    }
+
+    @Test
+    void shouldBuildOperationFromRoutePatternWithoutRequestValues() {
+        HttpServletRequest request = request("/api/students/13eaf3e9");
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+                .thenReturn("/api/students/{studentId}");
+
+        assertThat(handler.sentryOperation(request)).isEqualTo("GET /api/students/{studentId}");
     }
 
     private HttpServletRequest request(String uri) {

--- a/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/exception/handler/GlobalExceptionHandlerTest.java
@@ -5,7 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import com.chukchuk.haksa.global.exception.type.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GlobalExceptionHandlerTest {
 
@@ -28,6 +32,22 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    void shouldSkipSentryCaptureForExpectedLectureEvaluationErrors() {
+        assertThat(handler.shouldReportBaseException(
+                new CommonException(ErrorCode.LECTURE_EVALUATION_NOT_REQUIRED))).isFalse();
+        assertThat(handler.shouldReportBaseException(
+                new CommonException(ErrorCode.LECTURE_EVALUATION_COURSE_MISMATCH))).isFalse();
+    }
+
+    @Test
+    void shouldSkipMissingUserOnlyOnRefreshEndpoint() {
+        EntityNotFoundException exception = new EntityNotFoundException(ErrorCode.USER_NOT_FOUND);
+
+        assertThat(handler.shouldReportEntityNotFound(exception, request("/api/auth/refresh"))).isFalse();
+        assertThat(handler.shouldReportEntityNotFound(exception, request("/api/users/me"))).isTrue();
+    }
+
+    @Test
     void shouldReportSystemPortalExceptions() {
         assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_JOB_ENQUEUE_FAILED))).isTrue();
         assertThat(handler.shouldReportBaseException(new CommonException(ErrorCode.SCRAPE_RESULT_S3_FAILED))).isTrue();
@@ -38,5 +58,11 @@ class GlobalExceptionHandlerTest {
     @Test
     void shouldReportNonCommonBaseExceptions() {
         assertThat(handler.shouldReportBaseException(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND))).isTrue();
+    }
+
+    private HttpServletRequest request(String uri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(uri);
+        return request;
     }
 }

--- a/src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/LogbackConfigTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +21,8 @@ class LogbackConfigTest {
         assertThat(xml)
                 .contains("<appender name=\"SENTRY_DEV\" class=\"io.sentry.logback.SentryAppender\">")
                 .contains("<appender name=\"SENTRY_PROD\" class=\"io.sentry.logback.SentryAppender\">");
+        assertThat(Pattern.compile("SentryDuplicateEventFilter").matcher(xml).results().count())
+                .isEqualTo(2);
 
         for (String tag : SentryMdcTagBinder.tagKeys()) {
             assertThat(xml).contains("<tag>" + tag + "</tag>");

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilterTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryDuplicateEventFilterTest.java
@@ -1,0 +1,43 @@
+// 동일 요청에서 중복 생성되는 Sentry 로그 이벤트 필터를 검증하는 테스트
+package com.chukchuk.haksa.global.logging.sentry;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.FilterReply;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SentryDuplicateEventFilterTest {
+
+    private final SentryDuplicateEventFilter filter = new SentryDuplicateEventFilter();
+
+    @Test
+    void 관리_요청의_예외_핸들러와_Hibernate_로그는_제외한다() {
+        assertThat(filter.decide(event(
+                "com.chukchuk.haksa.global.exception.handler.GlobalExceptionHandler", true)))
+                .isEqualTo(FilterReply.DENY);
+        assertThat(filter.decide(event("org.hibernate.engine.jdbc.spi.SqlExceptionHelper", true)))
+                .isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    void 다른_애플리케이션_로그와_백그라운드_로그는_유지한다() {
+        assertThat(filter.decide(event("com.chukchuk.haksa.application.Worker", true)))
+                .isEqualTo(FilterReply.NEUTRAL);
+        assertThat(filter.decide(event("org.hibernate.SQL", false)))
+                .isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    private ILoggingEvent event(String loggerName, boolean managedRequest) {
+        ILoggingEvent event = mock(ILoggingEvent.class);
+        when(event.getLoggerName()).thenReturn(loggerName);
+        when(event.getMDCPropertyMap()).thenReturn(managedRequest
+                ? Map.of(SentryDuplicateEventFilter.MANAGED_REQUEST_MDC_KEY, "true")
+                : Map.of());
+        return event;
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallbackTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallbackTest.java
@@ -42,6 +42,15 @@ class SentryEventTitleCallbackTest {
         assertThat(exception.getValue()).isEqualTo("boom");
     }
 
+    @Test
+    void 예외_목록이_없으면_이벤트를_그대로_반환한다() {
+        SentryEvent event = new SentryEvent();
+        event.setTag("error.title", "[G02] 졸업요건 데이터 없음");
+
+        assertThat(callback.execute(event, new Hint())).isSameAs(event);
+        assertThat(event.getExceptions()).isNull();
+    }
+
     private SentryException exception(String type, String value) {
         SentryException exception = new SentryException();
         exception.setType(type);

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallbackTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryEventTitleCallbackTest.java
@@ -1,0 +1,51 @@
+// Sentry 이슈 제목 정규화 콜백을 검증하는 테스트
+package com.chukchuk.haksa.global.logging.sentry;
+
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import io.sentry.protocol.SentryException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SentryEventTitleCallbackTest {
+
+    private final SentryEventTitleCallback callback = new SentryEventTitleCallback();
+
+    @Test
+    void errorTitleTag가_있으면_최상위_예외_제목을_교체한다() {
+        SentryException cause = exception("DataAccessException", "constraint violation");
+        SentryException outer = exception("CommonException", "기존 메시지");
+        SentryEvent event = new SentryEvent();
+        event.setExceptions(List.of(cause, outer));
+        event.setTag("error.title", "[G02] 졸업요건 데이터 없음");
+
+        SentryEvent result = callback.execute(event, new Hint());
+
+        assertThat(result).isSameAs(event);
+        assertThat(cause.getType()).isEqualTo("DataAccessException");
+        assertThat(outer.getType()).isEqualTo("[G02] 졸업요건 데이터 없음");
+        assertThat(outer.getValue()).isNull();
+    }
+
+    @Test
+    void errorTitleTag가_없으면_예외를_변경하지_않는다() {
+        SentryException exception = exception("RuntimeException", "boom");
+        SentryEvent event = new SentryEvent();
+        event.setExceptions(List.of(exception));
+
+        callback.execute(event, new Hint());
+
+        assertThat(exception.getType()).isEqualTo("RuntimeException");
+        assertThat(exception.getValue()).isEqualTo("boom");
+    }
+
+    private SentryException exception(String type, String value) {
+        SentryException exception = new SentryException();
+        exception.setType(type);
+        exception.setValue(value);
+        return exception;
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
@@ -22,8 +22,11 @@ class SentryMdcTagBinderTest {
         MDC.put("outboxId", "outbox-1");
         MDC.put("operationType", "LINK");
         MDC.put("workerRequestId", "worker-req-1");
-        MDC.put("student_code", "20201234");
-        MDC.put("admission_year", "2020");
+        MDC.put("studentCodeHash", "student-hash");
+        MDC.put("admissionYear", "2020");
+        MDC.put("departmentId", "38");
+        MDC.put("majorType", "SINGLE");
+        MDC.put("traceId", "trace-1");
 
         Map<String, String> tags = SentryMdcTagBinder.collect();
 
@@ -33,8 +36,12 @@ class SentryMdcTagBinderTest {
                 .containsEntry("outboxId", "outbox-1")
                 .containsEntry("operationType", "LINK")
                 .containsEntry("workerRequestId", "worker-req-1")
-                .containsEntry("student_code", "20201234")
-                .containsEntry("admission_year", "2020")
-                .doesNotContainKey("secondary_department_id");
+                .containsEntry("studentCodeHash", "student-hash")
+                .containsEntry("admissionYear", "2020")
+                .containsEntry("departmentId", "38")
+                .containsEntry("majorType", "SINGLE")
+                .containsEntry("traceId", "trace-1")
+                .doesNotContainKey("student_code")
+                .doesNotContainKey("secondaryDepartmentId");
     }
 }


### PR DESCRIPTION
## 변경 사항

- 졸업요건 분석 실패 이벤트에서 원문 학번을 제거하고, 학번 해시·입학년도·주/복수전공 학과 ID·전공 유형을 Sentry 태그로 정규화했습니다.
- `A07/A08`과 토큰 재발급 경로의 `U01`은 Sentry 수집에서 제외하되, `G02` 등 조치가 필요한 사용자별 이벤트는 계속 수집합니다.
- 오류 코드 기반 이슈 제목과 정규화된 API `operation` 태그를 추가했습니다.
- HTTP 요청에서 명시적 예외 캡처와 중복되는 `GlobalExceptionHandler`, `org.hibernate.*` 로그만 Sentry 전송에서 제외합니다.

## 변경 이유

같은 원인으로 발생한 이벤트의 제목과 태그가 일관되지 않고, 예외 핸들러·Hibernate 로그가 같은 요청에서 중복 전송돼 Sentry 이슈를 빠르게 분류하기 어려웠습니다. 졸업요건 오류에는 원문 학번도 노출되고 있었습니다.

## 영향

- `G02`는 동일 원인으로 그룹화하면서도 사용자별 해시와 학과·입학년도 태그로 계속 조회할 수 있습니다.
- 예상 가능한 클라이언트 오류만 제외되며, 그 외 사용자 없음·스크래핑·서버 오류 이벤트는 수집을 유지합니다.
- 백그라운드 작업과 다른 애플리케이션 오류 로그는 중복 필터 대상이 아닙니다.

## 검증

- `./gradlew test --tests '*GlobalExceptionHandlerTest' --tests '*Sentry*Test' --tests '*LogbackConfigTest' --stacktrace --no-daemon`
- `./gradlew test --stacktrace --no-daemon`
- 전체 358개 테스트 중 실패 0개, 제외 1개

## 문서 및 운영

- 구현 및 검증 기록은 `docs/tasks/310/plan.md`에 남겼습니다.
- 외부 API와 배포 절차는 변경하지 않아 Wiki는 갱신하지 않았습니다.
- dev 배포 후 Sentry에서 제목과 중복 이벤트 감소를 확인합니다.

Closes #310