### PR TITLE
DB 백업

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -1,0 +1,58 @@
+name: Database Backup
+
+on:
+  schedule:
+    # GitHub Actions cron은 UTC 기준이다. KST 05:00에 실행한다.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: database-backup-prod
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: Back up production database
+    runs-on: ubuntu-latest
+    environment: prod
+    timeout-minutes: 60
+    env:
+      AWS_REGION: ${{ vars.PROD_AWS_REGION }}
+      BACKUP_S3_BUCKET: ${{ vars.PROD_BACKUP_S3_BUCKET }}
+      BACKUP_S3_PREFIX: supabase-db
+      SUPABASE_DB_URL: ${{ secrets.PROD_SUPABASE_DB_URL }}
+      BACKUP_ENCRYPTION_PASSPHRASE: ${{ secrets.BACKUP_ENCRYPTION_PASSPHRASE }}
+
+    steps:
+      - name: Checkout backup scripts
+        uses: actions/checkout@v4
+
+      - name: Validate required configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for variable_name in AWS_REGION BACKUP_S3_BUCKET SUPABASE_DB_URL BACKUP_ENCRYPTION_PASSPHRASE; do
+            if [ -z "${!variable_name}" ]; then
+              echo "Missing required GitHub Environment secret or variable: ${variable_name}." >&2
+              exit 1
+            fi
+          done
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+
+      - name: Configure AWS credentials with GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.PROD_DB_BACKUP_ROLE_ARN }}
+          role-session-name: cchaksa-db-backup
+          aws-region: ${{ env.AWS_REGION }}
+          mask-aws-account-id: true
+
+      - name: Create and upload encrypted database backup
+        shell: bash
+        run: ./scripts/backup/supabase-dump.sh

