### PR TITLE
328 fix: 졸업요건 부재 오류 Sentry 문맥 보강

### DIFF
--- a/docs/tasks/328/plan.md
+++ b/docs/tasks/328/plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** 모든 `G02` 발생 경로에 개인정보를 노출하지 않는 졸업요건 식별 태그를 남긴다.
 
-**Architecture:** Resolver 실패 경로와 Resolver 성공 후 진행률 조회 실패 경로가 동일한 MDC 태그 규칙을 사용한다. 서비스는 최종 전공 ID가 결정된 직후 문맥을 주입하고, Resolver는 전공 조합을 찾지 못한 경우 문맥을 주입한다.
+**Architecture:** Resolver 실패 경로와 Resolver 성공 후 진행률 조회 실패 경로가 동일한 MDC 태그 규칙을 사용한다. 서비스는 최종 전공 ID로 진행률을 조회하다 `G02`가 발생한 경우 문맥을 주입하고, Resolver는 전공 조합을 찾지 못한 경우 문맥을 주입한다.
 
 **Tech Stack:** Java 17, Spring Boot 3.2.5, SLF4J MDC, Sentry Java, JUnit 5, Mockito, AssertJ.
 
@@ -24,10 +24,10 @@
 - Modify: `src/main/resources/logback-spring.xml`
 - Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java`
 
-- [ ] `studentCodeHash`, `admissionYear`, `departmentId`, `secondaryDepartmentId`, `majorType`를 요구하는 실패 테스트를 작성한다.
-- [ ] 테스트가 기존 snake_case 태그 때문에 실패하는지 확인한다.
-- [ ] 바인더와 Logback Sentry appender의 태그 이름을 정규화한다.
-- [ ] 집중 테스트를 통과시키고 커밋한다.
+- [x] `studentCodeHash`, `admissionYear`, `departmentId`, `secondaryDepartmentId`, `majorType`를 요구하는 실패 테스트를 작성한다.
+- [x] 테스트가 기존 snake_case 태그 때문에 실패하는지 확인한다.
+- [x] 바인더와 Logback Sentry appender의 태그 이름을 정규화한다.
+- [x] 집중 테스트를 통과시키고 커밋한다.
 
 ### Task 2: 모든 G02 경로에 졸업요건 문맥 주입
 
@@ -37,20 +37,27 @@
 - Test: `src/test/java/com/chukchuk/haksa/domain/graduation/service/GraduationServiceTests.java`
 - Test: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java`
 
-- [ ] 단일전공 진행률이 비어 있을 때 최종 학과 문맥이 남는 실패 테스트를 작성한다.
-- [ ] 복수전공 Resolver 성공 후 Repository에서 `G02`가 발생할 때 문맥이 남는 실패 테스트를 작성한다.
-- [ ] Resolver 자체 실패 시 해시 학번과 원래 학과 문맥이 남는 실패 테스트를 작성한다.
-- [ ] 서비스에서 최종 전공 ID 결정 직후 MDC 문맥을 주입한다.
-- [ ] Resolver 실패 경로의 원문 학번을 해시로 교체한다.
-- [ ] 집중 테스트를 통과시키고 논리 단위로 커밋한다.
+- [x] 단일전공 진행률이 비어 있을 때 최종 학과 문맥이 남는 실패 테스트를 작성한다.
+- [x] 복수전공 Resolver 성공 후 Repository에서 `G02`가 발생할 때 문맥이 남는 실패 테스트를 작성한다.
+- [x] Resolver 자체 실패 시 해시 학번과 원래 학과 문맥이 남는 실패 테스트를 작성한다.
+- [x] 서비스에서 최종 전공 ID를 사용한 진행률 조회가 실패하면 MDC 문맥을 주입한다.
+- [x] Resolver 실패 경로의 원문 학번을 해시로 교체한다.
+- [x] 집중 테스트를 통과시키고 논리 단위로 커밋한다.
 
 ### Task 3: 통합 검증
 
 **Files:**
 - Modify only if verification exposes a #328 requirement defect.
 
