### PR TITLE
[HOTFIX] 복수전공 졸업요건 및 탈퇴 계정 재가입 오류 수정

### DIFF
--- a/docs/tasks/333/design.md
+++ b/docs/tasks/333/design.md
@@ -1,0 +1,148 @@
+# 복수전공 졸업요건 및 탈퇴 계정 재가입 Hotfix 설계
+
+## 연결 정보
+
+- GitHub Issue [#333](https://github.com/cchaksa/cchaksa-backend/issues/333)
+- 작업 브랜치 `hotfix/333`
+- 기준 및 최초 병합 대상 브랜치 `main`
+
+## 문제 1. 복수전공 졸업요건 후보 오선택
+
+학과 개편으로 학생의 현재 주전공 ID와 입학 연도별 졸업요건이 저장된 과거 학과 ID가 다를 수 있다. `GraduationMajorResolver`는 동일한 `established_department_name`을 가진 학과를 후보로 탐색하지만, 복수전공에서는 주전공 영역 요건을 확인하지 않고 복수전공 요건 조회 결과가 비어 있지 않은 첫 조합을 선택한다.
+
+복수전공 요건 조회는 후보 주전공의 `PRIMARY` 요건과 후보 복수전공의 `SECONDARY` 요건을 OR 조건으로 조회한다. 따라서 후보 주전공에 영역 요건이 없어도 복수전공의 `SECONDARY` 요건만 존재하면 그 조합이 선택된다. 이후 진행률 조회가 선택된 주전공의 영역 요건을 찾지 못해 `G02 GRADUATION_REQUIREMENTS_DATA_NOT_FOUND`를 반환한다.
+
+운영 재현 사례에서는 현재 주전공 후보에는 영역 요건이 없고 동일 학과의 과거 후보에는 영역 요건이 있었다. 기존 로직은 현재 후보를 선택해 404를 반환했지만, 과거 후보를 선택하면 정상 계산할 수 있었다.
+
+## 문제 2. 레거시 탈퇴 계정 재가입 시 탈퇴 상태 전파
+
+현재 탈퇴 처리에서는 학생 학번을 익명화한다. 그러나 익명화 정책 적용 전에 생성된 일부 레거시 탈퇴 데이터에는 원문 학번이 남아 있을 수 있다.
+
+이 상태에서 사용자가 재가입하고 포털을 연동하면 `UserService.tryMergeWithExistingUser`가 같은 학번의 탈퇴 계정을 정상 병합 대상으로 찾는다. `User.absorbFrom`은 기존 계정의 `isDeleted`와 `deletedAt`까지 신규 계정으로 복사하므로 활성 신규 계정이 다시 탈퇴 상태가 된다.
+
+카카오 로그인 API는 공개 경로이므로 토큰 발급 자체는 성공할 수 있다. 하지만 이후 보호 API에서 `JwtAuthenticationFilter`가 `UserDetails.isEnabled()`를 검사하고 탈퇴 사용자를 401로 차단한다. 그 결과 메인 화면에는 진입하지만 후속 데이터 요청은 모두 실패할 수 있다.
+
+소셜 계정 연결이 탈퇴 사용자에게 남아 있는 레거시 상태에서도 같은 문제가 생긴다. 현재 `findOrCreateUser`는 기존 소셜 계정의 사용자가 탈퇴 상태인지 확인하지 않고 그대로 반환하므로 탈퇴 사용자용 토큰을 다시 발급할 수 있다.
+
+## 목표
+
+- 복수전공 Resolver가 실제 진행률을 계산할 수 있는 주전공 후보만 선택한다.
+- 레거시 탈퇴 계정은 활성 계정에 병합하지 않고 현재 탈퇴 정책에 맞게 정리한다.
+- 활성 신규 계정에 `isDeleted`와 `deletedAt`이 전파되지 않도록 도메인 수준에서도 방어한다.
+- 탈퇴 사용자에 연결된 레거시 소셜 계정으로 로그인하면 기존 탈퇴 계정을 재활성화하지 않고 신규 활성 계정을 생성한다.
+- 공개 API, 오류 코드, DB 스키마와 정상 사용자의 기존 병합 동작은 유지한다.
+
+## 비목표
+
+- 탈퇴 계정을 복구하거나 과거 활동 데이터를 신규 계정으로 이관하지 않는다.
+- 졸업요건 기준 데이터를 다른 학과 ID로 복제하지 않는다.
+- 이번 Hotfix에서 DB 제약 조건이나 Flyway migration을 추가하지 않는다.
+- 운영 레거시 데이터 전체를 자동 일괄 수정하지 않는다. 조회로 대상을 분류한 뒤 검증된 건만 보정한다.
+
+## 설계 1. 복수전공 주전공 후보 선검증
+
+`GraduationMajorResolver.resolveDualMajor`의 바깥 반복문에서 기존 `hasSingleMajorRequirement`를 호출한다. 영역 요건이 없는 주전공 후보는 복수전공 조합 조회 전에 건너뛴다.
+
+```java
+for (Long primaryId : primaryCandidates) {
+    if (primaryId == null) continue;
+    if (!hasSingleMajorRequirement(primaryId, admissionYear)) continue;
+
+    for (Long secondaryId : secondaryCandidates) {
+        if (secondaryId == null) continue;
+
+        if (hasDualMajorRequirement(primaryId, secondaryId, admissionYear)) {
+            return new MajorResolutionResult(primaryId, secondaryId);
+        }
+    }
+}
+```
+
+검사는 바깥 반복문에서 한 번만 실행한다. 단일전공 처리, 후보 순서, 모든 후보가 실패했을 때의 G02 응답과 MDC 기록은 유지한다.
+
+## 설계 2. 탈퇴 계정은 병합 대신 레거시 정리
+
+`UserService.tryMergeWithExistingUser`가 동일 학번 사용자를 찾은 뒤 자기 자신인지 확인하고, 기존 사용자가 탈퇴 상태라면 정상 병합을 수행하지 않는다.
+
+대신 private helper인 `cleanupLegacyWithdrawnUser`에서 다음 처리를 수행하고 현재 활성 사용자를 그대로 반환한다.
+
+1. 기존 Student를 현재 정책과 같은 방식으로 익명화한다.
+2. 기존 User에 연결된 SocialAccount를 삭제한다.
+3. 기존 User의 RefreshToken과 인증 캐시를 제거한다.
+4. 변경 내용을 flush해 원문 학번과 소셜 로그인 고유키를 신규 계정이 안전하게 사용할 수 있게 한다.
+5. 기존 탈퇴 User와 익명화된 Student는 보존한다.
+
+Student는 수강평 등 다른 데이터가 참조할 수 있으므로 삭제하지 않는다. 기존 탈퇴 계정의 프로필, 학생 정보, 탈퇴 상태는 신규 계정으로 이관하지 않는다.
+
+학생 학번에는 UNIQUE 제약이 있으므로 익명화 UPDATE가 신규 Student INSERT보다 먼저 DB에 반영되어야 한다. `StudentDeletionService.anonymizeByStudent`는 `saveAndFlush`를 사용해 학번을 즉시 해제한다. 소셜 계정 삭제 후에도 동일 provider/social ID 재등록 전에 persistence context를 flush한다.
+
+## 설계 3. `User.absorbFrom`의 생명주기 상태 방어
+
+정상 계정 병합은 기존 프로필과 Student 이관 동작을 유지한다. 다만 `isDeleted`와 `deletedAt`은 계정 생명주기 상태이므로 `absorbFrom`에서 복사하지 않는다.
+
+서비스 분기에서 탈퇴 계정 병합을 차단하더라도, 다른 호출부가 실수로 탈퇴 사용자를 전달했을 때 활성 대상 사용자가 탈퇴 상태가 되지 않도록 도메인 불변식을 보강한다.
+
+## 설계 4. 탈퇴 사용자에 연결된 소셜 계정 로그인 방어
+
+`findOrCreateUser`를 명시적 분기로 변경한다.
+
+- 기존 SocialAccount의 User가 활성 상태면 현재처럼 그 User를 반환한다.
+- 기존 SocialAccount의 User가 탈퇴 상태면 `cleanupLegacyWithdrawnUser`를 실행한 뒤 새 User와 SocialAccount를 생성한다.
+- SocialAccount가 없으면 현재처럼 새 User와 SocialAccount를 생성한다.
+
+신규 생성 코드는 `createUserWithSocialAccount`로 추출해 두 생성 경로에서 공유한다. 로그인 성공 응답 계약은 변경하지 않는다.
+
+## 트랜잭션과 실패 처리
+
+병합과 로그인 경로는 기존 트랜잭션 안에서 처리한다. 익명화, 연결 삭제, 신규 생성 중 하나라도 실패하면 전체 트랜잭션을 rollback해 중간 상태를 남기지 않는다.
+
+레거시 정리 후 신규 Student 저장에서 동일 학번 UNIQUE 충돌이 발생하지 않는지 통합 테스트로 검증한다. 같은 provider/social ID의 신규 SocialAccount 생성도 삭제 flush 이후 성공하는지 단위 테스트에서 확인한다.
+
+## 테스트 정책
+
+### 졸업요건
+
+- 첫 주전공 후보에는 영역 요건이 없고 과거 동일 학과 후보에는 영역 요건이 있는 상황을 재현한다.
+- 수정 후 첫 후보를 건너뛰고 계산 가능한 과거 후보 조합을 반환하는지 확인한다.
+- 무효한 첫 후보에는 복수전공 요건 조회를 수행하지 않는지 확인한다.
+- 기존 단일전공, G02와 MDC 테스트가 모두 통과하는지 확인한다.
+
+### 사용자 병합과 로그인
+
+- 동일 학번의 활성 기존 사용자는 현재처럼 정상 병합되는지 확인한다.
+- 동일 학번의 탈퇴 기존 사용자는 병합하지 않고 익명화와 인증 연결 정리를 수행하는지 확인한다.
+- `User.absorbFrom`에 탈퇴 사용자를 전달해도 활성 대상의 탈퇴 상태가 바뀌지 않는지 확인한다.
+- 탈퇴 사용자에 연결된 SocialAccount로 로그인하면 신규 활성 User와 SocialAccount를 생성하는지 확인한다.
+- 정리 직후 신규 Student가 같은 원문 학번을 사용할 수 있고 기존 Student는 익명화 상태로 남는지 통합 테스트한다.
+- 기존 `JwtAuthenticationFilterTests`의 탈퇴 사용자 토큰 401 동작은 유지한다.
+
+## 운영 데이터 조치
+
+운영에서는 `is_deleted=true`이면서 연결 Student의 학번이 익명화되지 않은 계정을 조회 전용 쿼리로 찾는다.
+
+- `portal_connected=false`인 계정은 병합되지 않은 레거시 탈퇴 계정 후보로 분류하고 현재 정책에 맞게 익명화한다.
+- `portal_connected=true`인 계정은 재가입 병합으로 활성 계정에 탈퇴 상태가 전파된 후보로 본다. 가입·연동 이력을 수동 확인한 뒤 신규 계정임이 확인된 건만 `is_deleted=false`, `deleted_at=NULL`로 복구한다.
+- 복구 후 기존 인증 캐시와 토큰 영향을 제거하기 위해 재로그인을 안내한다.
+
+장애 확인을 위해 임시 변경한 학생의 주전공은 Hotfix 운영 배포 후 실제 학적 값으로 복원한다. 저장소 문서, 커밋과 PR에는 운영 학생의 학번이나 UUID를 기록하지 않는다.
+
+## 변경 범위
+
+- `GraduationMajorResolver`와 회귀 테스트.
+- `UserService`의 병합 및 로그인 분기와 단위 테스트.
+- `User.absorbFrom`과 도메인 테스트.
+- `StudentDeletionService`의 익명화 flush 처리.
+- 재가입 및 동일 학번 재사용 통합 테스트.
+- 관련 Wiki의 탈퇴·재가입 정책 문서.
+
+공개 API, DTO, DB 스키마, Flyway migration, 오류 코드와 응답 형식은 변경하지 않는다.
+
+## Wiki 판단
+
+이번 변경은 인증과 사용자 생명주기 규칙을 수정하므로 관련 Wiki를 확인하고 다음 내용을 반영한다.
+
+- 탈퇴 시 학번 익명화와 인증 연결 제거 정책.
+- 레거시 탈퇴 계정과 재가입 계정은 병합하지 않는 정책.
+- 재가입 시 과거 활동 데이터가 이관되지 않는 정책.
+
+PR에는 갱신한 Wiki 링크를 포함한다. 적절한 기존 문서가 없으면 새 운영·도메인 문서를 작성하고 링크를 남긴다.

--- a/docs/tasks/333/plan.md
+++ b/docs/tasks/333/plan.md
@@ -1,0 +1,228 @@
+# 복수전공 졸업요건 및 탈퇴 계정 재가입 Hotfix 구현 계획
+
+> 구현 시 `superpowers:test-driven-development`를 적용하고, 완료 주장 전 `superpowers:verification-before-completion`으로 실제 검증 결과를 확인한다.
+
+**목표:** 복수전공 졸업요건 404와 레거시 탈퇴 계정 재가입 후 보호 API 401을 각각 회귀 테스트로 재현하고 최소 변경으로 해결한다.
+
+**구조:** 졸업요건은 Resolver 후보 선택 조건을 보강한다. 사용자 영역은 탈퇴 계정을 병합 대상에서 제외하고 레거시 학생·인증 연결을 현재 정책대로 정리하며, 도메인 병합과 소셜 로그인 경로에도 방어를 추가한다.
+
+**기술:** Java 17, Spring Boot 3.2.5, Gradle, JUnit 5, Mockito, AssertJ, PostgreSQL.
+
+## 공통 제약
+
+- `main`에서 생성한 `hotfix/333`에서 작업하고 `main`에 먼저 병합한다.
+- 두 결함은 하나의 Hotfix에 포함하되 졸업요건과 사용자 생명주기 변경을 별도 논리 커밋으로 나눈다.
+- 공개 API, 오류 코드, DTO, DB 스키마와 Flyway migration은 변경하지 않는다.
+- 정상 사용자의 기존 계정 병합 동작은 유지한다.
+- 운영 개인정보는 문서, 테스트 데이터, 커밋과 PR에 기록하지 않는다.
+- 사용자 승인 전에는 Java 코드와 테스트를 변경하지 않는다.
+
+---
+
+### Task 1. 작업 문서 검토와 확정
+
+**Files**
+
+- Modify: `docs/tasks/333/design.md`
+- Modify: `docs/tasks/333/plan.md`
+
+- [ ] 사용자 검토 의견을 설계와 계획에 함께 반영한다.
+- [ ] 미확정 표현과 문서 공백 오류를 검사한다.
+
+  ```bash
+  rg -n 'T[B]D|T[O]DO|implement[ ]later|위와[ ]유사' docs/tasks/333
+  rg -n '[[:blank:]]+$' docs/tasks/333/design.md docs/tasks/333/plan.md
+  ```
+
+- [ ] 운영 식별자가 포함되지 않았는지 수동 검토한다.
+- [ ] 승인 후 문서를 커밋한다.
+
+  ```bash
+  git add -- docs/tasks/333/design.md docs/tasks/333/plan.md
+  git commit -m "333 docs: hotfix 구현 계획"
+  ```
+
+### Task 2. 복수전공 후보 선택 회귀 테스트와 수정
+
+**Files**
+
+- Modify: `src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java`
+
+- [ ] 현재 주전공 후보에는 영역 요건이 없고 과거 동일 학과 후보에는 영역 요건이 있는 실패 테스트를 추가한다.
+- [ ] 기존 구현이 현재 후보를 잘못 선택해 테스트가 실패하는지 확인한다.
+
+  ```bash
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.graduation.policy.GraduationMajorResolverTest' --stacktrace --no-daemon
+  ```
+
+- [ ] `resolveDualMajor`의 바깥 반복문에서 `hasSingleMajorRequirement`가 false인 주전공 후보를 건너뛴다.
+- [ ] 무효 주전공 후보에는 `getDualMajorRequirementsWithCache`가 호출되지 않았는지 Mockito `never()`로 검증한다.
+- [ ] Resolver 집중 테스트를 다시 실행해 통과시킨다.
+- [ ] 졸업요건 변경을 커밋한다.
+
+  ```bash
+  git add -- src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
+  git commit -m "333 fix: 복수전공 주전공 후보 검증"
+  ```
+
+### Task 3. 레거시 탈퇴 계정 병합 차단
+
+**Files**
+
+- Modify: `src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java`
+
+- [ ] `tryMergeWithExistingUser`가 동일 학번의 탈퇴 사용자를 찾은 상황을 단위 테스트로 구성한다.
+- [ ] 기대 동작을 다음과 같이 고정하고 기존 구현에서 실패하는지 확인한다.
+
+  - 현재 활성 User를 그대로 반환한다.
+  - `absorbFrom`과 기존 User 삭제를 수행하지 않는다.
+  - 기존 Student를 익명화한다.
+  - 기존 SocialAccount, RefreshToken과 인증 캐시를 제거한다.
+
+- [ ] 집중 테스트를 실행해 실패를 확인한다.
+
+  ```bash
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.user.service.UserServiceUnitTests' --stacktrace --no-daemon
+  ```
+
+- [ ] `tryMergeWithExistingUser`의 자기 자신 확인 다음에 탈퇴 사용자 분기를 추가한다.
+- [ ] private `cleanupLegacyWithdrawnUser(User withdrawnUser)`를 추가해 학생 익명화와 인증 연결 정리를 한곳에서 수행한다.
+- [ ] `StudentDeletionService.anonymizeByStudent`가 `saveAndFlush`로 학번 UNIQUE 값을 즉시 해제하도록 변경한다.
+- [ ] 소셜 계정과 토큰 삭제 후 persistence context를 flush한다.
+- [ ] 활성 사용자 정상 병합 테스트와 신규 탈퇴 분기 테스트를 함께 통과시킨다.
+
+### Task 4. 병합 도메인에서 탈퇴 상태 전파 방지
+
+**Files**
+
+- Modify: `src/main/java/com/chukchuk/haksa/domain/user/model/User.java`
+- Create: `src/test/java/com/chukchuk/haksa/domain/user/model/UserTests.java`
+
+- [ ] 신규 테스트 파일 첫 줄에 역할을 설명하는 한국어 한 줄 주석을 추가한다.
+- [ ] 활성 대상 User가 탈퇴 원본 User를 `absorbFrom`해도 `isDeleted=false`, `deletedAt=null`을 유지하는 실패 테스트를 작성한다.
+- [ ] `User.absorbFrom`에서 `isDeleted`와 `deletedAt` 복사를 제거한다.
+- [ ] 프로필, 학생 연결 등 정상 병합 속성은 기존대로 이관되는지 함께 확인한다.
+- [ ] 도메인 집중 테스트를 통과시킨다.
+
+  ```bash
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.user.model.UserTests' --stacktrace --no-daemon
+  ```
+
+### Task 5. 탈퇴 사용자에 연결된 소셜 로그인 방어
+
+**Files**
+
+- Modify: `src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java`
+- Modify: `src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java`
+
+- [ ] 기존 SocialAccount가 탈퇴 User를 가리키는 로그인 테스트를 추가한다.
+- [ ] 로그인 결과가 기존 탈퇴 User가 아닌 신규 활성 User인지 확인한다.
+- [ ] 기존 탈퇴 User의 Student 익명화와 인증 연결 삭제가 호출되는지 확인한다.
+- [ ] 신규 SocialAccount가 신규 User를 가리키는지 `ArgumentCaptor` 또는 `argThat`으로 검증한다.
+- [ ] `findOrCreateUser`를 명시적 분기로 바꾸고 신규 생성 코드를 `createUserWithSocialAccount`로 추출한다.
+- [ ] 활성 User의 기존 SocialAccount 로그인 동작이 변하지 않았는지 기존 테스트로 확인한다.
+- [ ] 사용자 생명주기 변경을 하나의 논리 단위로 커밋한다.
+
+  ```bash
+  git add -- src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java src/main/java/com/chukchuk/haksa/domain/user/model/User.java src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java src/test/java/com/chukchuk/haksa/domain/user/model/UserTests.java
+  git commit -m "333 fix: 레거시 탈퇴 계정 재가입 방어"
+  ```
+
+### Task 6. 동일 학번 재가입 통합 테스트
+
+**Files**
+
+- Modify: `src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java`
+
+- [ ] 원문 학번 Student를 가진 레거시 탈퇴 User와 별도의 신규 활성 User를 저장한다.
+- [ ] 현재 탈퇴 서비스는 학번을 자동 익명화하므로, 테스트 준비 단계에서는 레거시 상태를 직접 구성한다.
+- [ ] 신규 활성 User의 병합 시도를 실행한다.
+- [ ] 정리 직후 신규 User에 같은 원문 학번의 Student를 저장한다.
+- [ ] 다음 결과를 검증한다.
+
+  - UNIQUE 제약 충돌이 발생하지 않는다.
+  - 기존 Student 학번은 `deleted_` 접두어로 익명화된다.
+  - 기존 User는 탈퇴 상태로 보존된다.
+  - 신규 User는 활성 상태이며 원문 학번 Student를 소유한다.
+
+- [ ] 통합 테스트와 사용자 영역 테스트를 실행한다.
+
+  ```bash
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.user.service.UserServiceIntegrationTest' --stacktrace --no-daemon
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.user.*' --stacktrace --no-daemon
+  ```
+
+- [ ] 통합 회귀 테스트를 커밋한다.
+
+  ```bash
+  git add -- src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
+  git commit -m "333 test: 레거시 탈퇴 계정 재가입 회귀 검증"
+  ```
+
+### Task 7. 포맷과 전체 회귀 검증
+
+**Files**
+
+- No file changes expected. 포맷에 따른 대상 파일 변경만 허용한다.
+
+- [ ] Java 자동 포맷을 적용하고 대상 밖 파일 변경 여부를 확인한다.
+
+  ```bash
+  ./gradlew spotlessApply --no-daemon
+  git status --short
+  ```
+
+- [ ] 정적 검사와 관련 집중 테스트를 실행한다.
+
+  ```bash
+  ./gradlew spotlessCheck checkstyleMain checkstyleTest --stacktrace --no-daemon
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.graduation.*' --stacktrace --no-daemon
+  ./gradlew test --tests 'com.chukchuk.haksa.domain.user.*' --stacktrace --no-daemon
+  ```
+
+- [ ] 저장소 최종 검증을 실행한다.
+
+  ```bash
+  ./gradlew check --stacktrace --no-daemon
+  git diff --check main...HEAD
+  git diff --name-only main...HEAD
+  ```
+
+- [ ] 기존 미추적 `.DS_Store`와 사용자 변경이 커밋에 포함되지 않았는지 확인한다.
+
+### Task 8. Wiki, PR과 운영 조치
+
+**Files**
+
+- Wiki repository의 관련 탈퇴·재가입 정책 문서.
+- No application repository file changes expected.
+
+- [ ] Wiki에서 회원 탈퇴, 재가입, 포털 연동과 계정 병합 정책을 확인한다.
+- [ ] 레거시 탈퇴 계정은 신규 계정에 병합하지 않고 익명화한다는 정책을 반영한다.
+- [ ] PR 본문에 Wiki 링크, Issue #333, 변경 범위, 검증 결과와 남은 위험을 기록한다.
+- [ ] PR 작성자를 Assignee로 지정하고 BugFix 릴리즈 노트 라벨을 붙인다.
+- [ ] 운영 배포 전 조회 전용 쿼리로 다음 두 유형을 분류한다.
+
+  - 탈퇴 상태이며 Student 학번이 익명화되지 않았고 포털 미연동인 레거시 탈퇴 계정.
+  - 탈퇴 상태이며 Student 학번이 익명화되지 않았고 포털 연동된 재가입 오병합 의심 계정.
+
+- [ ] 포털 미연동 계정은 현재 탈퇴 정책에 맞게 Student와 인증 연결을 정리한다.
+- [ ] 포털 연동 계정은 이력을 수동 확인하고 신규 계정임이 확인된 건만 활성 상태로 복구한다.
+- [ ] 활성 복구 대상은 인증 캐시를 제거하고 사용자에게 재로그인을 안내한다.
+- [ ] Hotfix 배포 후 장애 학생의 임시 주전공 값을 실제 학적 값으로 복원한다. UPDATE는 현재 임시값과 복수전공·입학년도 조건을 모두 확인하고 정확히 1행일 때만 commit한다.
+- [ ] 실제 학적 상태에서 졸업요건 API 200과 보호 API 정상 응답을 확인한다.
+- [ ] 운영 배포가 확인된 `main`을 `dev`와 진행 중인 `release/*` 브랜치에 역병합한다.
+
+## 완료 기준
+
+- Resolver가 영역 요건이 없는 주전공 후보를 선택하지 않는다.
+- 탈퇴 레거시 사용자가 활성 신규 사용자에 병합되지 않는다.
+- `User.absorbFrom`이 탈퇴 상태를 전파하지 않는다.
+- 탈퇴 User에 연결된 소셜 계정 로그인은 신규 활성 User를 생성한다.
+- 동일 원문 학번으로 신규 Student를 저장해도 UNIQUE 충돌이 없다.
+- 관련 집중 테스트와 `./gradlew check --stacktrace --no-daemon`이 통과한다.
+- Wiki와 PR에 탈퇴·재가입 정책, 검증 결과와 운영 보정 절차가 기록된다.
+- 운영 데이터 복원 후 졸업요건 및 보호 API가 정상 응답한다.

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolver.java
@@ -67,6 +67,7 @@ public class GraduationMajorResolver {
     ) {
         for (Long primaryId : primaryCandidates) {
             if (primaryId == null) continue;
+            if (!hasSingleMajorRequirement(primaryId, admissionYear)) continue;
 
             for (Long secondaryId : secondaryCandidates) {
                 if (secondaryId == null) continue;

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentDeletionService.java
@@ -39,6 +39,6 @@ public class StudentDeletionService {
             studentGraduationProgressRepository.deleteByStudentId(studentId);
         }
         student.anonymize();
-        studentRepository.save(student);
+        studentRepository.saveAndFlush(student);
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/user/model/User.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/model/User.java
@@ -87,10 +87,8 @@ public class User extends BaseEntity {
         this.email = origin.email;
         this.profileNickname = origin.profileNickname;
         this.profileImage = origin.profileImage;
-        this.isDeleted = origin.isDeleted;
         this.portalConnected = origin.portalConnected;
         this.connectedAt = origin.connectedAt;
-        this.deletedAt = origin.deletedAt;
         this.lastSyncedAt = origin.lastSyncedAt;
         this.student = origin.student;
     }

--- a/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/user/service/UserService.java
@@ -115,6 +115,11 @@ public class UserService {
             return currentUser;
         }
 
+        if (Boolean.TRUE.equals(existingUser.getIsDeleted())) {
+            cleanupLegacyWithdrawnUser(existingUser);
+            return currentUser;
+        }
+
         // 소셜 계정 모두 이전
         List<SocialAccount> accounts = socialAccountRepository.findAllByUserId(existingUser.getId());
         for (SocialAccount sa : accounts) {
@@ -134,6 +139,16 @@ public class UserService {
         return currentUser;
     }
 
+    private void cleanupLegacyWithdrawnUser(User withdrawnUser) {
+        UUID withdrawnUserId = withdrawnUser.getId();
+        studentDeletionService.anonymizeByStudent(withdrawnUser.getStudent());
+        authTokenCache.evictByUserId(withdrawnUserId.toString());
+        socialAccountRepository.deleteByUser(withdrawnUser);
+        refreshTokenService.deleteAllByUserId(withdrawnUserId.toString());
+        userRepository.flush();
+        log.info("[BIZ] user.withdrawn-legacy.cleaned userId={}", withdrawnUserId);
+    }
+
     /* private method */
     private Claims verifyToken(OidcProvider provider, UserDto.SignInRequest request) {
         return oidcServices.get(provider).verifyIdToken(request.id_token(), request.nonce());
@@ -144,31 +159,47 @@ public class UserService {
     }
 
     private User findOrCreateUser(OidcProvider provider, String socialId, String email, String profileNickname) {
-        return socialAccountRepository.findByProviderAndSocialId(provider, socialId)
-                .map(socialAccount -> {
-                    log.info("[BIZ] users.signin.user.found provider={} socialId={} userId={}",
-                            provider, socialId, socialAccount.getUser().getId());
-                    return socialAccount.getUser();
-                })
-                .orElseGet(() -> {
-                    User newUser = userRepository.save(User.builder()
-                            .email(email)
-                            .profileNickname(profileNickname)
-                            .build());
+        Optional<SocialAccount> socialAccountOpt =
+                socialAccountRepository.findByProviderAndSocialId(provider, socialId);
 
-                    SocialAccount socialAccount = SocialAccount.builder()
-                            .user(newUser)
-                            .socialId(socialId)
-                            .provider(provider)
-                            .email(email)
-                            .build();
+        if (socialAccountOpt.isPresent()) {
+            User existingUser = socialAccountOpt.get().getUser();
+            if (Boolean.TRUE.equals(existingUser.getIsDeleted())) {
+                cleanupLegacyWithdrawnUser(existingUser);
+                return createUserWithSocialAccount(provider, socialId, email, profileNickname);
+            }
 
-                    socialAccountRepository.save(socialAccount);
-                    log.info("[BIZ] users.signin.user.created provider={} socialId={} userId={}",
-                            provider, socialId, newUser.getId());
+            log.info("[BIZ] users.signin.user.found provider={} socialId={} userId={}",
+                    provider, socialId, existingUser.getId());
+            return existingUser;
+        }
 
-                    return newUser;
-                });
+        return createUserWithSocialAccount(provider, socialId, email, profileNickname);
+    }
+
+    private User createUserWithSocialAccount(
+            OidcProvider provider,
+            String socialId,
+            String email,
+            String profileNickname
+    ) {
+        User newUser = userRepository.save(User.builder()
+                .email(email)
+                .profileNickname(profileNickname)
+                .build());
+
+        SocialAccount socialAccount = SocialAccount.builder()
+                .user(newUser)
+                .socialId(socialId)
+                .provider(provider)
+                .email(email)
+                .build();
+
+        socialAccountRepository.save(socialAccount);
+        log.info("[BIZ] users.signin.user.created provider={} socialId={} userId={}",
+                provider, socialId, newUser.getId());
+
+        return newUser;
     }
 
     private AuthDto.SignInTokenResponse generateSignInResponse(User user) {

--- a/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/graduation/policy/GraduationMajorResolverTest.java
@@ -3,6 +3,7 @@ package com.chukchuk.haksa.domain.graduation.policy;
 
 import com.chukchuk.haksa.domain.department.model.Department;
 import com.chukchuk.haksa.domain.department.repository.DepartmentRepository;
+import com.chukchuk.haksa.domain.graduation.dto.AreaRequirementDto;
 import com.chukchuk.haksa.domain.graduation.repository.GraduationQueryRepository;
 import com.chukchuk.haksa.domain.student.model.Student;
 import com.chukchuk.haksa.global.exception.code.ErrorCode;
@@ -20,6 +21,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,5 +61,40 @@ class GraduationMajorResolverTest {
         assertThat(MDC.get("secondaryDepartmentId")).isEqualTo("NONE");
         assertThat(MDC.get("majorType")).isEqualTo("SINGLE");
         assertThat(MDC.get("student_code")).isNull();
+    }
+
+    @Test
+    void 복수전공은_주전공_영역요건이_있는_과거_학과_후보를_선택한다() {
+        Student student = mock(Student.class);
+        Department currentPrimary = mock(Department.class);
+        Department legacyPrimary = mock(Department.class);
+        Department secondary = mock(Department.class);
+        AreaRequirementDto requirement = new AreaRequirementDto("전핵", 3, null, null);
+
+        when(student.getMajor()).thenReturn(currentPrimary);
+        when(student.getSecondaryMajor()).thenReturn(secondary);
+        when(currentPrimary.getId()).thenReturn(197L);
+        when(currentPrimary.getEstablishedDepartmentName()).thenReturn("경제금융");
+        when(legacyPrimary.getId()).thenReturn(93L);
+        when(secondary.getId()).thenReturn(94L);
+        when(secondary.getEstablishedDepartmentName()).thenReturn("국제개발협력");
+        when(departmentRepository.findAllByEstablishedDepartmentName("경제금융"))
+                .thenReturn(List.of(currentPrimary, legacyPrimary));
+        when(departmentRepository.findAllByEstablishedDepartmentName("국제개발협력"))
+                .thenReturn(List.of(secondary));
+        when(graduationQueryRepository.getAreaRequirementsWithCache(197L, 2022))
+                .thenReturn(List.of());
+        when(graduationQueryRepository.getAreaRequirementsWithCache(93L, 2022))
+                .thenReturn(List.of(requirement));
+        when(graduationQueryRepository.getDualMajorRequirementsWithCache(93L, 94L, 2022))
+                .thenReturn(List.of(requirement));
+
+        MajorResolutionResult result = resolver.resolve(student, 2022);
+
+        assertThat(result).isEqualTo(new MajorResolutionResult(93L, 94L));
+        verify(graduationQueryRepository, never())
+                .getDualMajorRequirementsWithCache(197L, 94L, 2022);
+        verify(graduationQueryRepository)
+                .getDualMajorRequirementsWithCache(93L, 94L, 2022);
     }
 }

--- a/src/test/java/com/chukchuk/haksa/domain/user/model/UserTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/model/UserTests.java
@@ -1,0 +1,29 @@
+// 사용자 병합 시 탈퇴 상태 전파 방지를 검증하는 도메인 테스트
+package com.chukchuk.haksa.domain.user.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTests {
+
+    @Test
+    void 탈퇴한_원본을_병합해도_대상_사용자는_활성_상태를_유지한다() {
+        User target = User.builder()
+                .email("target@example.com")
+                .profileNickname("target")
+                .build();
+        User withdrawnOrigin = User.builder()
+                .email("origin@example.com")
+                .profileNickname("origin")
+                .build();
+        withdrawnOrigin.withdraw(Instant.now());
+
+        target.absorbFrom(withdrawnOrigin);
+
+        assertThat(target.getIsDeleted()).isFalse();
+        assertThat(target.getDeletedAt()).isNull();
+    }
+}

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceIntegrationTest.java
@@ -233,6 +233,68 @@ class UserServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("레거시 탈퇴 계정은 재가입 계정에 병합하지 않고 같은 학번 재사용을 허용한다")
+    void rejoinWithLegacyWithdrawnUser_anonymizesLegacyStudentBeforeCreatingNewStudent() {
+        String studentCode = "20260003";
+        User withdrawnUser = userRepository.save(User.builder()
+                .email("legacy-withdrawn@haksa.com")
+                .profileNickname("legacy-withdrawn")
+                .build());
+        Student legacyStudent = createStudent(withdrawnUser, studentCode);
+        withdrawnUser.withdraw(java.time.Instant.now());
+        socialAccountRepository.save(SocialAccount.builder()
+                .provider(OidcProvider.KAKAO)
+                .socialId("legacy-withdrawn-social-id")
+                .email(null)
+                .user(withdrawnUser)
+                .build());
+        refreshTokenRepository.save(new RefreshToken(
+                "legacy-withdrawn-session",
+                withdrawnUser.getId().toString(),
+                "legacy-refresh-token",
+                new Date(System.currentTimeMillis() + 60_000)
+        ));
+        User rejoinedUser = userRepository.save(User.builder()
+                .email("rejoined-legacy@haksa.com")
+                .profileNickname("rejoined-legacy")
+                .build());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        User result = userService.tryMergeWithExistingUser(rejoinedUser.getId(), studentCode);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Student rejoinedStudent = createStudent(
+                userRepository.findById(rejoinedUser.getId()).orElseThrow(),
+                studentCode
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        User persistedWithdrawnUser = userRepository.findById(withdrawnUser.getId()).orElseThrow();
+        Student persistedLegacyStudent = studentRepository.findById(legacyStudent.getId()).orElseThrow();
+        User persistedRejoinedUser = userRepository.findById(rejoinedUser.getId()).orElseThrow();
+
+        assertThat(result.getId()).isEqualTo(rejoinedUser.getId());
+        assertThat(persistedWithdrawnUser.getIsDeleted()).isTrue();
+        assertThat(persistedLegacyStudent.getStudentCode()).startsWith("deleted_");
+        assertThat(persistedRejoinedUser.getIsDeleted()).isFalse();
+        assertThat(userRepository.findByStudent_StudentCode(studentCode))
+                .map(User::getId)
+                .contains(rejoinedUser.getId());
+        assertThat(rejoinedStudent.getId()).isNotEqualTo(legacyStudent.getId());
+        assertThat(socialAccountRepository.findByProviderAndSocialId(
+                OidcProvider.KAKAO,
+                "legacy-withdrawn-social-id"
+        )).isEmpty();
+        assertThat(refreshTokenRepository.findAll())
+                .noneMatch(token -> token.getUserId().equals(withdrawnUser.getId().toString()));
+    }
+
+    @Test
     @DisplayName("사용자와 소셜 계정은 이메일 없이 저장할 수 있다")
     void nullableSocialEmail_isPersistedAsNull() {
         User user = userRepository.save(User.builder()

--- a/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
+++ b/src/test/java/com/chukchuk/haksa/domain/user/service/UserServiceUnitTests.java
@@ -248,6 +248,43 @@ class UserServiceUnitTests {
     }
 
     @Test
+    @DisplayName("탈퇴한 기존 사용자는 병합하지 않고 레거시 데이터를 정리한다")
+    void tryMergeWithExistingUser_whenExistingUserIsDeleted_cleansUpLegacyUser() {
+        UUID currentUserId = UUID.randomUUID();
+        UUID withdrawnUserId = UUID.randomUUID();
+        User currentUser = User.builder()
+                .id(currentUserId)
+                .email("current@example.com")
+                .profileNickname("current")
+                .build();
+        User withdrawnUser = User.builder()
+                .id(withdrawnUserId)
+                .email("withdrawn@example.com")
+                .profileNickname("withdrawn")
+                .build();
+        withdrawnUser.withdraw(Instant.now());
+        Student withdrawnStudent = org.mockito.Mockito.mock(Student.class);
+        withdrawnUser.setStudent(withdrawnStudent);
+
+        UserService userService = createService();
+        when(userRepository.findById(currentUserId)).thenReturn(Optional.of(currentUser));
+        when(userRepository.findByStudent_StudentCode("20201234"))
+                .thenReturn(Optional.of(withdrawnUser));
+
+        User result = userService.tryMergeWithExistingUser(currentUserId, "20201234");
+
+        assertThat(result).isSameAs(currentUser);
+        assertThat(currentUser.getIsDeleted()).isFalse();
+        verify(studentDeletionService).anonymizeByStudent(withdrawnStudent);
+        verify(socialAccountRepository).deleteByUser(withdrawnUser);
+        verify(refreshTokenService).deleteAllByUserId(withdrawnUserId.toString());
+        verify(authTokenCache).evictByUserId(withdrawnUserId.toString());
+        verify(userRepository).flush();
+        verify(userRepository, never()).delete(withdrawnUser);
+        verify(socialAccountRepository, never()).findAllByUserId(withdrawnUserId);
+    }
+
+    @Test
     @DisplayName("병합 대상 current user가 없으면 USER_NOT_FOUND 예외를 던진다")
     void tryMergeWithExistingUser_whenCurrentMissing_throws() {
         UUID currentUserId = UUID.randomUUID();
@@ -335,6 +372,62 @@ class UserServiceUnitTests {
         verify(refreshTokenService).save(eq("existing-session"), eq(existingUser.getId().toString()), eq("refresh-token"), any(Date.class));
         verify(userRepository, never()).save(any(User.class));
         verify(socialAccountRepository, never()).save(any(SocialAccount.class));
+    }
+
+    @Test
+    @DisplayName("탈퇴 사용자에 연결된 소셜 계정으로 로그인하면 신규 활성 사용자를 생성한다")
+    void signIn_whenSocialAccountBelongsToDeletedUser_createsNewActiveUser() {
+        UUID withdrawnUserId = UUID.randomUUID();
+        UUID newUserId = UUID.randomUUID();
+        User withdrawnUser = User.builder()
+                .id(withdrawnUserId)
+                .email("withdrawn@example.com")
+                .profileNickname("withdrawn")
+                .build();
+        withdrawnUser.withdraw(Instant.now());
+        Student withdrawnStudent = org.mockito.Mockito.mock(Student.class);
+        withdrawnUser.setStudent(withdrawnStudent);
+        SocialAccount existingAccount = SocialAccount.builder()
+                .provider(OidcProvider.KAKAO)
+                .socialId("deleted-social-sub")
+                .email(null)
+                .user(withdrawnUser)
+                .build();
+        User newUser = User.builder()
+                .id(newUserId)
+                .email("new@example.com")
+                .profileNickname("Unknown User")
+                .build();
+        Claims claims = Jwts.claims()
+                .setSubject("deleted-social-sub")
+                .setIssuer("https://kauth.kakao.com");
+        claims.put("email", "new@example.com");
+
+        UserService userService = createService();
+        when(oidcService.verifyIdToken("id-token", "nonce")).thenReturn(claims);
+        when(socialAccountRepository.findByProviderAndSocialId(OidcProvider.KAKAO, "deleted-social-sub"))
+                .thenReturn(Optional.of(existingAccount));
+        when(userRepository.save(any(User.class))).thenReturn(newUser);
+        when(jwtProvider.createAccessToken(newUserId.toString(), "new@example.com", "USER"))
+                .thenReturn("new-access-token");
+        when(jwtProvider.createRefreshToken(newUserId.toString()))
+                .thenReturn(new AuthDto.RefreshTokenWithExpiry("new-refresh-token", new Date(), "new-session"));
+
+        AuthDto.SignInTokenResponse response = userService.signIn(
+                new UserDto.SignInRequest(OidcProvider.KAKAO, "id-token", "nonce")
+        );
+
+        assertThat(response.accessToken()).isEqualTo("new-access-token");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh-token");
+        verify(studentDeletionService).anonymizeByStudent(withdrawnStudent);
+        verify(socialAccountRepository).deleteByUser(withdrawnUser);
+        verify(refreshTokenService).deleteAllByUserId(withdrawnUserId.toString());
+        verify(authTokenCache).evictByUserId(withdrawnUserId.toString());
+        verify(userRepository).flush();
+
+        ArgumentCaptor<SocialAccount> socialCaptor = ArgumentCaptor.forClass(SocialAccount.class);
+        verify(socialAccountRepository).save(socialCaptor.capture());
+        assertThat(socialCaptor.getValue().getUser()).isSameAs(newUser);
     }
 
     @Test


### PR DESCRIPTION
### 참고 사항

P1: 꼭 반영해주세요 (Request changes)  
P2: 적극적으로 고려해주세요 (Request changes)  
P3: 웬만하면 반영해 주세요 (Comment)  
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)  
P5: 그냥 사소한 의견입니다 (Approve)

### 🔗 Related Issue

- Closes #333

### 변경 내용

#### 복수전공 졸업요건 후보 선택

- `GraduationMajorResolver.resolveDualMajor()`에서 주전공 영역 요건을 먼저 확인합니다.
- 영역 요건이 없는 주전공 후보는 건너뛰고, 실제 계산 가능한 주전공·복수전공 조합을 선택합니다.
- 현재 후보에 영역 요건이 없고 과거 후보에 요건이 있는 학과 개편 사례의 회귀 테스트를 추가했습니다.

#### 탈퇴 계정 레거시 병합 및 재가입

- 학번으로 조회된 기존 사용자가 탈퇴 상태이면 정상 계정 병합을 수행하지 않습니다.
- 기존 Student를 익명화하고 SocialAccount, RefreshToken, 인증 캐시를 정리합니다.
- 기존 탈퇴 User는 보존하고 신규 User는 활성 상태로 유지합니다.
- 탈퇴 User에 연결된 레거시 소셜 계정으로 로그인해도 신규 활성 User와 SocialAccount를 생성합니다.
- `User.absorbFrom()`에서 `isDeleted`, `deletedAt`이 신규 User로 전파되지 않도록 방어합니다.
- 학번 UNIQUE 충돌을 방지하기 위해 Student 익명화 결과를 `saveAndFlush()`로 즉시 반영합니다.

### 검증 결과

- `./gradlew test --tests com.chukchuk.haksa.domain.graduation.policy.GraduationMajorResolverTest --stacktrace --no-daemon` 통과.
- `./gradlew test --tests com.chukchuk.haksa.domain.user.service.UserServiceUnitTests --stacktrace --no-daemon` 통과.
- `./gradlew test --tests com.chukchuk.haksa.domain.user.service.UserServiceIntegrationTest --stacktrace --no-daemon` 통과.
- `./gradlew test --tests com.chukchuk.haksa.domain.user.model.UserTests --stacktrace --no-daemon` 통과.
- `./gradlew check --stacktrace --no-daemon` 통과.
- `git diff --check main...HEAD` 통과.
- 저장소에 `spotlessApply` Gradle task가 등록되어 있지 않아 해당 포맷 task는 실행하지 못했습니다.

### 운영 및 문서

- 운영 DB의 레거시 탈퇴 데이터는 별도 조회·검증 후 보정해야 합니다.
- Hotfix 배포 후 임시 변경한 학생의 주전공 데이터를 실제 학적 값으로 복원해야 합니다.
- 관련 Wiki를 확인했으며, 탈퇴·재가입 시 레거시 계정 병합 금지 정책은 아직 반영되지 않아 후속 갱신이 필요합니다.
- PR과 커밋에는 운영 학생의 학번·UUID·이름을 포함하지 않았습니다.

### 남은 위험

- 본 PR은 운영 DB 데이터를 직접 변경하지 않습니다.
- 기존 탈퇴 토큰은 계속 401로 차단되며, 재가입 사용자는 새 토큰으로 재로그인해야 합니다.