--- a/docs/runbooks/supabase-db-backup.md
+++ b/docs/runbooks/supabase-db-backup.md
@@ -1,0 +1,89 @@
+# Supabase DB 백업 Runbook
+
+## 목적
+
+이 문서는 GitHub Actions 기반 Supabase PostgreSQL logical backup의 사전 설정, 운영 확인, 복원 리허설 절차를 정의한다.
+
+## 자동 백업 정책
+
+- 실행: 매일 KST 05:00. GitHub Actions cron은 UTC `0 20 * * *`을 사용한다.
+- 수동 실행: Actions의 `Database Backup` workflow에서 `Run workflow`를 실행한다.
+- 저장: 날짜별 daily backup을 누적하고, `latest/`에는 가장 최근 성공 backup을 덮어쓴다.
+- monthly: KST 매월 1일에 생성된 daily backup을 `monthly/` prefix에도 보관한다.
+- 삭제: daily는 30일, monthly는 365일 후 S3 Lifecycle로 만료한다. Lifecycle은 정확한 KST 03:00 실행을 보장하지 않으며 비동기로 객체를 만료한다.
+- 삭제 권한: GitHub Actions IAM Role에는 `s3:DeleteObject`를 부여하지 않는다.
+
+## GitHub Environment 설정
+
+`prod` GitHub Environment에 다음 값을 설정한다.
+
+| 종류 | 이름 | 설명 |
+| --- | --- | --- |
+| Secret | `PROD_SUPABASE_DB_URL` | Supabase Session Pooler PostgreSQL 연결 문자열. 실제 값은 절대 로그나 문서에 남기지 않는다. |
+| Secret | `BACKUP_ENCRYPTION_PASSPHRASE` | GPG 대칭 암호화 passphrase. 충분한 길이의 무작위 값으로 생성하고 별도 비밀 관리 도구에도 보관한다. |
+| Variable | `PROD_AWS_REGION` | backup bucket의 AWS 리전. |
+| Variable | `PROD_BACKUP_S3_BUCKET` | 전용 backup bucket 이름. |
+| Variable | `PROD_DB_BACKUP_ROLE_ARN` | GitHub OIDC가 AssumeRole할 backup 전용 IAM Role ARN. |
+
+Supabase Free 플랜에서 GitHub-hosted runner는 direct DB endpoint 대신 IPv4 접근이 가능한 Session Pooler 연결 문자열을 사용한다. Transaction Pooler는 dump 작업에 사용하지 않는다.
+
+## Terraform 선행 조건
+
+Terraform 저장소에서 다음을 프로비저닝한 후 workflow를 수동 실행한다.
+
+1. 기존 Lambda artifact bucket과 분리된 private S3 backup bucket을 만든다.
+2. Block Public Access, versioning, default server-side encryption을 켠다. KMS를 사용한다면 bucket default encryption을 SSE-KMS로 설정하고 key 정책에 backup role을 포함한다.
+3. lifecycle rule을 설정한다.
+   - `supabase-db/daily/`: 30일 후 만료.
+   - `supabase-db/monthly/`: 365일 후 만료.
+   - `supabase-db/latest/`: lifecycle 만료 대상에서 제외.
+4. GitHub OIDC provider와 backup 전용 IAM Role을 만든다.
+   - trust policy의 audience는 `sts.amazonaws.com`으로 제한한다.
+   - subject는 `repo:cchaksa/cchaksa-backend:ref:refs/heads/dev`로 제한한다.
+5. Role permission은 bucket에 `s3:ListBucket`, object prefix `supabase-db/*`에 `s3:PutObject`, `s3:GetObject`만 허용한다. KMS 사용 시 필요한 encrypt/decrypt 권한만 별도 부여한다.
+
+Workflow의 `HeadObject` 검증은 `s3:GetObject` 권한으로 수행한다. S3 object versioning과 `latest/` overwrite가 함께 동작하므로 이전 latest object version은 lifecycle의 noncurrent-version 정책으로 별도 관리한다.
+
+## 성공 확인
+
+1. Actions workflow가 성공 상태인지 확인한다.
+2. 실행 summary에 daily prefix와 3개 파일 검증 결과가 기록됐는지 확인한다.
+3. S3에 `roles.sql.gz.gpg`, `schema.sql.gz.gpg`, `data.sql.gz.gpg`가 non-zero size로 있는지 확인한다.
+4. 월 1일 실행이면 monthly prefix도 확인한다.
+5. 최초 도입과 이후 월 1회는 아래 복원 리허설을 실행한다.
+
+## 복원 리허설
+
+운영 DB에 직접 복원하지 않는다. 새 Supabase 프로젝트 또는 격리된 임시 PostgreSQL DB를 사용한다.
+
+1. 복원 대상 timestamp의 세 파일을 다운로드한다.
+2. 암호화 passphrase를 사용해 각 파일을 복호화하고 gzip을 해제한다.
+
+```bash
+gpg --batch --decrypt roles.sql.gz.gpg | gzip --decompress > roles.sql
+gpg --batch --decrypt schema.sql.gz.gpg | gzip --decompress > schema.sql
+gpg --batch --decrypt data.sql.gz.gpg | gzip --decompress > data.sql
+```
+
+3. 대상 DB의 연결 문자열을 설정한 뒤 SQL을 `roles -> schema -> data` 순서로 적용한다.
+
+```bash
+psql \
+  --single-transaction \
+  --variable ON_ERROR_STOP=1 \
+  --file roles.sql \
+  --file schema.sql \
+  --command 'SET session_replication_role = replica' \
+  --file data.sql \
+  --dbname "$RESTORE_DB_URL"
+```
+
+4. 핵심 테이블 row count, Flyway migration history, 강의평가 관련 테이블을 확인한다.
+5. 복원에 사용한 timestamp, 결과, 오류와 조치 사항을 이슈 또는 운영 기록에 남긴다.
+
+## 실패와 복구
+
+- dump가 실패하면 Actions job을 실패 상태로 끝낸다. 실패한 daily prefix는 복원 대상으로 사용하지 않는다.
+- dump 시간에 Flyway migration, 수동 DDL, 대량 정리 작업을 동시에 실행하지 않는다. `pg_dump` 계열 작업은 일반 DML을 중단하지 않지만 강한 DDL과 대기할 수 있다.
+- GitHub Actions schedule 지연이나 누락이 반복되거나 backup 시간이 길어지면 EventBridge Scheduler + ECS Fargate 실행 환경으로 전환을 검토한다.
+- workflow 또는 script를 롤백해도 이미 생성된 S3 backup은 삭제하지 않는다.