-- [ ] 졸업요건 및 Sentry 집중 테스트를 실행한다.
-- [ ] `./gradlew test --stacktrace --no-daemon`을 실행한다.
-- [ ] `git diff --check origin/main...HEAD`를 실행한다.
-- [ ] 원문 학번 MDC 키가 운영 코드와 Logback 설정에 남지 않았는지 확인한다.
-- [ ] 변경 범위와 커밋 단위를 검토한다.
+- [x] 졸업요건 및 Sentry 집중 테스트를 실행한다.
+- [x] `./gradlew test --stacktrace --no-daemon`을 실행한다.
+- [x] `git diff --check origin/main...HEAD`를 실행한다.
+- [x] 원문 학번 MDC 키가 운영 코드와 Logback 설정에 남지 않았는지 확인한다.
+- [x] 변경 범위와 커밋 단위를 검토한다.
+
+## Verification
+
+- 집중 테스트: `BUILD SUCCESSFUL`.
+- 전체 테스트: `BUILD SUCCESSFUL`.
+- 요청 종료 시 `MdcCleanupFilter`의 `MDC.clear()`로 신규 문맥을 정리한다.
+- 성공 요청에는 졸업요건 문맥을 추가하지 않고 `G02` 발생 시에만 주입한다.

--- a/docs/tasks/328/plan.md
+++ b/docs/tasks/328/plan.md
@@ -1,0 +1,56 @@
+# 졸업요건 Sentry 문맥 누락 Hotfix 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 모든 `G02` 발생 경로에 개인정보를 노출하지 않는 졸업요건 식별 태그를 남긴다.
+
+**Architecture:** Resolver 실패 경로와 Resolver 성공 후 진행률 조회 실패 경로가 동일한 MDC 태그 규칙을 사용한다. 서비스는 최종 전공 ID가 결정된 직후 문맥을 주입하고, Resolver는 전공 조합을 찾지 못한 경우 문맥을 주입한다.
+
+**Tech Stack:** Java 17, Spring Boot 3.2.5, SLF4J MDC, Sentry Java, JUnit 5, Mockito, AssertJ.
+
+## Global Constraints
+
+- `origin/main`에서 생성한 `hotfix/328`에서 작업한다.
+- 원문 학번은 기록하지 않고 `HashUtil.sha256Short` 결과만 사용한다.
+- 사용자별 태그는 Sentry fingerprint에 포함하지 않는다.
+- API 응답과 졸업요건 계산 결과는 변경하지 않는다.
+
+---
+
+### Task 1: Sentry 태그 개인정보 정규화
+
+**Files:**
+- Modify: `src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java`
+- Modify: `src/main/resources/logback-spring.xml`
+- Test: `src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java`
+
+- [ ] `studentCodeHash`, `admissionYear`, `departmentId`, `secondaryDepartmentId`, `majorType`를 요구하는 실패 테스트를 작성한다.
+- [ ] 테스트가 기존 snake_case 태그 때문에 실패하는지 확인한다.
+- [ ] 바인더와 Logback Sentry appender의 태그 이름을 정규화한다.
+- [ ] 집중 테스트를 통과시키고 커밋한다.
+
+### Task 2: 모든 G02 경로에 졸업요건 문맥 주입
+
+**Files:**
+- Modify: `src/main/java/com/chukchuk/haksa/domain/graduation/service/GraduationService.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java`
+- Test: `src/test/java/com/chukchuk/haksa/domain/graduation/service/GraduationServiceTests.java`
+- Test: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java`
+
+- [ ] 단일전공 진행률이 비어 있을 때 최종 학과 문맥이 남는 실패 테스트를 작성한다.
+- [ ] 복수전공 Resolver 성공 후 Repository에서 `G02`가 발생할 때 문맥이 남는 실패 테스트를 작성한다.
+- [ ] Resolver 자체 실패 시 해시 학번과 원래 학과 문맥이 남는 실패 테스트를 작성한다.
+- [ ] 서비스에서 최종 전공 ID 결정 직후 MDC 문맥을 주입한다.
+- [ ] Resolver 실패 경로의 원문 학번을 해시로 교체한다.
+- [ ] 집중 테스트를 통과시키고 논리 단위로 커밋한다.
+
+### Task 3: 통합 검증
+
+**Files:**
+- Modify only if verification exposes a #328 requirement defect.
+
+- [ ] 졸업요건 및 Sentry 집중 테스트를 실행한다.
+- [ ] `./gradlew test --stacktrace --no-daemon`을 실행한다.
+- [ ] `git diff --check origin/main...HEAD`를 실행한다.
+- [ ] 원문 학번 MDC 키가 운영 코드와 Logback 설정에 남지 않았는지 확인한다.
+- [ ] 변경 범위와 커밋 단위를 검토한다.

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
@@ -8,7 +8,6 @@ import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -131,12 +130,7 @@ public class GraduationMajorResolver {
             Long secondaryMajorId,
             int admissionYear
     ) {
-        MDC.put("student_code", student.getStudentCode());
-        MDC.put("admission_year", String.valueOf(admissionYear));
-        MDC.put("primary_department_id", String.valueOf(primaryMajorId));
-        MDC.put("secondary_department_id",
-                secondaryMajorId == null ? "NONE" : String.valueOf(secondaryMajorId));
-        MDC.put("major_type", secondaryMajorId == null ? "SINGLE" : "DUAL");
+        GraduationMdcContext.bind(student, primaryMajorId, secondaryMajorId, admissionYear);
 
         throw new CommonException(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND);
     }

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMdcContext.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMdcContext.java
@@ -1,0 +1,26 @@
+// 졸업요건 조회 실패에 필요한 Sentry MDC 문맥을 설정하는 유틸리티
+package com.chukchuk.haksa.domain.graduation.policy;
+
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.global.logging.util.HashUtil;
+import org.slf4j.MDC;
+
+public final class GraduationMdcContext {
+
+    private GraduationMdcContext() {
+    }
+
+    public static void bind(
+            Student student,
+            Long primaryMajorId,
+            Long secondaryMajorId,
+            int admissionYear
+    ) {
+        MDC.put("studentCodeHash", HashUtil.sha256Short(student.getStudentCode()));
+        MDC.put("admissionYear", String.valueOf(admissionYear));
+        MDC.put("departmentId", String.valueOf(primaryMajorId));
+        MDC.put("secondaryDepartmentId",
+                secondaryMajorId == null ? "NONE" : String.valueOf(secondaryMajorId));
+        MDC.put("majorType", secondaryMajorId == null ? "SINGLE" : "DUAL");
+    }
+}

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/service/GraduationService.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.graduation.service;
 import com.chukchuk.haksa.domain.cache.AcademicCache;
 import com.chukchuk.haksa.domain.graduation.dto.AreaProgressDto;
 import com.chukchuk.haksa.domain.graduation.dto.GraduationProgressResponse;
+import com.chukchuk.haksa.domain.graduation.policy.GraduationMdcContext;
 import com.chukchuk.haksa.domain.graduation.policy.GraduationMajorResolver;
 import com.chukchuk.haksa.domain.graduation.policy.MajorResolutionResult;
 import com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepository;
@@ -63,14 +64,26 @@ public class GraduationService {
         MajorResolutionResult majorResolution =
                 graduationMajorResolver.resolve(student, admissionYear);
 
-        List<AreaProgressDto> areaProgress =
-                resolveAreaProgress(
+        List<AreaProgressDto> areaProgress;
+        try {
+            areaProgress = resolveAreaProgress(
+                    student,
+                    studentId,
+                    majorResolution.primaryMajorId(),
+                    majorResolution.secondaryMajorId(),
+                    admissionYear
+            );
+        } catch (CommonException e) {
+            if (ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND.code().equals(e.getCode())) {
+                GraduationMdcContext.bind(
                         student,
-                        studentId,
                         majorResolution.primaryMajorId(),
                         majorResolution.secondaryMajorId(),
                         admissionYear
                 );
+            }
+            throw e;
+        }
 
         GraduationProgressResponse response =
                 new GraduationProgressResponse(

--- a/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
+++ b/src/main/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinder.java
@@ -19,11 +19,11 @@ public final class SentryMdcTagBinder {
             "outboxId",
             "operationType",
             "workerRequestId",
-            "student_code",
-            "admission_year",
-            "primary_department_id",
-            "secondary_department_id",
-            "major_type"
+            "studentCodeHash",
+            "admissionYear",
+            "departmentId",
+            "secondaryDepartmentId",
+            "majorType"
     );
 
     private SentryMdcTagBinder() {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,11 +34,11 @@
             <tag>outboxId</tag>
             <tag>operationType</tag>
             <tag>workerRequestId</tag>
-            <tag>student_code</tag>
-            <tag>admission_year</tag>
-            <tag>primary_department_id</tag>
-            <tag>secondary_department_id</tag>
-            <tag>major_type</tag>
+            <tag>studentCodeHash</tag>
+            <tag>admissionYear</tag>
+            <tag>departmentId</tag>
+            <tag>secondaryDepartmentId</tag>
+            <tag>majorType</tag>
         </mdcTags>
     </appender>
 
@@ -53,11 +53,11 @@
             <tag>outboxId</tag>
             <tag>operationType</tag>
             <tag>workerRequestId</tag>
-            <tag>student_code</tag>
-            <tag>admission_year</tag>
-            <tag>primary_department_id</tag>
-            <tag>secondary_department_id</tag>
-            <tag>major_type</tag>
+            <tag>studentCodeHash</tag>
+            <tag>admissionYear</tag>
+            <tag>departmentId</tag>
+            <tag>secondaryDepartmentId</tag>
+            <tag>majorType</tag>
         </mdcTags>
     </appender>
 

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
@@ -1,0 +1,62 @@
+// 졸업요건 학과 판별 실패 시 Sentry 문맥을 검증하는 테스트
+package com.chukchuk.haksa.domain.graduation.policy;
+
+import com.chukchuk.haksa.domain.department.model.Department;
+import com.chukchuk.haksa.domain.department.repository.DepartmentRepository;
+import com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepository;
+import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.global.exception.code.ErrorCode;
+import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GraduationMajorResolverTest {
+
+    @Mock
+    private GraduationQueryRepository graduationQueryRepository;
+    @Mock
+    private DepartmentRepository departmentRepository;
+    @InjectMocks
+    private GraduationMajorResolver resolver;
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    void 졸업요건이_없으면_학번_해시와_학과_문맥을_남긴다() {
+        Student student = mock(Student.class);
+        Department department = mock(Department.class);
+        when(student.getStudentCode()).thenReturn("17015080");
+        when(student.getDepartment()).thenReturn(department);
+        when(department.getId()).thenReturn(38L);
+        when(graduationQueryRepository.getAreaRequirementsWithCache(38L, 2017))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> resolver.resolve(student, 2017))
+                .isInstanceOf(CommonException.class)
+                .satisfies(error -> assertThat(((CommonException) error).getCode())
+                        .isEqualTo(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND.code()));
+
+        assertThat(MDC.get("studentCodeHash")).isEqualTo("W26l-ok3P0");
+        assertThat(MDC.get("admissionYear")).isEqualTo("2017");
+        assertThat(MDC.get("departmentId")).isEqualTo("38");
+        assertThat(MDC.get("secondaryDepartmentId")).isEqualTo("NONE");
+        assertThat(MDC.get("majorType")).isEqualTo("SINGLE");
+        assertThat(MDC.get("student_code")).isNull();
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/service/GraduationServiceTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/service/GraduationServiceTests.java
@@ -14,12 +14,14 @@ import com.chukchuk.haksa.domain.student.model.embeddable.AcademicInfo;
 import com.chukchuk.haksa.domain.student.service.StudentService;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
 import com.chukchuk.haksa.global.exception.type.CommonException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +53,12 @@ class GraduationServiceTests {
 
     private static final UUID STUDENT_ID = UUID.randomUUID();
     private static final int ADMISSION_YEAR = 2022;
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
     @Test
     @DisplayName("전공 학과가 존재하면 전공 학과 ID로 졸업요건을 조회한다")
     void getGraduationProgressUsesMajorDepartmentIdFirst() {
@@ -88,6 +96,25 @@ class GraduationServiceTests {
         assertThatThrownBy(() -> graduationService.getGraduationProgress(STUDENT_ID))
                 .isInstanceOf(CommonException.class)
                 .hasMessage(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND.message());
+
+        assertGraduationContext("1", "NONE", "SINGLE");
+    }
+
+    @Test
+    @DisplayName("복수전공 진행률 조회가 실패하면 최종 전공 문맥을 남긴다")
+    void getGraduationProgressAddsContextWhenDualMajorProgressMissing() {
+        Student student = mockStudent(60L, 71L);
+        when(studentService.getStudentById(STUDENT_ID)).thenReturn(student);
+        when(graduationMajorResolver.resolve(student, ADMISSION_YEAR))
+                .thenReturn(new MajorResolutionResult(60L, 71L));
+        when(graduationQueryRepository.getDualMajorAreaProgress(STUDENT_ID, 60L, 71L, ADMISSION_YEAR))
+                .thenThrow(new CommonException(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND));
+
+        assertThatThrownBy(() -> graduationService.getGraduationProgress(STUDENT_ID))
+                .isInstanceOf(CommonException.class)
+                .hasMessage(ErrorCode.GRADUATION_REQUIREMENTS_DATA_NOT_FOUND.message());
+
+        assertGraduationContext("60", "71", "DUAL");
     }
 
     @Test
@@ -272,6 +299,7 @@ class GraduationServiceTests {
     private Student mockStudent(Long majorId, Long secondaryId, int admissionYear, boolean transferStudent) {
         Student student = mock(Student.class);
         lenient().when(student.isTransferStudent()).thenReturn(transferStudent);
+        lenient().when(student.getStudentCode()).thenReturn("20221234");
 
         AcademicInfo info = AcademicInfo.builder()
                 .admissionYear(admissionYear)
@@ -296,6 +324,14 @@ class GraduationServiceTests {
         }
 
         return student;
+    }
+
+    private void assertGraduationContext(String departmentId, String secondaryDepartmentId, String majorType) {
+        assertThat(MDC.get("studentCodeHash")).isEqualTo("LUJPiDE6PY");
+        assertThat(MDC.get("admissionYear")).isEqualTo("2022");
+        assertThat(MDC.get("departmentId")).isEqualTo(departmentId);
+        assertThat(MDC.get("secondaryDepartmentId")).isEqualTo(secondaryDepartmentId);
+        assertThat(MDC.get("majorType")).isEqualTo(majorType);
     }
 
     private List<AreaProgressDto> sampleProgress() {

--- a/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
+++ b/src/test/java/com/chukchuk/haksa/global/logging/sentry/SentryMdcTagBinderTest.java
@@ -22,8 +22,10 @@ class SentryMdcTagBinderTest {
         MDC.put("outboxId", "outbox-1");
         MDC.put("operationType", "LINK");
         MDC.put("workerRequestId", "worker-req-1");
-        MDC.put("student_code", "20201234");
-        MDC.put("admission_year", "2020");
+        MDC.put("studentCodeHash", "student-hash");
+        MDC.put("admissionYear", "2020");
+        MDC.put("departmentId", "38");
+        MDC.put("majorType", "SINGLE");
 
         Map<String, String> tags = SentryMdcTagBinder.collect();
 
@@ -33,8 +35,11 @@ class SentryMdcTagBinderTest {
                 .containsEntry("outboxId", "outbox-1")
                 .containsEntry("operationType", "LINK")
                 .containsEntry("workerRequestId", "worker-req-1")
-                .containsEntry("student_code", "20201234")
-                .containsEntry("admission_year", "2020")
-                .doesNotContainKey("secondary_department_id");
+                .containsEntry("studentCodeHash", "student-hash")
+                .containsEntry("admissionYear", "2020")
+                .containsEntry("departmentId", "38")
+                .containsEntry("majorType", "SINGLE")
+                .doesNotContainKey("secondaryDepartmentId")
+                .doesNotContainKeys("student_code", "primary_department_id");
     }
 }


### PR DESCRIPTION
### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

#### 원인

복수전공 요구사항은 존재하지만 주전공 영역별 졸업요건이 없는 경우, `GraduationMajorResolver`가 정상 반환한 뒤 Repository에서 `G02`가 발생했습니다. 졸업요건 MDC는 Resolver 자체 실패 경로에서만 설정되어 이 이벤트에는 학번 해시와 학과 문맥이 남지 않았습니다.

#### 변경 내용

- Resolver 실패와 진행률 조회 실패가 동일한 `GraduationMdcContext`를 사용하도록 정리했습니다.
- 단일전공·복수전공 진행률 조회 중 `G02`가 발생하면 최종 전공 ID로 MDC 문맥을 설정합니다.
- 원문 학번 태그를 `studentCodeHash`로 교체하고 Sentry·Logback 태그 이름을 camelCase로 통일했습니다.
- 성공 요청의 동작, 졸업요건 계산 결과, API 오류 응답은 변경하지 않았습니다.

#### 검증

- [x] Resolver 자체 실패 시 학번 해시와 학과 문맥 검증.
- [x] 단일전공 진행률 부재 시 MDC 문맥 검증.
- [x] 복수전공 Repository `G02` 발생 시 최종 전공 문맥 검증.
- [x] `./gradlew test --stacktrace --no-daemon --rerun-tasks`.
- [x] `git diff --check origin/main...HEAD`.
- [ ] 운영 배포 후 Sentry 신규 이벤트의 태그 확인.

### 🔗 Related Issue

- Closes #328
- [JAVA-SPRING-BOOT-34](https://cchaksa-be.sentry.io/issues/7283117315/?project=4509868363481088)
