### PR TITLE
325 docs: 에이전트 공통 개발 규칙 연결

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - 새 작업에는 기존 Spec Kit 파일인 `spec-lite.md`, `spec.md`, `clarify.md`, `tasks.md`, `checklist.md`, `context-notes.md`를 만들지 않습니다.
 - 커밋과 PR 작업 전 `CONTRIBUTING.md`의 커밋·PR 규칙을 확인합니다.
 - PR 생성 시 `.github/PULL_REQUEST_TEMPLATE.md`를 기반으로 본문을 작성하고, 연결 이슈, 변경 범위, 검증 결과, Wiki 갱신 여부와 남은 위험을 포함합니다.
+- PR 생성 시 PR 작성자를 Assignee로 지정하고, 변경 유형에 맞는 릴리즈 노트 분류 라벨을 하나 이상 붙입니다. 릴리즈 노트에서 제외할 변경에는 `skip-release-notes` 라벨을 붙입니다.
 
 ## Branch Rules
 - `feat/{이슈 번호}`는 `dev`에서 생성해 `dev`로 병합합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,20 +7,24 @@
 - 기본 패키지는 `com.chukchuk.haksa`이며 `domain`, `application`, `infrastructure`, `global` 구조를 사용합니다.
 
 ## Agent Instruction Policy
-- `AGENTS.md`만 프로젝트 에이전트 규칙으로 사용합니다.
+- `AGENTS.md`는 에이전트 전용 실행 규칙을 담당합니다.
+- 모든 개발 작업에서 `CONTRIBUTING.md`를 공통 개발 규칙으로 읽고 준수합니다.
 - 작업별 결정은 이슈, PR 또는 `docs/tasks/{이슈 번호}/`에 둡니다.
 - 사용자가 한국어로 작성하면 한국어로 응답하고, 한국어 문장은 `.`, `?`, `!`로 끝냅니다.
 
 ## Documentation Rules
-- `README.md`는 프로젝트 진입점, `CONTRIBUTING.md`는 사람용 협업 규칙, Wiki는 개발·운영 상세 가이드와 ADR을 담당합니다.
+- `README.md`는 프로젝트 진입점, `CONTRIBUTING.md`는 사람과 에이전트가 함께 따르는 개발 규칙, Wiki는 개발·운영 상세 가이드와 ADR을 담당합니다.
 - Wiki는 별도 `https://github.com/cchaksa/cchaksa-backend.wiki.git` 저장소의 `master` 브랜치에서 관리합니다.
-- 공개 API, 인증, DB 스키마, 도메인 규칙, 아키텍처, 배포, 운영, 장애 대응 변경은 Wiki 갱신 여부를 확인합니다.
+- 공개 API, 인증, DB 스키마, 도메인 규칙, 아키텍처, 배포, 운영, 장애 대응 작업은 관련 Wiki 문서를 확인하고 갱신 여부를 최종 결과에 기록합니다.
 
 ## Workflow
 - 작업 전에 GitHub 이슈 번호를 확인합니다.
+- 작업 시작 전에 `CONTRIBUTING.md`를 읽고, 해당 이슈의 `docs/tasks/{이슈 번호}/` 문서가 있으면 함께 확인합니다.
 - 설계 판단이 필요하면 `docs/tasks/{이슈 번호}/design.md`, 여러 단계 계획이 필요하면 `docs/tasks/{이슈 번호}/plan.md`를 사용합니다.
 - 기존 `docs/specs`, `docs/context`, `checklist.md`, `context-notes.md`는 과거 기록으로만 유지합니다.
 - 새 작업에는 기존 Spec Kit 파일인 `spec-lite.md`, `spec.md`, `clarify.md`, `tasks.md`, `checklist.md`, `context-notes.md`를 만들지 않습니다.
+- 커밋과 PR 작업 전 `CONTRIBUTING.md`의 커밋·PR 규칙을 확인합니다.
+- PR 생성 시 `.github/PULL_REQUEST_TEMPLATE.md`를 기반으로 본문을 작성하고, 연결 이슈, 변경 범위, 검증 결과, Wiki 갱신 여부와 남은 위험을 포함합니다.
 
 ## Branch Rules
 - `feat/{이슈 번호}`는 `dev`에서 생성해 `dev`로 병합합니다.


### PR DESCRIPTION
## 📌 Related Issue

- Closes #325

## 📤 Tasks

- `CONTRIBUTING.md`를 사람과 에이전트가 함께 따르는 공통 개발 규칙으로 지정했습니다.
- 작업 시작 전에 `CONTRIBUTING.md`와 존재하는 이슈별 `docs/tasks/{이슈 번호}/` 문서를 확인하도록 명시했습니다.
- 커밋·PR 작업 전 관련 규칙을 확인하도록 명시했습니다.
- PR 생성 시 `.github/PULL_REQUEST_TEMPLATE.md`를 기반으로 작성하고 필수 보고 항목을 포함하도록 명시했습니다.
- PR 생성 시 작성자를 Assignee로 지정하고 변경 유형에 맞는 릴리즈 노트 라벨을 붙이도록 명시했습니다.
- 관련 변경에서 Wiki 문서를 확인하고 갱신 여부를 최종 결과에 기록하도록 명시했습니다.

<br/>

## 📸 Screenshot

- 문서 변경으로 스크린샷은 없습니다.

<br/>

## 💌 To Reviewer

- 에이전트가 공통 개발 규칙과 PR 템플릿을 실제로 읽도록 경로와 실행 시점을 명확히 했는지 확인해 주세요.
- PR 작성자 Assignee와 릴리즈 노트 분류 라벨을 빠뜨리지 않도록 명시했는지 확인해 주세요.
- 기존 브랜치·릴리즈·테스트 규칙은 변경하지 않았습니다.

<br/>

## 검증 결과

- `test -f CONTRIBUTING.md && test -f .github/PULL_REQUEST_TEMPLATE.md && test -f .github/release.yml` 통과.
- `git diff --check origin/dev...HEAD` 통과.
- `git diff --name-status origin/dev...HEAD` 결과 `AGENTS.md`만 변경.
- 문서만 변경해 Gradle 테스트는 실행하지 않았습니다.

## Wiki 갱신 여부

- 저장소의 에이전트 실행 규칙만 변경하므로 Wiki 갱신 대상이 아닙니다.

## 남은 위험

- 별도 위험은 확인되지 않았습니다.
