### PR TITLE
319 chore: CodeRabbit 백엔드 리뷰 정책 보강

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,67 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "ko-KR"
 early_access: false
+tone_instructions: >-
+  한국어로 간결하고 직접적으로 작성한다. 실제 결함, 보안 문제, API·DB 계약 위반,
+  회귀 가능성처럼 조치가 필요한 내용만 지적한다. 각 지적에는 근거와 영향을 포함하고
+  취향 차이, CI가 검사하는 포맷, 요청 범위 밖 리팩터링은 제안하지 않는다.
+
 reviews:
   profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
-  poem: true
+  poem: false
   review_status: true
   collapse_walkthrough: false
+  in_progress_fortune: false
   auto_review:
     enabled: true
+    auto_incremental_review: true
     drafts: false
+    base_branches:
+      - "^main$"
+      - "^release/.*$"
+  path_instructions:
+    - path: "src/main/java/com/chukchuk/haksa/global/security/**"
+      instructions: |
+        JWT 서명·만료·issuer 검증, 인증 우회, SecurityContext 오염과 권한 누락을 확인한다.
+        access token, refresh token, 사용자 식별정보가 로그나 응답에 노출되지 않아야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/domain/auth/**"
+      instructions: |
+        로그인·토큰 재발급·세션 무효화 계약과 오류 코드·HTTP 상태의 일관성을 확인한다.
+        중복 요청과 만료·폐기된 토큰에서 기존 세션이 되살아나지 않아야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/domain/**"
+      instructions: |
+        엔티티 생명주기, repository 계약, nullability와 도메인 불변식 회귀를 확인한다.
+        유니크 제약과 재시도·동시 요청에서 중복 생성이나 부분 갱신이 없어야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/application/**"
+      instructions: |
+        use case의 트랜잭션 경계, 멱등성, 외부 호출과 DB 변경 순서를 확인한다.
+        실패 시 부분 상태가 남거나 같은 요청의 재시도로 데이터가 중복되지 않아야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/application/portal/**"
+      instructions: |
+        포털 콜백 서명·작업 상태 전이·재시도와 중복 콜백 처리를 확인한다.
+        같은 callback이나 job이 반복돼도 학생·과목·수강 데이터가 중복 생성되지 않아야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/infrastructure/portal/**"
+      instructions: |
+        외부 payload를 신뢰하지 않고 스키마·코드·null 값을 저장 전에 검증하는지 확인한다.
+        원문 credential, 학생 개인정보, 전체 payload가 로그와 예외에 포함되지 않아야 한다.
+    - path: "src/main/resources/db/migration/**"
+      instructions: |
+        migration은 순방향이며 이미 적용된 파일을 수정하지 않아야 한다.
+        새 schema는 이전 운영 Lambda와 호환되고 제약 조건 추가 전 데이터 보정이 보장돼야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/global/logging/**"
+      instructions: |
+        학번·이메일·토큰·원문 payload·SQL 같은 민감정보가 로그와 Sentry 제목에 노출되지 않는지 확인한다.
+        같은 원인의 명시적 캡처와 Logback 이벤트가 중복 생성되지 않아야 한다.
+    - path: "src/main/java/com/chukchuk/haksa/global/exception/**"
+      instructions: |
+        예외 매핑이 API 오류 코드와 HTTP 상태를 보존하고 예상 가능한 4xx를 서버 장애로 수집하지 않는지 확인한다.
+        조치가 필요한 예외를 과도하게 필터링하거나 원인을 삼키지 않아야 한다.
+    - path: "src/test/**"
+      instructions: |
+        변경된 실패 경계, 동시성, 재시도와 개인정보 비노출 조건을 회귀 테스트가 검증하는지 확인한다.
+        외부 네트워크나 운영 자원에 의존하지 않고 실패 원인을 명확히 드러내야 한다.
+
 chat:
   auto_reply: true

--- a/docs/tasks/319/design.md
+++ b/docs/tasks/319/design.md
@@ -1,0 +1,75 @@
+# CodeRabbit PR 리뷰 전환 설계
+
+## 목표
+
+척척학사 백엔드의 PR 자동 리뷰를 CodeRabbit으로 통일하고, 현재 연결된 Gemini Code Assist를 제거한다. CodeRabbit은 한국어로 실제 결함, 보안, 계약 위반, 회귀 위험에 집중하며 저장소의 Spring 백엔드 위험 영역을 경로별로 검토한다.
+
+## 현재 상태
+
+- `origin/dev`에 기본 `.coderabbit.yaml`이 이미 존재한다.
+- 현재 설정은 한국어, `chill`, 자동 리뷰, Draft 제외만 지정하며 경로별 검토 기준과 incremental review 설정은 없다.
+- 저장소에는 Gemini 전용 workflow나 설정 파일이 없다.
+- PR #316에는 Gemini Code Assist consumer version 종료 안내가 남아 있다. Gemini 제거는 코드 삭제가 아니라 GitHub App의 저장소 접근 권한을 해제하는 운영 작업이다.
+
+## 접근 방식
+
+전환은 다음 순서를 따른다.
+
+1. 기존 `.coderabbit.yaml`을 백엔드 맞춤형 정책으로 보강한다.
+2. 설정 파일 구조와 핵심 정책을 자동 테스트로 검증한다.
+3. CodeRabbit GitHub App이 `cchaksa/cchaksa-backend`에 접근 가능한지 확인한다.
+4. Ready PR에서 최초 리뷰와 후속 커밋의 incremental review를 확인한다.
+5. CodeRabbit 동작 확인 후 Gemini Code Assist의 저장소 접근 권한을 제거한다.
+
+이 순서는 자동 리뷰가 비는 구간을 피하고, 설정 파일 반영과 외부 App 권한 문제를 구분할 수 있게 한다.
+
+## CodeRabbit 정책
+
+### 공통 리뷰 정책
+
+- 스키마는 CodeRabbit v2 공식 스키마를 사용한다.
+- 언어는 `ko-KR`, 프로필은 `chill`을 유지한다.
+- 실제 결함, 보안 문제, API·DB 계약 위반, 회귀 가능성만 지적한다.
+- 취향 차이, CI가 검사하는 포맷, 요청 범위 밖 리팩터링은 제안하지 않는다.
+- poem과 fortune은 비활성화한다.
+- Draft PR은 리뷰하지 않고 Ready for review 이후 자동 리뷰한다.
+- 후속 push는 incremental review를 활성화한다.
+- 자동 리뷰 대상 base branch는 `dev`, `main`, `release/*`로 제한한다.
+
+### 경로별 검토 기준
+
+- `global/security/**`, `domain/auth/**`는 JWT 검증, 인증 우회, 토큰·개인정보 노출, 세션 무효화를 검토한다.
+- `domain/**`, `application/**`는 트랜잭션 경계, 동시성, 멱등성, 엔티티 생명주기와 API 계약 회귀를 검토한다.
+- `application/portal/**`, `infrastructure/portal/**`는 콜백 검증, 재시도, 중복 처리, 외부 payload 신뢰 경계를 검토한다.
+- `src/main/resources/db/migration/**`는 순방향 migration, 이전 운영 Lambda와의 호환성, 제약 조건과 데이터 보정을 검토한다.
+- `global/logging/**`, `global/exception/**`는 Sentry·로그의 학번, 이메일, 토큰, 원문 payload 같은 민감정보 노출과 중복 이벤트를 검토한다.
+- `src/test/**`는 변경된 실패 경계와 회귀 조건을 실제로 검증하는지 확인한다.
+
+다른 저장소와의 연결 지식은 이번 범위에서 추가하지 않는다. 척척학사 백엔드는 현재 단일 저장소 계약만으로 리뷰할 수 있다.
+
+## 검증
+
+- JUnit에서 `.coderabbit.yaml`을 YAML 파서로 읽어 문법 오류를 검출한다.
+- 언어, 프로필, Draft 제외, incremental review, base branch 정규식, poem·fortune 비활성화를 테스트한다.
+- `./gradlew test --stacktrace --no-daemon`으로 전체 회귀 테스트를 실행한다.
+- Ready PR에서 CodeRabbit 자동 리뷰가 생성되는지 확인한다.
+- 같은 PR에 후속 커밋을 추가하거나 수동 명령을 사용해 incremental review를 확인한다.
+- 전환 후 새 PR에서 Gemini Code Assist 댓글이 더 이상 생성되지 않는지 확인한다.
+
+## 실패 대응
+
+CodeRabbit 리뷰가 생성되지 않으면 다음 순서로 원인을 분리한다.
+
+1. CodeRabbit App의 저장소 접근 권한을 확인한다.
+2. `.coderabbit.yaml`이 PR base branch에 존재하는지 확인한다.
+3. PR이 Draft가 아닌지와 base branch가 허용 정규식에 포함되는지 확인한다.
+4. CodeRabbit 댓글의 `Configuration used`와 skip 사유를 확인한다.
+5. 필요하면 `@coderabbitai review` 또는 `@coderabbitai full review`로 수동 호출한다.
+
+CodeRabbit 확인 전에 Gemini App을 제거하지 않는다. 설정 보강으로 리뷰 품질이 나빠지면 기존 최소 설정으로 되돌릴 수 있으며, 외부 App 권한은 별도로 유지한다.
+
+## 범위 제외
+
+- 애플리케이션 코드, API, DB 스키마, 배포 workflow는 변경하지 않는다.
+- CodeRabbit 유료 플랜이나 조직 전체 Global Overrides는 변경하지 않는다.
+- 다른 척척학사 저장소와 `knowledge_base.linked_repositories`를 연결하지 않는다.

--- a/docs/tasks/319/design.md
+++ b/docs/tasks/319/design.md
@@ -34,7 +34,7 @@
 - poem과 fortune은 비활성화한다.
 - Draft PR은 리뷰하지 않고 Ready for review 이후 자동 리뷰한다.
 - 후속 push는 incremental review를 활성화한다.
-- 자동 리뷰 대상 base branch는 `dev`, `main`, `release/*`로 제한한다.
+- 기본 브랜치 `dev`는 자동 리뷰하고, `base_branches`에는 추가 대상인 `main`, `release/*`만 지정한다.
 
 ### 경로별 검토 기준
 
@@ -50,7 +50,7 @@
 ## 검증
 
 - JUnit에서 `.coderabbit.yaml`을 YAML 파서로 읽어 문법 오류를 검출한다.
-- 언어, 프로필, Draft 제외, incremental review, base branch 정규식, poem·fortune 비활성화를 테스트한다.
+- 언어, 프로필, Draft 제외, incremental review, 추가 base branch 정규식, poem·fortune 비활성화를 테스트한다.
 - `./gradlew test --stacktrace --no-daemon`으로 전체 회귀 테스트를 실행한다.
 - Ready PR에서 CodeRabbit 자동 리뷰가 생성되는지 확인한다.
 - 같은 PR에 후속 커밋을 추가하거나 수동 명령을 사용해 incremental review를 확인한다.

--- a/docs/tasks/319/plan.md
+++ b/docs/tasks/319/plan.md
@@ -1,0 +1,157 @@
+# CodeRabbit PR Review Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strengthen the existing CodeRabbit configuration for the Haksa backend, verify it automatically, and publish a PR that can confirm the GitHub App transition before Gemini Code Assist access is removed.
+
+**Architecture:** Keep `.coderabbit.yaml` as the single repository policy file and add one focused JUnit configuration test using the existing SnakeYAML dependency. Treat repository configuration, CodeRabbit App authorization, and Gemini App removal as separate gates so a failed external setup cannot be mistaken for a YAML defect.
+
+**Tech Stack:** CodeRabbit schema v2, YAML, Java 17, JUnit 5, AssertJ, SnakeYAML, GitHub Apps.
+
+## Global Constraints
+
+- Preserve `language: ko-KR` and `reviews.profile: chill`.
+- Review only actionable defects, security risks, contract violations, and regressions.
+- Skip Draft PRs and enable incremental reviews after later pushes.
+- The default branch `dev` is reviewed automatically; `base_branches` lists only `main` and `release/*` as additional targets.
+- Do not add linked repositories, change application behavior, or modify deployment workflows.
+- Do not remove Gemini Code Assist access before CodeRabbit is verified on a Ready PR.
+
+---
+
+### Task 1: Lock the CodeRabbit policy with a configuration test
+
+**Files:**
+- Create: `src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java`
+
+**Interfaces:**
+- Consumes: repository-root `.coderabbit.yaml` and `org.yaml.snakeyaml.Yaml` already available in the test runtime.
+- Produces: parsed `Map<String, Object>` assertions for common review policy, automatic review targets, and required path instructions.
+
+- [ ] **Step 1: Add a failing structured YAML test.**
+
+Create `CodeRabbitConfigTest` with a Korean file header. Load `.coderabbit.yaml` through `new Yaml().load(inputStream)` and assert these exact values.
+
+```java
+assertThat(config.get("language")).isEqualTo("ko-KR");
+assertThat(reviews.get("profile")).isEqualTo("chill");
+assertThat(reviews.get("poem")).isEqualTo(false);
+assertThat(reviews.get("in_progress_fortune")).isEqualTo(false);
+assertThat(autoReview.get("enabled")).isEqualTo(true);
+assertThat(autoReview.get("auto_incremental_review")).isEqualTo(true);
+assertThat(autoReview.get("drafts")).isEqualTo(false);
+assertThat(autoReview.get("base_branches"))
+        .isEqualTo(List.of("^main$", "^release/.*$"));
+```
+
+Parse `reviews.path_instructions` and assert that it contains these exact path globs.
+
+```java
+assertThat(paths).containsExactly(
+        "src/main/java/com/chukchuk/haksa/global/security/**",
+        "src/main/java/com/chukchuk/haksa/domain/auth/**",
+        "src/main/java/com/chukchuk/haksa/domain/**",
+        "src/main/java/com/chukchuk/haksa/application/**",
+        "src/main/java/com/chukchuk/haksa/application/portal/**",
+        "src/main/java/com/chukchuk/haksa/infrastructure/portal/**",
+        "src/main/resources/db/migration/**",
+        "src/main/java/com/chukchuk/haksa/global/logging/**",
+        "src/main/java/com/chukchuk/haksa/global/exception/**",
+        "src/test/**"
+);
+```
+
+- [ ] **Step 2: Run the focused test and confirm the current minimal configuration fails.**
+
+Run: `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon`
+
+Expected: FAIL because `poem` is true and incremental review, extra base branches, fortune, and path instructions are absent.
+
+- [ ] **Step 3: Commit the failing policy test.**
+
+```bash
+git add src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
+git commit -m "319 test: CodeRabbit 리뷰 정책 검증 추가"
+```
+
+### Task 2: Apply the Haksa backend review policy
+
+**Files:**
+- Modify: `.coderabbit.yaml`
+- Test: `src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java`
+
+**Interfaces:**
+- Consumes: CodeRabbit schema v2 properties `tone_instructions`, `reviews.auto_review`, and `reviews.path_instructions`.
+- Produces: a repository policy that CodeRabbit reads from the PR base branch.
+
+- [ ] **Step 1: Add the official schema header and common review policy.**
+
+Add `# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json`, set `poem: false`, `in_progress_fortune: false`, and add concise Korean `tone_instructions` that excludes style-only, CI-format, and out-of-scope refactoring comments.
+
+- [ ] **Step 2: Configure automatic review behavior.**
+
+Set `auto_incremental_review: true`, preserve `drafts: false`, and add the exact additional base patterns below.
+
+```yaml
+base_branches:
+  - "^main$"
+  - "^release/.*$"
+```
+
+- [ ] **Step 3: Add repository-specific path instructions.**
+
+Add the ten path globs from Task 1 in that order. Their instructions must cover JWT and authorization bypass, transaction and concurrency defects, portal callback validation and idempotency, forward-only Flyway compatibility, Sentry and log PII, and regression-focused tests.
+
+- [ ] **Step 4: Run the focused test and verify it passes.**
+
+Run: `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the reviewed configuration.**
+
+```bash
+git add .coderabbit.yaml
+git commit -m "319 chore: CodeRabbit 백엔드 리뷰 정책 보강"
+```
+
+### Task 3: Verify and publish the transition
+
+**Files:**
+- Modify: `docs/tasks/319/plan.md` only to record completed checks or implementation discoveries.
+- Update externally: GitHub issue #319 and a `feat/319` to `dev` pull request.
+
+**Interfaces:**
+- Consumes: committed `.coderabbit.yaml`, passing Gradle tests, GitHub App access, and PR review events.
+- Produces: a clean pushed branch, an issue body aligned with the pre-existing config, and a Ready PR suitable for CodeRabbit verification.
+
+- [ ] **Step 1: Run the complete repository verification.**
+
+Run: `./gradlew test --stacktrace --no-daemon`
+
+Expected: BUILD SUCCESSFUL with zero failed tests.
+
+- [ ] **Step 2: Inspect repository scope and policy safety.**
+
+Run: `git diff --check origin/dev...HEAD`, `git status --short`, and `git diff --stat origin/dev...HEAD`.
+
+Expected: only `.coderabbit.yaml`, the focused test, and `docs/tasks/319/*` are changed; no application, API, DB, or workflow files are modified.
+
+- [ ] **Step 3: Update issue #319.**
+
+Replace the inaccurate “add `.coderabbit.yaml`” wording with “strengthen the existing `.coderabbit.yaml`”. Preserve the external gates for CodeRabbit App access, Ready/incremental review verification, and Gemini App removal after successful verification.
+
+- [ ] **Step 4: Record verification and commit the plan.**
+
+```bash
+git add docs/tasks/319/design.md docs/tasks/319/plan.md
+git commit -m "319 docs: CodeRabbit 전환 검증 결과 반영"
+```
+
+- [ ] **Step 5: Push and create a Ready PR to `dev`.**
+
+Push `feat/319`, create a Korean PR using the repository's current PR structure, and link `Closes #319`. Verify the remote head SHA equals local HEAD and the PR base is `dev`.
+
+- [ ] **Step 6: Check the external review gate.**
+
+Confirm whether CodeRabbit creates a review or a skip/configuration message. If no CodeRabbit event appears, report CodeRabbit App installation as the remaining blocker and do not claim Gemini removal is complete. Remove Gemini access only after CodeRabbit review is proven.

--- a/docs/tasks/319/plan.md
+++ b/docs/tasks/319/plan.md
@@ -145,15 +145,17 @@ Replace the inaccurate “add `.coderabbit.yaml`” wording with “strengthen t
 - Regression: `./gradlew test --stacktrace --no-daemon` passed with `BUILD SUCCESSFUL`.
 - Scope: `git diff --check origin/dev...HEAD` passed, and the branch changes are limited to `.coderabbit.yaml`, the focused test, and `docs/tasks/319/*`.
 - Issue: #319 now describes strengthening the existing configuration and keeps CodeRabbit App verification and Gemini removal as separate external gates.
+- PR: Ready PR #320 targets `dev`, and its remote head matched the local branch at creation time.
+- External gate: CodeRabbit did not respond to automatic review or `@coderabbitai review`; Gemini still posted its consumer sunset notice. App access must be configured before Gemini access is removed.
 
-- [ ] **Step 4: Record verification and commit the plan.**
+- [x] **Step 4: Record verification and commit the plan.**
 
 ```bash
 git add docs/tasks/319/design.md docs/tasks/319/plan.md
 git commit -m "319 docs: CodeRabbit 전환 검증 결과 반영"
 ```
 
-- [ ] **Step 5: Push and create a Ready PR to `dev`.**
+- [x] **Step 5: Push and create a Ready PR to `dev`.**
 
 Push `feat/319`, create a Korean PR using the repository's current PR structure, and link `Closes #319`. Verify the remote head SHA equals local HEAD and the PR base is `dev`.
 

--- a/docs/tasks/319/plan.md
+++ b/docs/tasks/319/plan.md
@@ -147,9 +147,10 @@ Replace the inaccurate “add `.coderabbit.yaml`” wording with “strengthen t
 - Issue: #319 now describes strengthening the existing configuration and keeps CodeRabbit App verification and Gemini removal as separate external gates.
 - PR: Ready PR #320 targets `dev`, and its remote head matched the local branch at creation time.
 - App access: the existing CodeRabbit installation initially allowed only `cchaksa-app`; `cchaksa-backend` was added as the second selected repository and the saved setting was rechecked.
-- Initial review: CodeRabbit acknowledged `@coderabbitai review`, loaded `.coderabbit.yaml`, selected all four changed files, and started a review. Its status remained pending when this note was recorded.
+- Review: CodeRabbit acknowledged `@coderabbitai review`, reviewed all four changed files, posted two findings, and completed with a successful status check.
 - Configuration activation: CodeRabbit reported that open source PRs use configuration from the base branch, so this PR verifies App and incremental behavior while the strengthened policy becomes active after merge.
-- Gemini gate: Gemini still posted its consumer sunset notice. Its App access remains until CodeRabbit review completes.
+- Incremental review: later pushes each created a CodeRabbit status on the new HEAD, and the latest review-fix commit completed successfully.
+- Gemini gate: `cchaksa-backend` was removed from Gemini Code Assist repository access after CodeRabbit verification. Terraform and scraper access remains unchanged.
 
 - [x] **Step 4: Record verification and commit the plan.**
 
@@ -162,6 +163,6 @@ git commit -m "319 docs: CodeRabbit 전환 검증 결과 반영"
 
 Push `feat/319`, create a Korean PR using the repository's current PR structure, and link `Closes #319`. Verify the remote head SHA equals local HEAD and the PR base is `dev`.
 
-- [ ] **Step 6: Check the external review gate.**
+- [x] **Step 6: Check the external review gate.**
 
 Confirm whether CodeRabbit creates a review or a skip/configuration message. If no CodeRabbit event appears, report CodeRabbit App installation as the remaining blocker and do not claim Gemini removal is complete. Remove Gemini access only after CodeRabbit review is proven.

--- a/docs/tasks/319/plan.md
+++ b/docs/tasks/319/plan.md
@@ -146,7 +146,10 @@ Replace the inaccurate “add `.coderabbit.yaml`” wording with “strengthen t
 - Scope: `git diff --check origin/dev...HEAD` passed, and the branch changes are limited to `.coderabbit.yaml`, the focused test, and `docs/tasks/319/*`.
 - Issue: #319 now describes strengthening the existing configuration and keeps CodeRabbit App verification and Gemini removal as separate external gates.
 - PR: Ready PR #320 targets `dev`, and its remote head matched the local branch at creation time.
-- External gate: CodeRabbit did not respond to automatic review or `@coderabbitai review`; Gemini still posted its consumer sunset notice. App access must be configured before Gemini access is removed.
+- App access: the existing CodeRabbit installation initially allowed only `cchaksa-app`; `cchaksa-backend` was added as the second selected repository and the saved setting was rechecked.
+- Initial review: CodeRabbit acknowledged `@coderabbitai review`, loaded `.coderabbit.yaml`, selected all four changed files, and started a review. Its status remained pending when this note was recorded.
+- Configuration activation: CodeRabbit reported that open source PRs use configuration from the base branch, so this PR verifies App and incremental behavior while the strengthened policy becomes active after merge.
+- Gemini gate: Gemini still posted its consumer sunset notice. Its App access remains until CodeRabbit review completes.
 
 - [x] **Step 4: Record verification and commit the plan.**
 

--- a/docs/tasks/319/plan.md
+++ b/docs/tasks/319/plan.md
@@ -28,7 +28,7 @@
 - Consumes: repository-root `.coderabbit.yaml` and `org.yaml.snakeyaml.Yaml` already available in the test runtime.
 - Produces: parsed `Map<String, Object>` assertions for common review policy, automatic review targets, and required path instructions.
 
-- [ ] **Step 1: Add a failing structured YAML test.**
+- [x] **Step 1: Add a failing structured YAML test.**
 
 Create `CodeRabbitConfigTest` with a Korean file header. Load `.coderabbit.yaml` through `new Yaml().load(inputStream)` and assert these exact values.
 
@@ -61,18 +61,15 @@ assertThat(paths).containsExactly(
 );
 ```
 
-- [ ] **Step 2: Run the focused test and confirm the current minimal configuration fails.**
+- [x] **Step 2: Run the focused test and confirm the current minimal configuration fails.**
 
 Run: `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon`
 
 Expected: FAIL because `poem` is true and incremental review, extra base branches, fortune, and path instructions are absent.
 
-- [ ] **Step 3: Commit the failing policy test.**
+- [x] **Step 3: Keep the failing test uncommitted and proceed to Task 2.**
 
-```bash
-git add src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
-git commit -m "319 test: CodeRabbit 리뷰 정책 검증 추가"
-```
+Record the expected assertion failure in the plan verification notes. Do not create a commit while the focused test is failing.
 
 ### Task 2: Apply the Haksa backend review policy
 
@@ -84,11 +81,11 @@ git commit -m "319 test: CodeRabbit 리뷰 정책 검증 추가"
 - Consumes: CodeRabbit schema v2 properties `tone_instructions`, `reviews.auto_review`, and `reviews.path_instructions`.
 - Produces: a repository policy that CodeRabbit reads from the PR base branch.
 
-- [ ] **Step 1: Add the official schema header and common review policy.**
+- [x] **Step 1: Add the official schema header and common review policy.**
 
 Add `# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json`, set `poem: false`, `in_progress_fortune: false`, and add concise Korean `tone_instructions` that excludes style-only, CI-format, and out-of-scope refactoring comments.
 
-- [ ] **Step 2: Configure automatic review behavior.**
+- [x] **Step 2: Configure automatic review behavior.**
 
 Set `auto_incremental_review: true`, preserve `drafts: false`, and add the exact additional base patterns below.
 
@@ -98,20 +95,20 @@ base_branches:
   - "^release/.*$"
 ```
 
-- [ ] **Step 3: Add repository-specific path instructions.**
+- [x] **Step 3: Add repository-specific path instructions.**
 
 Add the ten path globs from Task 1 in that order. Their instructions must cover JWT and authorization bypass, transaction and concurrency defects, portal callback validation and idempotency, forward-only Flyway compatibility, Sentry and log PII, and regression-focused tests.
 
-- [ ] **Step 4: Run the focused test and verify it passes.**
+- [x] **Step 4: Run the focused test and verify it passes.**
 
 Run: `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the reviewed configuration.**
+- [x] **Step 5: Commit the reviewed configuration.**
 
 ```bash
-git add .coderabbit.yaml
+git add .coderabbit.yaml src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
 git commit -m "319 chore: CodeRabbit 백엔드 리뷰 정책 보강"
 ```
 
@@ -125,21 +122,29 @@ git commit -m "319 chore: CodeRabbit 백엔드 리뷰 정책 보강"
 - Consumes: committed `.coderabbit.yaml`, passing Gradle tests, GitHub App access, and PR review events.
 - Produces: a clean pushed branch, an issue body aligned with the pre-existing config, and a Ready PR suitable for CodeRabbit verification.
 
-- [ ] **Step 1: Run the complete repository verification.**
+- [x] **Step 1: Run the complete repository verification.**
 
 Run: `./gradlew test --stacktrace --no-daemon`
 
 Expected: BUILD SUCCESSFUL with zero failed tests.
 
-- [ ] **Step 2: Inspect repository scope and policy safety.**
+- [x] **Step 2: Inspect repository scope and policy safety.**
 
 Run: `git diff --check origin/dev...HEAD`, `git status --short`, and `git diff --stat origin/dev...HEAD`.
 
 Expected: only `.coderabbit.yaml`, the focused test, and `docs/tasks/319/*` are changed; no application, API, DB, or workflow files are modified.
 
-- [ ] **Step 3: Update issue #319.**
+- [x] **Step 3: Update issue #319.**
 
 Replace the inaccurate “add `.coderabbit.yaml`” wording with “strengthen the existing `.coderabbit.yaml`”. Preserve the external gates for CodeRabbit App access, Ready/incremental review verification, and Gemini App removal after successful verification.
+
+**Verification notes:**
+
+- RED: the focused test failed against the original minimal configuration because the required review policy and path instructions were absent.
+- GREEN: `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon` passed after the configuration update.
+- Regression: `./gradlew test --stacktrace --no-daemon` passed with `BUILD SUCCESSFUL`.
+- Scope: `git diff --check origin/dev...HEAD` passed, and the branch changes are limited to `.coderabbit.yaml`, the focused test, and `docs/tasks/319/*`.
+- Issue: #319 now describes strengthening the existing configuration and keeps CodeRabbit App verification and Gemini removal as separate external gates.
 
 - [ ] **Step 4: Record verification and commit the plan.**
 

--- a/src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
@@ -1,0 +1,81 @@
+// CodeRabbit 자동 리뷰 정책과 경로별 검토 범위를 검증하는 테스트
+package com.chukchuk.haksa.global.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CodeRabbitConfigTest {
+
+    private static Map<String, Object> config;
+    private static Map<String, Object> reviews;
+    private static Map<String, Object> autoReview;
+
+    @BeforeAll
+    static void loadConfig() throws Exception {
+        try (InputStream inputStream = Files.newInputStream(Path.of(".coderabbit.yaml"))) {
+            config = map(new Yaml().load(inputStream));
+        }
+        reviews = map(config.get("reviews"));
+        autoReview = map(reviews.get("auto_review"));
+    }
+
+    @Test
+    void 백엔드_자동_리뷰_정책을_유지한다() {
+        assertThat(config.get("language")).isEqualTo("ko-KR");
+        assertThat(reviews.get("profile")).isEqualTo("chill");
+        assertThat(reviews.get("poem")).isEqualTo(false);
+        assertThat(reviews.get("in_progress_fortune")).isEqualTo(false);
+        assertThat(autoReview.get("enabled")).isEqualTo(true);
+        assertThat(autoReview.get("auto_incremental_review")).isEqualTo(true);
+        assertThat(autoReview.get("drafts")).isEqualTo(false);
+        assertThat(autoReview.get("base_branches"))
+                .isEqualTo(List.of("^main$", "^release/.*$"));
+    }
+
+    @Test
+    void 백엔드_위험_영역별_리뷰_지침을_유지한다() {
+        Object rawPathInstructions = reviews.get("path_instructions");
+        assertThat(rawPathInstructions).isInstanceOf(List.class);
+        List<Map<String, Object>> pathInstructions = list(rawPathInstructions);
+        List<String> paths = pathInstructions.stream()
+                .map(instruction -> (String) instruction.get("path"))
+                .toList();
+
+        assertThat(paths).containsExactly(
+                "src/main/java/com/chukchuk/haksa/global/security/**",
+                "src/main/java/com/chukchuk/haksa/domain/auth/**",
+                "src/main/java/com/chukchuk/haksa/domain/**",
+                "src/main/java/com/chukchuk/haksa/application/**",
+                "src/main/java/com/chukchuk/haksa/application/portal/**",
+                "src/main/java/com/chukchuk/haksa/infrastructure/portal/**",
+                "src/main/resources/db/migration/**",
+                "src/main/java/com/chukchuk/haksa/global/logging/**",
+                "src/main/java/com/chukchuk/haksa/global/exception/**",
+                "src/test/**"
+        );
+        assertThat(pathInstructions)
+                .allSatisfy(instruction -> assertThat(instruction.get("instructions"))
+                        .isInstanceOf(String.class)
+                        .asString()
+                        .isNotBlank());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> map(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> list(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/config/CodeRabbitConfigTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,10 @@ class CodeRabbitConfigTest {
     @Test
     void 백엔드_자동_리뷰_정책을_유지한다() {
         assertThat(config.get("language")).isEqualTo("ko-KR");
+        assertThat(config.get("tone_instructions"))
+                .asString()
+                .contains("한국어", "결함", "보안", "API·DB 계약", "회귀")
+                .contains("취향 차이", "요청 범위 밖 리팩터링");
         assertThat(reviews.get("profile")).isEqualTo("chill");
         assertThat(reviews.get("poem")).isEqualTo(false);
         assertThat(reviews.get("in_progress_fortune")).isEqualTo(false);
@@ -67,6 +72,23 @@ class CodeRabbitConfigTest {
                         .isInstanceOf(String.class)
                         .asString()
                         .isNotBlank());
+
+        Map<String, String> instructionsByPath = pathInstructions.stream()
+                .collect(Collectors.toMap(
+                        instruction -> (String) instruction.get("path"),
+                        instruction -> (String) instruction.get("instructions")
+                ));
+        assertThat(instructionsByPath.get(
+                "src/main/java/com/chukchuk/haksa/global/security/**"))
+                .contains("JWT", "인증 우회");
+        assertThat(instructionsByPath.get(
+                "src/main/java/com/chukchuk/haksa/application/portal/**"))
+                .contains("콜백", "중복 생성");
+        assertThat(instructionsByPath.get("src/main/resources/db/migration/**"))
+                .contains("순방향", "이전 운영 Lambda");
+        assertThat(instructionsByPath.get(
+                "src/main/java/com/chukchuk/haksa/global/logging/**"))
+                .contains("민감정보", "Sentry");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 변경 사항

- 기존 `.coderabbit.yaml`에 공식 스키마, 한국어 리뷰 톤, Ready PR 자동 리뷰, 증분 리뷰 설정을 추가했습니다.
- `dev` 기본 브랜치 외에 `main`, `release/*` 대상 PR도 리뷰하도록 설정했습니다.
- 보안·인증, 도메인, 애플리케이션, 포털 연동, Flyway, Sentry·예외, 테스트 경로별 리뷰 지침을 추가했습니다.
- 설정의 핵심 값, 정책 문구, 위험 경로별 필수 내용을 구조적으로 검증하는 `CodeRabbitConfigTest`를 추가했습니다.

## 변경 이유

Gemini Code Assist의 consumer 버전 리뷰가 종료되어 현재 자동 리뷰가 실질적으로 동작하지 않습니다. CodeRabbit으로 전환하면서 결함, 보안, API·DB 계약, 회귀 위험을 우선하고 취향성 지적과 범위 밖 리팩터링 제안을 줄이기 위해 저장소 정책을 구체화했습니다.

## 영향

- 애플리케이션 동작, 외부 API, DB, 배포 워크플로에는 변경이 없습니다.
- Draft PR은 자동 리뷰하지 않고 Ready PR과 이후 추가 커밋을 증분 리뷰합니다.
- CodeRabbit의 선택 저장소에 `cchaksa-backend`를 추가했습니다.
- CodeRabbit 리뷰 검증 후 Gemini Code Assist의 백엔드 저장소 접근을 제거했습니다.
- Terraform과 scraper의 Gemini 접근은 이번 범위가 아니므로 유지했습니다.

## 검증

- `./gradlew test --tests com.chukchuk.haksa.global.config.CodeRabbitConfigTest --stacktrace --no-daemon`
- `./gradlew test --stacktrace --no-daemon`
- `git diff --check origin/dev...HEAD`
- 전체 테스트 `BUILD SUCCESSFUL`
- CodeRabbit 최초 리뷰 및 후속 커밋 상태 체크 `success`

## 문서 및 운영

- 설계와 구현·검증 기록은 `docs/tasks/319/design.md`, `docs/tasks/319/plan.md`에 남겼습니다.
- OSS 저장소에서는 base branch 설정이 적용되므로 강화된 정책은 이 PR 병합 후 다음 PR부터 사용됩니다.
- 다음 PR에서 강화된 정책 적용과 Gemini 댓글 부재를 최종 확인한 뒤 이슈를 종료합니다.

Refs #319