--- a/docs/specs/20260729-db-backup/spec-lite.md
+++ b/docs/specs/20260729-db-backup/spec-lite.md
@@ -1,0 +1,78 @@
+# DB 백업
+
+## 목적
+
+Supabase PostgreSQL에서 서비스가 생성한 원천 데이터를 일관되게 보관하고, 장애 또는 운영 실수 후 복원할 수 있는 최소 백업 체계를 제공한다.
+
+## 범위
+
+- GitHub Actions에서 KST 05:00에 하루 한 번 Supabase CLI logical dump를 실행한다.
+- 수동 실행(`workflow_dispatch`)을 지원한다.
+- `roles.sql`, `schema.sql`, `data.sql`을 생성해 gzip 및 GPG 대칭 암호화 후 전용 S3 버킷에 올린다.
+- 날짜별 backup, `latest/` 사본, 매월 1일 KST 실행 시 monthly 사본을 만든다.
+- runbook에 복원 순서, GitHub 설정값, S3/IAM/Terraform 선행 조건과 보관 정책을 기록한다.
+
+## 비범위
+
+- 백업 버킷, OIDC IAM Role, KMS Key의 Terraform 생성.
+- S3 객체를 workflow에서 삭제하는 cleanup job.
+- Supabase 관리 스키마(`auth`, `storage`, extension 생성 스키마)의 전체 백업.
+- EventBridge Scheduler 또는 ECS 기반 실행 환경.
+
+## 설계
+
+### 실행
+
+- workflow는 `prod` GitHub Environment에서 실행하며, `id-token: write`로 AWS OIDC Role을 AssumeRole 한다.
+- GitHub scheduled workflow는 기본 브랜치에서만 실행되므로, 이 저장소의 기본 브랜치인 `dev`에 workflow를 둔다.
+- 동일한 prod backup은 `concurrency`로 직렬화한다.
+
+### 저장 구조
+
+```text
+s3://<bucket>/supabase-db/daily/YYYY/MM/DD/<utc-timestamp>/{roles,schema,data}.sql.gz.gpg
+s3://<bucket>/supabase-db/latest/{roles,schema,data}.sql.gz.gpg
+s3://<bucket>/supabase-db/monthly/YYYY/MM/<utc-timestamp>/{roles,schema,data}.sql.gz.gpg
+```
+
+- Daily와 monthly는 서로 다른 prefix를 사용해 독립 lifecycle을 적용한다.
+- `latest/`는 편의용 사본이므로 덮어쓴다.
+- workflow에는 `DeleteObject` 권한을 부여하지 않는다.
+
+### 복원
+
+- GPG 복호화와 gzip 해제 후 `roles.sql`, `schema.sql`, `data.sql` 순서로 `psql`에 전달한다.
+- 새 프로젝트 또는 격리된 임시 DB에서 월 1회 리허설한다.
+- schema와 data dump는 Supabase CLI가 기본적으로 제외하는 관리 스키마를 포함하지 않는다는 점을 리허설에서 확인한다.
+
+## 필요한 GitHub 설정
+
+Secrets.
+
+- `PROD_SUPABASE_DB_URL`.
+- `BACKUP_ENCRYPTION_PASSPHRASE`.
+
+Variables.
+
+- `PROD_AWS_REGION`.
+- `PROD_BACKUP_S3_BUCKET`.
+- `PROD_DB_BACKUP_ROLE_ARN`.
+
+## S3/IAM 선행 조건
+
+- 전용 private bucket, Block Public Access, versioning, default encryption을 설정한다.
+- OIDC Role은 `cchaksa/cchaksa-backend`의 `dev` 브랜치 workflow만 AssumeRole하도록 trust policy를 제한한다.
+- Role에는 백업 bucket의 `supabase-db/*`에 대한 `PutObject`, `GetObject`, bucket의 `ListBucket`과 `HeadObject`에 필요한 최소 권한만 부여한다.
+- S3 Lifecycle은 `daily/` 30일, `monthly/` 365일 만료를 적용한다. `latest/`는 lifecycle 대상에서 제외한다.
+
+## 검증과 롤백
+
+- workflow YAML과 shell script 문법을 검증한다.
+- 애플리케이션 회귀 방지를 위해 `./gradlew test`를 실행한다.
+- 실제 production dump는 PR 단계에서 실행하지 않는다.
+- 롤백은 workflow와 script, runbook을 되돌리고 S3 lifecycle을 Terraform 상태에서 별도로 되돌린다. 이미 저장된 backup object는 삭제하지 않는다.
+
+## 리스크
+
+- GitHub Actions cron은 정확한 시각 실행을 보장하지 않는다. 누락 또는 지연이 관찰되면 EventBridge Scheduler + ECS Fargate 전환을 검토한다.
+- `pg_dump` 계열 백업은 일반 DML을 중단시키지 않지만, 강한 DDL과 대기할 수 있다. backup 시간에는 Flyway migration과 수동 DDL을 실행하지 않는다.

--- a/scripts/backup/supabase-dump.sh
+++ b/scripts/backup/supabase-dump.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_variables=(
+  BACKUP_ENCRYPTION_PASSPHRASE
+  BACKUP_S3_BUCKET
+  SUPABASE_DB_URL
+)
+
+for variable_name in "${required_variables[@]}"; do
+  if [[ -z "${!variable_name:-}" ]]; then
+    echo "Missing required environment variable: ${variable_name}." >&2
+    exit 1
+  fi
+done
+
+backup_prefix="${BACKUP_S3_PREFIX:-supabase-db}"
+runner_temp_dir="${RUNNER_TEMP:-/tmp}"
+backup_dir="$(mktemp -d "${runner_temp_dir}/supabase-backup.XXXXXX")"
+passphrase_file="${backup_dir}/passphrase"
+
+cleanup() {
+  rm -rf "${backup_dir}"
+}
+trap cleanup EXIT
+
+umask 077
+printf '%s' "${BACKUP_ENCRYPTION_PASSPHRASE}" > "${passphrase_file}"
+
+require_nonempty_file() {
+  local file_path="$1"
+
+  if [[ ! -s "${file_path}" ]]; then
+    echo "Backup output is missing or empty: ${file_path##*/}." >&2
+    exit 1
+  fi
+}
+
+encrypt_dump() {
+  local source_path="$1"
+  local encrypted_path="${source_path}.gz.gpg"
+
+  gzip --no-name --stdout "${source_path}" | \
+    gpg --batch --yes --no-tty --pinentry-mode loopback \
+      --passphrase-file "${passphrase_file}" \
+      --symmetric --cipher-algo AES256 \
+      --output "${encrypted_path}"
+
+  require_nonempty_file "${encrypted_path}"
+  printf '%s\n' "${encrypted_path}"
+}
+
+verify_s3_object() {
+  local s3_key="$1"
+  local content_length
+
+  content_length="$(aws s3api head-object \
+    --bucket "${BACKUP_S3_BUCKET}" \
+    --key "${s3_key}" \
+    --query 'ContentLength' \
+    --output text)"
+
+  if [[ ! "${content_length}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Uploaded backup is missing or empty: ${s3_key}." >&2
+    exit 1
+  fi
+}
+
+upload_copy() {
+  local source_path="$1"
+  local s3_key="$2"
+
+  aws s3 cp --only-show-errors "${source_path}" "s3://${BACKUP_S3_BUCKET}/${s3_key}"
+  verify_s3_object "${s3_key}"
+}
+
+daily_timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+daily_prefix="${backup_prefix}/daily/$(date -u +%Y/%m/%d)/${daily_timestamp}"
+kst_day="$(TZ=Asia/Seoul date +%d)"
+kst_month="$(TZ=Asia/Seoul date +%Y/%m)"
+
+supabase db dump --db-url "${SUPABASE_DB_URL}" --role-only -f "${backup_dir}/roles.sql"
+supabase db dump --db-url "${SUPABASE_DB_URL}" -f "${backup_dir}/schema.sql"
+supabase db dump --db-url "${SUPABASE_DB_URL}" --data-only --use-copy \
+  -x "storage.buckets_vectors" \
+  -x "storage.vector_indexes" \
+  -f "${backup_dir}/data.sql"
+
+dump_names=(roles schema data)
+encrypted_files=()
+
+for dump_name in "${dump_names[@]}"; do
+  source_file="${backup_dir}/${dump_name}.sql"
+  require_nonempty_file "${source_file}"
+  encrypted_files+=("$(encrypt_dump "${source_file}")")
+done
+
+for encrypted_file in "${encrypted_files[@]}"; do
+  object_name="$(basename "${encrypted_file}")"
+  upload_copy "${encrypted_file}" "${daily_prefix}/${object_name}"
+  upload_copy "${encrypted_file}" "${backup_prefix}/latest/${object_name}"
+
+  if [[ "${kst_day}" == "01" ]]; then
+    upload_copy "${encrypted_file}" "${backup_prefix}/monthly/${kst_month}/${daily_timestamp}/${object_name}"
+  fi
+done
+
+{
+  echo "## Database Backup"
+  echo
+  printf '%s\n' "- Daily backup: \`${daily_prefix}\`."
+  printf '%s\n' "- Latest copy updated: \`${backup_prefix}/latest/\`."
+  if [[ "${kst_day}" == "01" ]]; then
+    printf '%s\n' "- Monthly backup created: \`${backup_prefix}/monthly/${kst_month}/${daily_timestamp}\`."
+  fi
+  echo "- Files verified: ${#encrypted_files[@]}."
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"


### PR DESCRIPTION
## 연결 이슈

- Closes #308

## 작업 내용

1. 매일 KST 05:00 및 수동 실행을 지원하는 Supabase DB 백업 workflow를 추가했습니다.
2. Supabase CLI dump 3종을 gzip 및 GPG 대칭 암호화한 뒤 S3의 daily, latest, monthly prefix로 업로드하는 스크립트를 추가했습니다.
3. GitHub Environment 설정값, OIDC/S3 Lifecycle Terraform 선행 조건, 복원 리허설 절차를 runbook과 spec에 기록했습니다.

## 리뷰 포인트

1. `.github/workflows/database-backup.yml`의 prod Environment, OIDC role, cron, concurrency 구성이 운영 환경과 맞는지 확인 부탁드립니다.
2. `scripts/backup/supabase-dump.sh`의 S3 prefix와 GPG 암호화, non-zero object 검증 흐름을 확인 부탁드립니다.
3. `docs/runbooks/supabase-db-backup.md`의 Terraform IAM 최소 권한과 S3 Lifecycle 설정을 인프라 PR과 일치시켜야 합니다.

## 의도한 구현 선택

1. 초기 실행 환경은 별도 AWS 실행 인프라 없이 GitHub Actions cron을 사용했습니다.
2. 날짜별 backup은 보존하고 latest만 덮어써서 복원 지점과 최근 backup 접근성을 함께 확보했습니다.
3. workflow에는 DeleteObject 권한을 부여하지 않고 S3 Lifecycle로 보관 만료를 처리하도록 설계했습니다.

## 검증

1. `bash -n scripts/backup/supabase-dump.sh`: 통과했습니다.
2. Ruby YAML parser로 workflow를 파싱했습니다.
3. 모의 Supabase/AWS/GPG 환경에서 dump 3종 생성, 암호화, daily/latest 업로드 검증, summary 기록을 확인했습니다.
4. `JAVA_HOME="$(/usr/libexec/java_home -v 17)" PATH="$(/usr/libexec/java_home -v 17)/bin:${PATH}" ./gradlew test --no-daemon`: 통과했습니다.
5. Pre-PR verification: pass.
6. Pre-PR verification isolation: current-context.
7. Security check: pass.

## 리스크 및 후속 작업

1. S3 bucket, Lifecycle, GitHub OIDC IAM Role과 GitHub Environment 값은 Terraform PR에서 프로비저닝해야 합니다.
2. 실제 Supabase/S3 backup과 복원 리허설은 위 인프라 설정 후 수동 실행으로 먼저 검증해야 합니다.
3. GitHub Actions scheduled workflow의 지연 또는 누락이 반복되면 EventBridge Scheduler + ECS Fargate 전환을 검토합니다.